### PR TITLE
Change Previews to QPixmap

### DIFF
--- a/io/media.h
+++ b/io/media.h
@@ -37,7 +37,7 @@ struct MediaStream {
 
     // preview thumbnail/waveform
     bool preview_done;
-    QImage video_preview; // TODO change to QPixmap
+    QPixmap video_preview; // TODO change to QPixmap
 	QVector<char> audio_preview;
 };
 

--- a/io/previewgenerator.cpp
+++ b/io/previewgenerator.cpp
@@ -271,7 +271,7 @@ void PreviewGenerator::generate_waveform() {
 						linesize[0] = dstW*3;
 						sws_scale(sws_ctx, temp_frame->data, temp_frame->linesize, 0, temp_frame->height, &data, linesize);
 
-						s->video_preview = QImage(data, dstW, dstH, linesize[0], QImage::Format_RGB888);
+                        s->video_preview.convertFromImage(QImage(data, dstW, dstH, linesize[0], QImage::Format_RGB888));
 
 						// is video interlaced?
 						s->video_auto_interlacing = (temp_frame->interlaced_frame) ? ((temp_frame->top_field_first) ? VIDEO_TOP_FIELD_FIRST : VIDEO_BOTTOM_FIELD_FIRST) : VIDEO_PROGRESSIVE;
@@ -439,7 +439,7 @@ void PreviewGenerator::run() {
 				// save preview to file
 				for (int i=0;i<media->video_tracks.size();i++) {
 					MediaStream* ms = media->video_tracks.at(i);
-					if (ms->video_preview.save(get_thumbnail_path(hash, ms), "PNG")) {
+                    if (ms->video_preview.save(get_thumbnail_path(hash, ms), "PNG")) {
 						//dout << "saved" << ms->file_index << "thumb to" << get_thumbnail_path(hash, ms);
 					}
 				}

--- a/ui/timelinewidget.cpp
+++ b/ui/timelinewidget.cpp
@@ -2013,7 +2013,7 @@ void TimelineWidget::paintEvent(QPaintEvent*) {
 				QRect clip_rect(panel_timeline->getTimelineScreenPointFromFrame(clip->timeline_in), getScreenPointFromTrack(clip->track), getScreenPointFromFrame(panel_timeline->zoom, clip->getLength()), panel_timeline->calculate_track_height(clip->track, -1));
 				QRect text_rect(clip_rect.left() + CLIP_TEXT_PADDING, clip_rect.top() + CLIP_TEXT_PADDING, clip_rect.width() - CLIP_TEXT_PADDING - 1, clip_rect.height() - CLIP_TEXT_PADDING - 1);
 				if (clip_rect.left() < width() && clip_rect.right() >= 0 && clip_rect.top() < height() && clip_rect.bottom() >= 0) {
-					QRect actual_clip_rect = clip_rect;
+                    QRect actual_clip_rect = clip_rect;
 					if (actual_clip_rect.x() < 0) actual_clip_rect.setX(0);
 					if (actual_clip_rect.right() > width()) actual_clip_rect.setRight(width());
 					if (actual_clip_rect.y() < 0) actual_clip_rect.setY(0);
@@ -2085,11 +2085,14 @@ void TimelineWidget::paintEvent(QPaintEvent*) {
 									int thumb_width = (thumb_height*((double)ms->video_preview.width()/(double)ms->video_preview.height()));
 									if (thumb_x + thumb_width >= 0
 											&& thumb_height > thumb_y
-											&& thumb_y + thumb_height >= 0
-											&& text_rect.width() + CLIP_TEXT_PADDING > thumb_width
-											&& space_for_thumb >= thumb_width) { // at small clip heights, don't even draw it
-										QRect thumb_rect(thumb_x, clip_rect.y()+thumb_y, thumb_width, thumb_height);
-										p.drawImage(thumb_rect, ms->video_preview);
+                                            && thumb_y + thumb_height >= 0){
+                                        if (space_for_thumb < thumb_width){
+                                            p.setClipping(true);
+                                            p.setClipRegion(QRegion(thumb_x, clip_rect.y()+thumb_y, clip_rect.width()-1, thumb_height));
+                                            p.drawPixmap(thumb_x,clip_rect.y()+thumb_y, ms->video_preview.scaledToHeight(thumb_height));
+                                            p.setClipping(false);
+                                        } else
+                                        p.drawPixmap(thumb_x,clip_rect.y()+thumb_y, ms->video_preview.scaledToHeight(thumb_height));
 									}
 								}
 							} else if (clip_rect.height() > TRACK_MIN_HEIGHT) {

--- a/ui/timelinewidget.cpp
+++ b/ui/timelinewidget.cpp
@@ -2085,7 +2085,8 @@ void TimelineWidget::paintEvent(QPaintEvent*) {
 									int thumb_width = (thumb_height*((double)ms->video_preview.width()/(double)ms->video_preview.height()));
 									if (thumb_x + thumb_width >= 0
 											&& thumb_height > thumb_y
-                                            && thumb_y + thumb_height >= 0){
+                                            && thumb_y + thumb_height >= 0
+                                            && space_for_thumb > thumb_width / 4){ //don't show thumbnail if 1/4 is only showing
                                         if (space_for_thumb < thumb_width){
                                             p.setClipping(true);
                                             p.setClipRegion(QRegion(thumb_x, clip_rect.y()+thumb_y, clip_rect.width()-1, thumb_height));


### PR DESCRIPTION
Convert video_preview into QPixmap's, previously was QImage.
Also changed previews to be cropped when region display is smaller than preview width.

Previous behaviour was for previews to disappear when region was too small to show full image.
Now previews show (and are cropped) until only 1/4 of the size of preview is showing, at which point the preview image disappears. 