### PR TITLE
Check if sequence doesn't exist first, and if so accept a drag event

### DIFF
--- a/ui/timelinewidget.cpp
+++ b/ui/timelinewidget.cpp
@@ -316,7 +316,9 @@ void TimelineWidget::dragEnterEvent(QDragEnterEvent *event) {
 }
 
 void TimelineWidget::dragMoveEvent(QDragMoveEvent *event) {
-    if (sequence != NULL && panel_timeline->importing) {
+    if (sequence == NULL){
+        event->acceptProposedAction();
+    } else if (sequence != NULL && panel_timeline->importing) {
         event->acceptProposedAction();
 		QPoint pos = event->pos();
         update_ghosts(pos, event->keyboardModifiers() & Qt::ShiftModifier);


### PR DESCRIPTION
Fix for timeline drag & drop only. Timeline was not allowing a drag event when the Sequence was NULL, which is what happens when there is no loaded sequence.