### PR TITLE
previously imported interlaced videos being shown/treated as progressive on subsequent imports

### DIFF
--- a/io/previewgenerator.cpp
+++ b/io/previewgenerator.cpp
@@ -118,7 +118,7 @@ void PreviewGenerator::parse_media() {
 
       if (append) {
         QVector<FootageStream>& stream_list = (fmt_ctx_->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) ?
-              footage_->audio_tracks : footage_->video_tracks;
+                                                footage_->audio_tracks : footage_->video_tracks;
 
         for (int j=0;j<stream_list.size();j++) {
           if (stream_list.at(j).file_index == i) {
@@ -323,17 +323,17 @@ void PreviewGenerator::generate_waveform() {
               uint8_t* data = new uint8_t[size_t(dstW*dstH*4)];
 
               sws_ctx = sws_getContext(
-                    temp_frame->width,
-                    temp_frame->height,
-                    static_cast<AVPixelFormat>(temp_frame->format),
-                    dstW,
-                    dstH,
-                    static_cast<AVPixelFormat>(AV_PIX_FMT_RGBA),
-                    SWS_FAST_BILINEAR,
-                    nullptr,
-                    nullptr,
-                    nullptr
-                    );
+                          temp_frame->width,
+                          temp_frame->height,
+                          static_cast<AVPixelFormat>(temp_frame->format),
+                          dstW,
+                          dstH,
+                          static_cast<AVPixelFormat>(AV_PIX_FMT_RGBA),
+                          SWS_FAST_BILINEAR,
+                          nullptr,
+                          nullptr,
+                          nullptr
+                          );
 
               int linesize[AV_NUM_DATA_POINTERS];
               linesize[0] = dstW*4;
@@ -363,16 +363,16 @@ void PreviewGenerator::generate_waveform() {
             swr_frame->format = AV_SAMPLE_FMT_S16P;
 
             swr_ctx = swr_alloc_set_opts(
-                  nullptr,
-                  temp_frame->channel_layout,
-                  static_cast<AVSampleFormat>(swr_frame->format),
-                  temp_frame->sample_rate,
-                  temp_frame->channel_layout,
-                  static_cast<AVSampleFormat>(temp_frame->format),
-                  temp_frame->sample_rate,
-                  0,
-                  nullptr
-                  );
+                        nullptr,
+                        temp_frame->channel_layout,
+                        static_cast<AVSampleFormat>(swr_frame->format),
+                        temp_frame->sample_rate,
+                        temp_frame->channel_layout,
+                        static_cast<AVSampleFormat>(temp_frame->format),
+                        temp_frame->sample_rate,
+                        0,
+                        nullptr
+                        );
 
             swr_init(swr_ctx);
 
@@ -552,30 +552,26 @@ void PreviewGenerator::run() {
       // see if we already have data for this
       QString hash = get_file_hash(footage_->url);
 
+      generate_waveform();
+
       if (retrieve_preview(hash)) {
         sem.acquire();
-
         if (!cancelled_) {
-          generate_waveform();
-
-          if (!cancelled_) {
-            // save preview to file
-            for (int i=0;i<footage_->video_tracks.size();i++) {
-              FootageStream& ms = footage_->video_tracks[i];
-              ms.video_preview.save(get_thumbnail_path(hash, ms), "PNG");
-              //dout << "saved" << ms->file_index << "thumbnail to" << get_thumbnail_path(hash, ms);
-            }
-            for (int i=0;i<footage_->audio_tracks.size();i++) {
-              FootageStream& ms = footage_->audio_tracks[i];
-              QFile f(get_waveform_path(hash, ms));
-              f.open(QFile::WriteOnly);
-              f.write(ms.audio_preview.constData(), ms.audio_preview.size());
-              f.close();
-              //dout << "saved" << ms->file_index << "waveform to" << get_waveform_path(hash, ms);
-            }
+          // save preview to file
+          for (int i=0;i<footage_->video_tracks.size();i++) {
+            FootageStream& ms = footage_->video_tracks[i];
+            ms.video_preview.save(get_thumbnail_path(hash, ms), "PNG");
+            //dout << "saved" << ms->file_index << "thumbnail to" << get_thumbnail_path(hash, ms);
+          }
+          for (int i=0;i<footage_->audio_tracks.size();i++) {
+            FootageStream& ms = footage_->audio_tracks[i];
+            QFile f(get_waveform_path(hash, ms));
+            f.open(QFile::WriteOnly);
+            f.write(ms.audio_preview.constData(), ms.audio_preview.size());
+            f.close();
+            //dout << "saved" << ms->file_index << "waveform to" << get_waveform_path(hash, ms);
           }
         }
-
         sem.release();
       }
     }


### PR DESCRIPTION
If a preview already exists a waveform was not generated and stream info (at least interlacing) was not found

(cherry picked from commit 70ef8cedcb7eba7a29b55563a03d10d5dd01a20a)

---

On the 1st import of an interlaced video, it's field order is correctly shown in the Media hover-popup and treated as an interlaced video. 
On the next import, the same interlaced video is shown as progressive, and is treated as such.

Moving PreviewGenerator::generate_waveform() out of the PreviewGenerator::retrieve_preview() condition allows the interlaced video to be treated correctly, but i'm not entirely sure why.  I saw Lines 106 to 108 for the reason.


On a slightly different note. Are interlaced videos actually working in Olive? It always shows either garbage (looks like empty frame data) or the last frame of the last shown video. At least in the preview viewer. I came across this issue whilst going through the caching thread in Chestnut.

