### PR TITLE
Remove pleonasms in appdata/desktop files, add Russian translation

### DIFF
--- a/packaging/linux/org.olivevideoeditor.Olive.appdata.xml
+++ b/packaging/linux/org.olivevideoeditor.Olive.appdata.xml
@@ -5,9 +5,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPLv3</project_license>
   <developer_name>Olive Team</developer_name>
-  <summary>NLE video editor</summary>
-  <summary xml:lang="pt_BR">Editor de vídeo NLE</summary>
-  <summary xml:lang="es">Editor de video NLE</summary>
+  <summary>Non-linear video editor</summary>
+  <summary xml:lang="pt_BR">Editor de vídeo não-linear</summary>
+  <summary xml:lang="es">Editor de video no lineal</summary>
   <description><p>Olive is a free non-linear video editor aiming to provide a fully-featured alternative to high-end professional video editing software.</p></description>
   <description xml:lang="pt_BR">Olive é um editor de vídeo não-linear com o objetivo de fornecer uma alternativa completa para softwares profissionais de edição de vídeo.<p></p></description>
   <description xml:lang="es"><p>Olive es un editor de video no lineal gratuito que apunta a brindar una alternativa completa al software de edición de video profesional.</p></description>

--- a/packaging/linux/org.olivevideoeditor.Olive.appdata.xml
+++ b/packaging/linux/org.olivevideoeditor.Olive.appdata.xml
@@ -8,9 +8,11 @@
   <summary>Non-linear video editor</summary>
   <summary xml:lang="pt_BR">Editor de vídeo não-linear</summary>
   <summary xml:lang="es">Editor de video no lineal</summary>
+  <summary xml:lang="ru">Нелинейный видеоредактор</summary>
   <description><p>Olive is a free non-linear video editor aiming to provide a fully-featured alternative to high-end professional video editing software.</p></description>
   <description xml:lang="pt_BR">Olive é um editor de vídeo não-linear com o objetivo de fornecer uma alternativa completa para softwares profissionais de edição de vídeo.<p></p></description>
-  <description xml:lang="es"><p>Olive es un editor de video no lineal gratuito que apunta a brindar una alternativa completa al software de edición de video profesional.</p></description>
+  <description xml:lang="es"><p>Olive es un editor de video no lineal libre que apunta a brindar una alternativa completa al software de edición de video profesional.</p></description>
+  <description xml:lang="ru"><p>Olive — свободный нелинейный видеоредактор, задуманный как полноценная замена закрытым коммерческим продуктам.</p></description>
   <url type="homepage">https://www.olivevideoeditor.org</url>
   <url type="donation">https://www.patreon.com/olivevideoeditor</url>
   <url type="help">https://github.com/olive-editor/olive/issues</url>

--- a/packaging/linux/org.olivevideoeditor.Olive.desktop
+++ b/packaging/linux/org.olivevideoeditor.Olive.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Olive
-Comment=Professional open-source NLE video editor
+Comment=Professional open-source non-linear video editor
 Exec=olive-editor
 Icon=org.olivevideoeditor.Olive
 Terminal=false


### PR DESCRIPTION
"NLE video editor" is "non-linear editor video editor", so that's obviously wrong :)

Also, the Spanish translation had "gratuito" instead of "libre", which is wrong too.