### PR TITLE
Timeline rework and option for horiz/vert mousewheel

### DIFF
--- a/io/config.cpp
+++ b/io/config.cpp
@@ -70,7 +70,8 @@ Config::Config()
     center_timeline_timecodes(true),
     waveform_resolution(64),
     thumbnail_resolution(120),
-    add_default_effects_to_clips(true)
+    add_default_effects_to_clips(true),
+    horizontal_scroll_wheel(true)
 {}
 
 void Config::load(QString path) {

--- a/io/config.cpp
+++ b/io/config.cpp
@@ -88,6 +88,9 @@ void Config::load(QString path) {
         } else if (stream.name() == "ScrollZooms") {
           stream.readNext();
           scroll_zooms = (stream.text() == "1");
+        } else if (stream.name() == "HorizontalScrollWheel") {
+          stream.readNext();
+          horizontal_scroll_wheel = (stream.text() == "1");
         } else if (stream.name() == "EditToolSelectsLinks") {
           stream.readNext();
           edit_tool_selects_links = (stream.text() == "1");
@@ -234,6 +237,7 @@ void Config::save(QString path) {
   stream.writeTextElement("Version", QString::number(olive::kSaveVersion));
   stream.writeTextElement("ShowTrackLines", QString::number(show_track_lines));
   stream.writeTextElement("ScrollZooms", QString::number(scroll_zooms));
+  stream.writeTextElement("HorizontalScrollWheel", QString::number(horizontal_scroll_wheel));
   stream.writeTextElement("EditToolSelectsLinks", QString::number(edit_tool_selects_links));
   stream.writeTextElement("EditToolAlsoSeeks", QString::number(edit_tool_also_seeks));
   stream.writeTextElement("SelectAlsoSeeks", QString::number(select_also_seeks));

--- a/io/config.h
+++ b/io/config.h
@@ -165,6 +165,7 @@ struct Config {
    * @brief The scroll wheel zooms rather than scrolls
    *
    * **TRUE** if the scroll wheel should zoom in and out rather than scroll up and down.
+   * The Control key temporarily toggles this setting.
    */
   bool scroll_zooms;
 
@@ -508,6 +509,14 @@ struct Config {
    * VolumeEffect, and PanEffect) added to them by default.
    */
   bool add_default_effects_to_clips;
+
+  /**
+   * @brief Horizontal scroll wheel
+   *
+   * **TRUE** Scrolling vertically with a mouse wheel or touchpad scrolls the Timeline horizontally.
+   * The Shift key temporarily toggles this setting.
+   */
+  bool horizontal_scroll_wheel;
 
   /**
    * @brief Load config from file

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -631,6 +631,10 @@ void MainWindow::setup_menus() {
   scroll_wheel_zooms->setCheckable(true);
   scroll_wheel_zooms->setData(reinterpret_cast<quintptr>(&olive::CurrentConfig.scroll_zooms));
 
+  horizontal_scroll_wheel = MenuHelper::create_menu_action(tools_menu, "horizontalscrollwheel", &olive::MenuHelper, SLOT(toggle_bool_action()));
+  horizontal_scroll_wheel->setCheckable(true);
+  horizontal_scroll_wheel->setData(reinterpret_cast<quintptr>(&olive::CurrentConfig.horizontal_scroll_wheel));
+
   enable_drag_files_to_timeline = MenuHelper::create_menu_action(tools_menu, "enabledragfilestotimeline", &olive::MenuHelper, SLOT(toggle_bool_action()));
   enable_drag_files_to_timeline->setCheckable(true);
   enable_drag_files_to_timeline->setData(reinterpret_cast<quintptr>(&olive::CurrentConfig.enable_drag_files_to_timeline));
@@ -795,7 +799,8 @@ void MainWindow::Retranslate()
   edit_tool_selects_links->setText(tr("Edit Tool Selects Links"));
   seek_also_selects->setText(tr("Seek Also Selects"));
   seek_to_end_of_pastes->setText(tr("Seek to the End of Pastes"));
-  scroll_wheel_zooms->setText(tr("Scroll Wheel Zooms"));
+  scroll_wheel_zooms->setText(tr("Scroll Wheel Zooms (Ctrl toggles)"));
+  horizontal_scroll_wheel->setText(tr("Horizontal Scroll Wheel (Shift toggles)"));
   enable_drag_files_to_timeline->setText(tr("Enable Drag Files to Timeline"));
   autoscale_by_default->setText(tr("Auto-Scale By Default"));
   enable_seek_to_import->setText(tr("Enable Seek to Import"));
@@ -997,6 +1002,7 @@ void MainWindow::toolMenu_About_To_Be_Shown() {
   olive::MenuHelper.set_bool_action_checked(edit_tool_selects_links);
   olive::MenuHelper.set_bool_action_checked(seek_to_end_of_pastes);
   olive::MenuHelper.set_bool_action_checked(scroll_wheel_zooms);
+  olive::MenuHelper.set_bool_action_checked(horizontal_scroll_wheel);
   olive::MenuHelper.set_bool_action_checked(rectified_waveforms);
   olive::MenuHelper.set_bool_action_checked(enable_drag_files_to_timeline);
   olive::MenuHelper.set_bool_action_checked(autoscale_by_default);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -315,6 +315,7 @@ private:
   QAction* edit_tool_selects_links;
   QAction* seek_to_end_of_pastes;
   QAction* scroll_wheel_zooms;
+  QAction* horizontal_scroll_wheel;
   QAction* rectified_waveforms;
   QAction* enable_drag_files_to_timeline;
   QAction* autoscale_by_default;

--- a/ui/timelinewidget.cpp
+++ b/ui/timelinewidget.cpp
@@ -360,49 +360,65 @@ void TimelineWidget::dragMoveEvent(QDragMoveEvent *event) {
 }
 
 void TimelineWidget::wheelEvent(QWheelEvent *event) {
-  // ctrl used to toggle zooming instead of scrolling
+
+  // TODO: implement pixel scrolling
+
+  bool shift = (event->modifiers() & Qt::ShiftModifier);
   bool ctrl = (event->modifiers() & Qt::ControlModifier);
+  bool alt = (event->modifiers() & Qt::AltModifier);
 
-  //
-  // NOTE/FIXME: CURRENTLY disabling pixel scrolling because it needs more testing
-  //
+  // "Scroll Zooms" false + Control up  : not zooming
+  // "Scroll Zooms" false + Control down:     zooming
+  // "Scroll Zooms" true  + Control up  :     zooming
+  // "Scroll Zooms" true  + Control down: not zooming
+  bool zooming = (olive::CurrentConfig.scroll_zooms != ctrl);
 
-  /*if (!event->pixelDelta().isNull()) {
-        // if we got pixel scrolling data, prefer it over the angleDelta data
+  // Allow shift for axis swap, but don't swap on zoom... Unless
+  // we need to override Qt's axis swap via Alt
+  bool swap_hv = ((shift != olive::CurrentConfig.horizontal_scroll_wheel) &
+                  !zooming) | (alt & !shift & zooming);
 
-        QScrollBar* horiz_bar = panel_timeline->horizontalScrollBar;
-        QScrollBar* vert_bar = scrollBar;
+  int delta_h = swap_hv ? event->angleDelta().y() : event->angleDelta().x();
+  int delta_v = swap_hv ? event->angleDelta().x() : event->angleDelta().y();
 
-        horiz_bar->setValue(horiz_bar->value() + event->pixelDelta().x());
-        vert_bar->setValue(vert_bar->value() + event->pixelDelta().y());
+  if (zooming) {
 
-    } else*/ if (!event->angleDelta().isNull()) {
+    // Zoom only uses vertical scrolling, to avoid glitches on touchpads.
+    // Don't do anything if not scrolling vertically.
 
-    // alt is used to swap horizontal and vertical scrolling
-    bool alt = (event->modifiers() & Qt::AltModifier);
+    if (delta_v != 0) {
 
-    int scroll_amount = alt ? (event->angleDelta().x()) : (event->angleDelta().y());
+      // delta_v == 120 for one click of a mousewheel. Less or more for a
+      // touchpad gesture. Calculate speed to compensate.
+      // 120 = ratio of 4/3 (1.33), -120 = ratio of 3/4 (.75)
 
-    bool in = (scroll_amount > 0);
-    if (olive::CurrentConfig.scroll_zooms != ctrl) {
+      double zoom_ratio = 1.0 + (abs(delta_v) * 0.33 / 120);
 
-      // if config.scroll_zooms is enabled or ctrl is held, zoom instead of scrolling
-      if (in) {
-        panel_timeline->multiply_zoom(1.5);
-      } else {
-        panel_timeline->multiply_zoom(0.75);
+      if (delta_v < 0) {
+        zoom_ratio = 1.0 / zoom_ratio;
       }
 
-    } else {
-      // pass the scrolling to the Timeline's main scrollbar for horizontal scrolling, or this widget's
-      // scrollbar for vertical scrolling
-
-      QScrollBar* bar = alt ? scrollBar : panel_timeline->horizontalScrollBar;
-
-      int step = bar->singleStep();
-      if (in) step = -step;
-      bar->setValue(bar->value() + step);
+      panel_timeline->multiply_zoom(zoom_ratio);
     }
+
+  } else {
+
+    // Use the Timeline's main scrollbar for horizontal scrolling, and this
+    // widget's scrollbar for vertical scrolling.
+
+    QScrollBar* bar_v = scrollBar;
+    QScrollBar* bar_h = panel_timeline->horizontalScrollBar;
+
+    // Match the wheel events to the size of a step as per
+    // https://doc.qt.io/qt-5/qwheelevent.html#angleDelta
+
+    int step_h = bar_h->singleStep() * delta_h / -120;
+    int step_v = bar_v->singleStep() * delta_v / -120;
+
+    // Apply to appropriate scrollbars
+
+    bar_h->setValue(bar_h->value() + step_h);
+    bar_v->setValue(bar_v->value() + step_v);
   }
 }
 


### PR DESCRIPTION
Replaces PR #560.

- New option, "Horizontal Scroll Wheel"
- Shift or Alt for axis swap
- Mention Ctrl and Shift near their relevant options
