### PR TITLE
Add missing tooltip for the Hand tool

### DIFF
--- a/panels/timeline.ui
+++ b/panels/timeline.ui
@@ -196,6 +196,9 @@
        </item>
        <item>
         <widget class="QPushButton" name="toolHandButton">
+         <property name="toolTip">
+          <string>Hand Tool (H)</string>
+         </property>
          <property name="text">
           <string/>
          </property>


### PR DESCRIPTION
The timeline toolbar was missing it.