### PR TITLE
Fix memory leak from using libavcodec api

### DIFF
--- a/io/previewgenerator.cpp
+++ b/io/previewgenerator.cpp
@@ -1,4 +1,4 @@
-﻿#include "previewgenerator.h"
+#include "previewgenerator.h"
 
 #include "project/media.h"
 #include "project/footage.h"
@@ -277,7 +277,7 @@ void PreviewGenerator::generate_waveform() {
 					if (!s->preview_done) {
 						int dstH = 120;
 						int dstW = dstH * ((float)temp_frame->width/(float)temp_frame->height);
-						uint8_t* data = new uint8_t[dstW*dstH*4];
+						uint8_t* imgData = new uint8_t[dstW*dstH*4];
 
 						sws_ctx = sws_getContext(
 								temp_frame->width,
@@ -294,9 +294,9 @@ void PreviewGenerator::generate_waveform() {
 
 						int linesize[AV_NUM_DATA_POINTERS];
 						linesize[0] = dstW*4;
-						sws_scale(sws_ctx, temp_frame->data, temp_frame->linesize, 0, temp_frame->height, &data, linesize);
+						sws_scale(sws_ctx, temp_frame->data, temp_frame->linesize, 0, temp_frame->height, &imgData, linesize);
 
-						s->video_preview = QImage(data, dstW, dstH, linesize[0], QImage::Format_RGBA8888);
+						s->video_preview = QImage(imgData, dstW, dstH, linesize[0], QImage::Format_RGBA8888);
 						s->make_square_thumb();
 
 						// is video interlaced?
@@ -311,6 +311,8 @@ void PreviewGenerator::generate_waveform() {
 							avcodec_close(codec_ctx[packet->stream_index]);
 							codec_ctx[packet->stream_index] = nullptr;
 						}
+
+                        delete[] imgData;
 					}
 					media_lengths[packet->stream_index]++;
 				} else if (fmt_ctx->streams[packet->stream_index]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
@@ -415,7 +417,10 @@ void PreviewGenerator::generate_waveform() {
 		finalize_media();
 	}
 	delete [] media_lengths;
-	delete [] codec_ctx;
+
+    if (codec_ctx != NULL) {
+        avcodec_free_context(codec_ctx);
+    }
 }
 
 QString PreviewGenerator::get_thumbnail_path(const QString& hash, const FootageStream& ms) {


### PR DESCRIPTION
Identified 2 sources of memory leaks in io/previewgenerator.cpp

(cherry picked from commit 8c7eb8997660a70e1e58a4f89a82574931195e63)
Sequence class encapsulation work. Memory leak fixes work

(cherry picked from commit 7caaa778697ea2a84162f4ce523be8b6cef79647)