### PR TITLE
place tabs on top of windows, allows both viewers to be at same height

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -70,6 +70,8 @@ void MainWindow::setup_layout(bool reset) {
     }*/
 
     if (load_default) {
+        setTabPosition(Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea, QTabWidget::North);
+
         addDockWidget(Qt::TopDockWidgetArea, panel_project);
         addDockWidget(Qt::TopDockWidgetArea, panel_footage_viewer);
         tabifyDockWidget(panel_footage_viewer, panel_effect_controls);


### PR DESCRIPTION
The transport controls of both viewers are not aligned if the panel tabs are placed at the bottom. This allows both viewers transports to be aligned.