### PR TITLE
Add default shortcut for Action Search

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -806,7 +806,7 @@ void MainWindow::setup_menus() {
 
 	QMenu* help_menu = menuBar->addMenu("&Help");
 
-	help_menu->addAction("A&ction Search", this, SLOT(show_action_search()));
+	help_menu->addAction("A&ction Search", this, SLOT(show_action_search()), QKeySequence("/"));
 
 	help_menu->addSeparator();
 


### PR DESCRIPTION
Photoshop uses 'Ctrl+F'. Blender alternates between Spacebar and F3 depending on right-click/left-click. GIMP uses '/'.

I'm a GIMP guy, so I chose '/' :)