### PR TITLE
Use pkg-config on all the non-Mac Unices

### DIFF
--- a/olive.pro
+++ b/olive.pro
@@ -205,7 +205,7 @@ mac {
     INCLUDEPATH = /usr/local/include
 }
 
-linux {
+unix:!mac {
     CONFIG += link_pkgconfig
     PKGCONFIG += libavutil libavformat libavcodec libavfilter libswscale libswresample
 }


### PR DESCRIPTION
Make use of pkg-config to link to the ffmpeg libraries on all the Unix platforms other than Mac (instead of Linux only).  This fixes the builing on those platforms.