### PR TITLE
Limit bezier handles

### DIFF
--- a/ui/graphview.cpp
+++ b/ui/graphview.cpp
@@ -524,11 +524,20 @@ void GraphView::mouseMoveEvent(QMouseEvent *event) {
 				}
 
 				EffectKeyframe& key = row->field(handle_field)->keyframes[handle_index];
-				key.pre_handle_x = new_pre_handle_x;
-				key.pre_handle_y = new_pre_handle_y;
-				key.post_handle_x = new_post_handle_x;
-				key.post_handle_y = new_post_handle_y;
-
+                if (new_pre_handle_x < 0){
+                    key.pre_handle_x = new_pre_handle_x;
+                    key.pre_handle_y = new_pre_handle_y;
+                } else {
+                    key.pre_handle_x = 0;
+                    key.pre_handle_y = new_pre_handle_y;
+                }
+                if (new_post_handle_x > 0){
+                    key.post_handle_x = new_post_handle_x;
+                    key.post_handle_y = new_post_handle_y;
+                } else {
+                    key.post_handle_x = 0;
+                    key.post_handle_y = new_post_handle_y;
+                }
 				moved_keys = true;
 				update_ui(false);
 			}

--- a/ui/graphview.cpp
+++ b/ui/graphview.cpp
@@ -1,4 +1,4 @@
-#include "graphview.h"
+﻿#include "graphview.h"
 
 #include <QPainter>
 #include <QMouseEvent>
@@ -524,20 +524,20 @@ void GraphView::mouseMoveEvent(QMouseEvent *event) {
 				}
 
 				EffectKeyframe& key = row->field(handle_field)->keyframes[handle_index];
-                if (new_pre_handle_x < 0){
-                    key.pre_handle_x = new_pre_handle_x;
-                    key.pre_handle_y = new_pre_handle_y;
-                } else {
-                    key.pre_handle_x = 0;
-                    key.pre_handle_y = new_pre_handle_y;
-                }
-                if (new_post_handle_x > 0){
-                    key.post_handle_x = new_post_handle_x;
-                    key.post_handle_y = new_post_handle_y;
-                } else {
-                    key.post_handle_x = 0;
-                    key.post_handle_y = new_post_handle_y;
-                }
+				if (new_pre_handle_x < 0){
+					key.pre_handle_x = new_pre_handle_x;
+					key.pre_handle_y = new_pre_handle_y;
+				} else {
+					key.pre_handle_x = 0;
+					key.pre_handle_y = new_pre_handle_y;
+				}
+				if (new_post_handle_x > 0){
+					key.post_handle_x = new_post_handle_x;
+					key.post_handle_y = new_post_handle_y;
+				} else {
+					key.post_handle_x = 0;
+					key.post_handle_y = new_post_handle_y;
+				}
 				moved_keys = true;
 				update_ui(false);
 			}


### PR DESCRIPTION
Stop control point handles from being able to cross centre of control point, and flip over to the wrong side. This is the behaviour of handles in other software that uses bezier / graph editors.