### PR TITLE
add cmake buildsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,479 @@
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+
+project(olive-editor LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+set(OLIVE_DEFINITIONS -DQT_DEPRECATED_WARNINGS)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+if(UNIX AND NOT APPLE AND NOT DEFINED OpenGL_GL_PREFERENCE)
+  set(OpenGL_GL_PREFERENCE GLVND)
+endif()
+find_package(OpenGL REQUIRED)
+
+find_package(Qt5 5.7 REQUIRED
+  COMPONENTS
+  Core
+  Gui
+  Widgets
+  Multimedia
+  OpenGL
+  Svg
+  LinguistTools
+)
+
+find_package(FFMPEG 3.4 REQUIRED
+  COMPONENTS
+  avutil
+  avcodec
+  avformat
+  avfilter
+  swscale
+  swresample
+)
+
+find_package(frei0r)
+if(NOT FREI0R_FOUND)
+  list(APPEND OLIVE_DEFINITIONS -DNOFREI0R)
+endif()
+
+if(WIN32)
+  find_package(OpenColorIO)
+  if(OPENCOLORIO_FOUND)
+    list(APPEND OLIVE_DEFINITIONS -DOLIVE_OCIO)
+  endif()
+endif()
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  find_package(Git)
+  if(GIT_FOUND)
+    execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_HASH
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
+elseif(UNIX AND NOT APPLE)
+  # Fallback for Ubuntu/Launchpad (extracts Git hash from debian/changelog rather than Git repo)
+  # (see https://answers.launchpad.net/launchpad/+question/678556)
+  execute_process(COMMAND sh debian/gitfromlog.sh debian/changelog
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endif()
+if(DEFINED GIT_HASH)
+  message("Olive: git hash = " "${GIT_HASH}")
+  list(APPEND OLIVE_DEFINITIONS -DGITHASH="${GIT_HASH}")
+else()
+  message("Olive: No git hash defined!")
+endif()
+
+set(OLIVE_SOURCES
+  dialogs/aboutdialog.cpp
+  dialogs/aboutdialog.h
+  dialogs/actionsearch.cpp
+  dialogs/actionsearch.h
+  dialogs/advancedvideodialog.cpp
+  dialogs/advancedvideodialog.h
+  dialogs/autocutsilencedialog.cpp
+  dialogs/autocutsilencedialog.h
+  dialogs/clippropertiesdialog.cpp
+  dialogs/clippropertiesdialog.h
+  dialogs/debugdialog.cpp
+  dialogs/debugdialog.h
+  dialogs/demonotice.cpp
+  dialogs/demonotice.h
+  dialogs/exportdialog.cpp
+  dialogs/exportdialog.h
+  dialogs/loaddialog.cpp
+  dialogs/loaddialog.h
+  dialogs/mediapropertiesdialog.cpp
+  dialogs/mediapropertiesdialog.h
+  dialogs/newsequencedialog.cpp
+  dialogs/newsequencedialog.h
+  dialogs/preferencesdialog.cpp
+  dialogs/preferencesdialog.h
+  dialogs/proxydialog.cpp
+  dialogs/proxydialog.h
+  dialogs/replaceclipmediadialog.cpp
+  dialogs/replaceclipmediadialog.h
+  dialogs/speeddialog.cpp
+  dialogs/speeddialog.h
+  dialogs/texteditdialog.cpp
+  dialogs/texteditdialog.h
+  effects/fields/boolfield.cpp
+  effects/fields/boolfield.h
+  effects/fields/buttonfield.cpp
+  effects/fields/buttonfield.h
+  effects/fields/colorfield.cpp
+  effects/fields/colorfield.h
+  effects/fields/combofield.cpp
+  effects/fields/combofield.h
+  effects/fields/doublefield.cpp
+  effects/fields/doublefield.h
+  effects/fields/filefield.cpp
+  effects/fields/filefield.h
+  effects/fields/fontfield.cpp
+  effects/fields/fontfield.h
+  effects/fields/labelfield.cpp
+  effects/fields/labelfield.h
+  effects/fields/stringfield.cpp
+  effects/fields/stringfield.h
+  effects/internal/audionoiseeffect.cpp
+  effects/internal/audionoiseeffect.h
+  effects/internal/blending.frag
+  effects/internal/common.vert
+  effects/internal/cornerpin.frag
+  effects/internal/cornerpin.vert
+  effects/internal/cornerpineffect.cpp
+  effects/internal/cornerpineffect.h
+  effects/internal/crossdissolvetransition.cpp
+  effects/internal/crossdissolvetransition.h
+  effects/internal/cubetransition.h
+  effects/internal/dropshadow.frag
+  effects/internal/dropshadoweffect.cpp
+  effects/internal/dropshadoweffect.h
+  effects/internal/exponentialfadetransition.cpp
+  effects/internal/exponentialfadetransition.h
+  effects/internal/fillleftrighteffect.cpp
+  effects/internal/fillleftrighteffect.h
+  effects/internal/frei0reffect.cpp
+  effects/internal/frei0reffect.h
+  effects/internal/internalshaders.qrc
+  effects/internal/linearfadetransition.cpp
+  effects/internal/linearfadetransition.h
+  effects/internal/logarithmicfadetransition.cpp
+  effects/internal/logarithmicfadetransition.h
+  effects/internal/ocio.frag
+  effects/internal/paneffect.cpp
+  effects/internal/paneffect.h
+  effects/internal/premultiply.frag
+  effects/internal/richtexteffect.cpp
+  effects/internal/richtexteffect.h
+  effects/internal/shakeeffect.cpp
+  effects/internal/shakeeffect.h
+  effects/internal/solideffect.cpp
+  effects/internal/solideffect.h
+  effects/internal/texteffect.cpp
+  effects/internal/texteffect.h
+  effects/internal/timecodeeffect.cpp
+  effects/internal/timecodeeffect.h
+  effects/internal/toneeffect.cpp
+  effects/internal/toneeffect.h
+  effects/internal/transformeffect.cpp
+  effects/internal/transformeffect.h
+  effects/internal/voideffect.cpp
+  effects/internal/voideffect.h
+  effects/internal/volumeeffect.cpp
+  effects/internal/volumeeffect.h
+  effects/internal/vsthost.cpp
+  effects/internal/vsthost.h
+  effects/effect.cpp
+  effects/effect.h
+  effects/effectfield.cpp
+  effects/effectfield.h
+  effects/effectfields.h
+  effects/effectgizmo.cpp
+  effects/effectgizmo.h
+  effects/effectloaders.cpp
+  effects/effectloaders.h
+  effects/effectrow.cpp
+  effects/effectrow.h
+  effects/keyframe.cpp
+  effects/keyframe.h
+  effects/transition.cpp
+  effects/transition.h
+  global/config.cpp
+  global/config.h
+  global/debug.cpp
+  global/debug.h
+  global/global.cpp
+  global/global.h
+  global/math.cpp
+  global/math.h
+  global/path.cpp
+  global/path.h
+  include/vestige.h
+  panels/effectcontrols.cpp
+  panels/effectcontrols.h
+  panels/grapheditor.cpp
+  panels/grapheditor.h
+  panels/panels.cpp
+  panels/panels.h
+  panels/project.cpp
+  panels/project.h
+  panels/timeline.cpp
+  panels/timeline.h
+  panels/viewer.cpp
+  panels/viewer.h
+  project/clipboard.cpp
+  project/clipboard.h
+  project/footage.cpp
+  project/footage.h
+  project/loadthread.cpp
+  project/loadthread.h
+  project/media.cpp
+  project/media.h
+  project/previewgenerator.cpp
+  project/previewgenerator.h
+  project/projectelements.h
+  project/projectfilter.cpp
+  project/projectfilter.h
+  project/projectmodel.cpp
+  project/projectmodel.h
+  project/proxygenerator.cpp
+  project/proxygenerator.h
+  project/sourcescommon.cpp
+  project/sourcescommon.h
+  rendering/audio.cpp
+  rendering/audio.h
+  rendering/cacher.cpp
+  rendering/cacher.h
+  rendering/clipqueue.cpp
+  rendering/clipqueue.h
+  rendering/exportthread.cpp
+  rendering/exportthread.h
+  rendering/framebufferobject.cpp
+  rendering/framebufferobject.h
+  rendering/renderfunctions.cpp
+  rendering/renderfunctions.h
+  rendering/renderthread.cpp
+  rendering/renderthread.h
+  timeline/clip.cpp
+  timeline/clip.h
+  timeline/marker.cpp
+  timeline/marker.h
+  timeline/mediaimportdata.cpp
+  timeline/mediaimportdata.h
+  timeline/selection.h
+  timeline/sequence.cpp
+  timeline/sequence.h
+  ui/audiomonitor.cpp
+  ui/audiomonitor.h
+  ui/blur.cpp
+  ui/blur.h
+  ui/clickablelabel.cpp
+  ui/clickablelabel.h
+  ui/collapsiblewidget.cpp
+  ui/collapsiblewidget.h
+  ui/columnedgridlayout.cpp
+  ui/columnedgridlayout.h
+  ui/colorbutton.cpp
+  ui/colorbutton.h
+  ui/comboboxex.cpp
+  ui/comboboxex.h
+  ui/cursors.cpp
+  ui/cursors.h
+  ui/effectui.cpp
+  ui/effectui.h
+  ui/embeddedfilechooser.cpp
+  ui/embeddedfilechooser.h
+  ui/flowlayout.cpp
+  ui/flowlayout.h
+  ui/focusfilter.cpp
+  ui/focusfilter.h
+  ui/fontcombobox.cpp
+  ui/fontcombobox.h
+  ui/graphview.cpp
+  ui/graphview.h
+  ui/icons.cpp
+  ui/icons.h
+  ui/keyframedrawing.cpp
+  ui/keyframedrawing.h
+  ui/keyframenavigator.cpp
+  ui/keyframenavigator.h
+  ui/keyframeview.cpp
+  ui/keyframeview.h
+  ui/labelslider.cpp
+  ui/labelslider.h
+  ui/mainwindow.cpp
+  ui/mainwindow.h
+  ui/mediaiconservice.cpp
+  ui/mediaiconservice.h
+  ui/menu.cpp
+  ui/menu.h
+  ui/menuhelper.cpp
+  ui/menuhelper.h
+  ui/panel.cpp
+  ui/panel.h
+  ui/playbutton.cpp
+  ui/playbutton.h
+  ui/rectangleselect.cpp
+  ui/rectangleselect.h
+  ui/resizablescrollbar.cpp
+  ui/resizablescrollbar.h
+  ui/scrollarea.cpp
+  ui/scrollarea.h
+  ui/sourceiconview.cpp
+  ui/sourceiconview.h
+  ui/sourcetable.cpp
+  ui/sourcetable.h
+  ui/styling.cpp
+  ui/styling.h
+  ui/texteditex.cpp
+  ui/texteditex.h
+  ui/timelineheader.cpp
+  ui/timelineheader.h
+  ui/timelinetools.h
+  ui/timelinewidget.cpp
+  ui/timelinewidget.h
+  ui/updatenotification.cpp
+  ui/updatenotification.h
+  ui/viewercontainer.cpp
+  ui/viewercontainer.h
+  ui/viewerwidget.cpp
+  ui/viewerwidget.h
+  ui/viewerwindow.cpp
+  ui/viewerwindow.h
+  undo/comboaction.cpp
+  undo/comboaction.h
+  undo/undo.cpp
+  undo/undo.h
+  undo/undostack.cpp
+  undo/undostack.h
+  main.cpp
+)
+
+set(OLIVE_RESOURCES
+  cursors/cursors.qrc
+  effects/internal/internalshaders.qrc
+  icons/icons.qrc
+)
+
+set(OLIVE_EFFECTS
+  effects/shaders/boxblur.frag
+  effects/shaders/boxblur.xml
+  effects/shaders/bulge.frag
+  effects/shaders/bulge.xml
+  effects/shaders/chromakey.frag
+  effects/shaders/chromakey.xml
+  effects/shaders/chromaticaberration.frag
+  effects/shaders/chromaticaberration.xml
+  effects/shaders/colorcorrection.frag
+  effects/shaders/colorcorrection.xml
+  effects/shaders/colorsel.frag
+  effects/shaders/colorsel.xml
+  effects/shaders/common.frag
+  effects/shaders/common.vert
+  effects/shaders/crop.frag
+  effects/shaders/crop.xml
+  effects/shaders/crossstitch.frag
+  effects/shaders/crossstitch.xml
+  effects/shaders/directionalblur.frag
+  effects/shaders/directionalblur.xml
+  effects/shaders/dropshadow.xml.disabled
+  effects/shaders/emboss.frag
+  effects/shaders/emboss.xml
+  effects/shaders/findedges.frag
+  effects/shaders/findedges.xml.disabled
+  effects/shaders/fisheye.frag
+  effects/shaders/fisheye.xml
+  effects/shaders/flip.frag
+  effects/shaders/flip.xml
+  effects/shaders/gaussianblur.frag
+  effects/shaders/gaussianblur.xml
+  effects/shaders/huesatbri.frag
+  effects/shaders/huesatbri.xml
+  effects/shaders/invert.frag
+  effects/shaders/invert.xml
+  effects/shaders/lumakey.frag
+  effects/shaders/lumakey.xml
+  effects/shaders/noise.frag
+  effects/shaders/noise.xml
+  effects/shaders/pixelate.frag
+  effects/shaders/pixelate.xml
+  effects/shaders/posterize.frag
+  effects/shaders/posterize.xml
+  effects/shaders/radialblur.frag
+  effects/shaders/radialblur.xml
+  effects/shaders/ripple.frag
+  effects/shaders/ripple.xml
+  effects/shaders/sphere.frag
+  effects/shaders/sphere.xml
+  effects/shaders/swirl.frag
+  effects/shaders/swirl.xml
+  effects/shaders/tile.frag
+  effects/shaders/tile.xml
+  effects/shaders/toonify.frag
+  effects/shaders/toonify.xml
+  effects/shaders/vignette.frag
+  effects/shaders/vignette.xml
+  effects/shaders/volumetriclight.frag
+  effects/shaders/volumetriclight.xml
+  effects/shaders/wave.frag
+  effects/shaders/wave.xml
+)
+
+qt5_add_translation(OLIVE_QM_FILES
+  ts/olive_ar.ts
+  ts/olive_bs.ts
+  ts/olive_cs.ts
+  ts/olive_de.ts
+  ts/olive_es.ts
+  ts/olive_fr.ts
+  ts/olive_it.ts
+  ts/olive_ru.ts
+  ts/olive_sr.ts
+)
+
+set(OLIVE_TARGET "olive-editor")
+if(APPLE)
+  set(OLIVE_TARGET "Olive")
+endif()
+
+add_executable(${OLIVE_TARGET}
+  ${OLIVE_SOURCES}
+  ${OLIVE_RESOURCES}
+  ${OLIVE_EFFECTS}
+  ${OLIVE_QM_FILES}
+)
+
+target_compile_definitions(${OLIVE_TARGET} PRIVATE ${OLIVE_DEFINITIONS})
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+target_link_libraries(${OLIVE_TARGET}
+  PRIVATE
+  OpenGL::GL
+  Qt5::Core
+  Qt5::Gui
+  Qt5::Widgets
+  Qt5::Multimedia
+  Qt5::OpenGL
+  Qt5::Svg
+  FFMPEG::avutil
+  FFMPEG::avcodec
+  FFMPEG::avformat
+  FFMPEG::avfilter
+  FFMPEG::swscale
+  FFMPEG::swresample
+)
+
+if(WIN32 AND OPENCOLORIO_FOUND)
+  target_link_libraries(${OLIVE_TARGET} PRIVATE OpenColorIO)
+endif()
+
+if(UNIX AND NOT APPLE)
+  install(TARGETS ${OLIVE_TARGET} RUNTIME DESTINATION bin)
+  install(FILES ${OLIVE_EFFECTS} DESTINATION share/olive-editor/effects)
+  install(FILES packaging/linux/org.olivevideoeditor.Olive.desktop DESTINATION share/applications)
+  install(FILES packaging/linux/org.olivevideoeditor.Olive.appdata.xml DESTINATION share/metainfo)
+  install(FILES packaging/linux/org.olivevideoeditor.Olive.xml DESTINATION share/mime/packages)
+  install(FILES packaging/linux/icons/16x16/org.olivevideoeditor.Olive.png DESTINATION share/icons/hicolor/16x16/apps)
+  install(FILES packaging/linux/icons/32x32/org.olivevideoeditor.Olive.png DESTINATION share/icons/hicolor/32x32/apps)
+  install(FILES packaging/linux/icons/48x48/org.olivevideoeditor.Olive.png DESTINATION share/icons/hicolor/48x48/apps)
+  install(FILES packaging/linux/icons/64x64/org.olivevideoeditor.Olive.png DESTINATION share/icons/hicolor/64x64/apps)
+  install(FILES packaging/linux/icons/128x128/org.olivevideoeditor.Olive.png DESTINATION share/icons/hicolor/128x128/apps)
+  install(FILES packaging/linux/icons/256x256/org.olivevideoeditor.Olive.png DESTINATION share/icons/hicolor/256x256/apps)
+  install(FILES packaging/linux/icons/512x512/org.olivevideoeditor.Olive.png DESTINATION share/icons/hicolor/512x512/apps)
+  install(FILES ${OLIVE_QM_FILES} DESTINATION share/olive-editor/ts)
+endif()

--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -1,0 +1,193 @@
+#[==[
+Provides the following variables:
+
+  * `FFMPEG_INCLUDE_DIRS`: Include directories necessary to use FFMPEG.
+  * `FFMPEG_LIBRARIES`: Libraries necessary to use FFMPEG. Note that this only
+    includes libraries for the components requested.
+  * `FFMPEG_VERSION`: The version of FFMPEG found.
+
+The following components are supported:
+
+  * `avcodec`
+  * `avdevice`
+  * `avfilter`
+  * `avformat`
+  * `avresample`
+  * `avutil`
+  * `swresample`
+  * `swscale`
+
+For each component, the following are provided:
+
+  * `FFMPEG_<component>_FOUND`: Libraries for the component.
+  * `FFMPEG_<component>_INCLUDE_DIRS`: Include directories for
+    the component.
+  * `FFMPEG_<component>_LIBRARIES`: Libraries for the component.
+  * `FFMPEG::<component>`: A target to use with `target_link_libraries`.
+
+Note that only components requested with `COMPONENTS` or `OPTIONAL_COMPONENTS`
+are guaranteed to set these variables or provide targets.
+#]==]
+
+function (_ffmpeg_find component headername)
+  find_path("FFMPEG_${component}_INCLUDE_DIR"
+    NAMES
+      "lib${component}/${headername}"
+    PATHS
+      "${FFMPEG_ROOT}/include"
+      ~/Library/Frameworks
+      /Library/Frameworks
+      /usr/local/include
+      /usr/include
+      /sw/include # Fink
+      /opt/local/include # DarwinPorts
+      /opt/csw/include # Blastwave
+      /opt/include
+      /usr/freeware/include
+    PATH_SUFFIXES
+      ffmpeg
+    DOC "FFMPEG's ${component} include directory")
+  mark_as_advanced("FFMPEG_${component}_INCLUDE_DIR")
+
+  # On Windows, static FFMPEG is sometimes built as `lib<name>.a`.
+  if (WIN32)
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".lib")
+    list(APPEND CMAKE_FIND_LIBRARY_PREFIXES "" "lib")
+  endif ()
+
+  find_library("FFMPEG_${component}_LIBRARY"
+    NAMES
+      "${component}"
+    PATHS
+      "${FFMPEG_ROOT}/lib"
+      ~/Library/Frameworks
+      /Library/Frameworks
+      /usr/local/lib
+      /usr/local/lib64
+      /usr/lib
+      /usr/lib64
+      /sw/lib
+      /opt/local/lib
+      /opt/csw/lib
+      /opt/lib
+      /usr/freeware/lib64
+      "${FFMPEG_ROOT}/bin"
+    DOC "FFMPEG's ${component} library")
+  mark_as_advanced("FFMPEG_${component}_LIBRARY")
+
+  if (FFMPEG_${component}_LIBRARY AND FFMPEG_${component}_INCLUDE_DIR)
+    set(_deps_found TRUE)
+    set(_deps_link)
+    foreach (_ffmpeg_dep IN LISTS ARGN)
+      if (TARGET "FFMPEG::${_ffmpeg_dep}")
+        list(APPEND _deps_link "FFMPEG::${_ffmpeg_dep}")
+      else ()
+        set(_deps_found FALSE)
+      endif ()
+    endforeach ()
+    if (_deps_found)
+      add_library("FFMPEG::${component}" UNKNOWN IMPORTED)
+      set_target_properties("FFMPEG::${component}" PROPERTIES
+        IMPORTED_LOCATION "${FFMPEG_${component}_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_${component}_INCLUDE_DIR}"
+        IMPORTED_LINK_INTERFACE_LIBRARIES "${_deps_link}")
+      set("FFMPEG_${component}_FOUND" 1
+        PARENT_SCOPE)
+
+      set(version_header_path "${FFMPEG_${component}_INCLUDE_DIR}/lib${component}/version.h")
+      if (EXISTS "${version_header_path}")
+        string(TOUPPER "${component}" component_upper)
+        file(STRINGS "${version_header_path}" version
+          REGEX "#define  *LIB${component_upper}_VERSION_(MAJOR|MINOR|MICRO) ")
+        string(REGEX REPLACE ".*_MAJOR *\([0-9]*\).*" "\\1" major "${version}")
+        string(REGEX REPLACE ".*_MINOR *\([0-9]*\).*" "\\1" minor "${version}")
+        string(REGEX REPLACE ".*_MICRO *\([0-9]*\).*" "\\1" micro "${version}")
+        if (NOT major STREQUAL "" AND
+            NOT minor STREQUAL "" AND
+            NOT micro STREQUAL "")
+          set("FFMPEG_${component}_VERSION" "${major}.${minor}.${micro}"
+            PARENT_SCOPE)
+        endif ()
+      endif ()
+    else ()
+      set("FFMPEG_${component}_FOUND" 0
+        PARENT_SCOPE)
+      set(what)
+      if (NOT FFMPEG_${component}_LIBRARY)
+        set(what "library")
+      endif ()
+      if (NOT FFMPEG_${component}_INCLUDE_DIR)
+        if (what)
+          string(APPEND what " or headers")
+        else ()
+          set(what "headers")
+        endif ()
+      endif ()
+      set("FFMPEG_${component}_NOT_FOUND_MESSAGE"
+        "Could not find the ${what} for ${component}."
+        PARENT_SCOPE)
+    endif ()
+  endif ()
+endfunction ()
+
+_ffmpeg_find(avutil     avutil.h)
+_ffmpeg_find(avresample avresample.h
+  avutil)
+_ffmpeg_find(swresample swresample.h
+  avutil)
+_ffmpeg_find(swscale    swscale.h
+  avutil)
+_ffmpeg_find(avcodec    avcodec.h
+  avutil)
+_ffmpeg_find(avformat   avformat.h
+  avcodec avutil)
+_ffmpeg_find(avfilter   avfilter.h
+  avutil)
+_ffmpeg_find(avdevice   avdevice.h
+  avformat avutil)
+
+if (TARGET FFMPEG::avutil)
+  set(_ffmpeg_version_header_path "${FFMPEG_avutil_INCLUDE_DIR}/libavutil/ffversion.h")
+  if (EXISTS "${_ffmpeg_version_header_path}")
+    file(STRINGS "${_ffmpeg_version_header_path}" _ffmpeg_version
+      REGEX "FFMPEG_VERSION")
+    string(REGEX REPLACE ".*\"n?\(.*\)\"" "\\1" FFMPEG_VERSION "${_ffmpeg_version}")
+    unset(_ffmpeg_version)
+  else ()
+    set(FFMPEG_VERSION FFMPEG_VERSION-NOTFOUND)
+  endif ()
+  unset(_ffmpeg_version_header_path)
+endif ()
+
+set(FFMPEG_INCLUDE_DIRS)
+set(FFMPEG_LIBRARIES)
+set(_ffmpeg_required_vars)
+foreach (_ffmpeg_component IN LISTS FFMPEG_FIND_COMPONENTS)
+  if (TARGET "FFMPEG::${_ffmpeg_component}")
+    set(FFMPEG_${_ffmpeg_component}_INCLUDE_DIRS
+      "${FFMPEG_${_ffmpeg_component}_INCLUDE_DIR}")
+    set(FFMPEG_${_ffmpeg_component}_LIBRARIES
+      "${FFMPEG_${_ffmpeg_component}_LIBRARY}")
+    list(APPEND FFMPEG_INCLUDE_DIRS
+      "${FFMPEG_${_ffmpeg_component}_INCLUDE_DIRS}")
+    list(APPEND FFMPEG_LIBRARIES
+      "${FFMPEG_${_ffmpeg_component}_LIBRARIES}")
+    if (FFMEG_FIND_REQUIRED_${_ffmpeg_component})
+      list(APPEND _ffmpeg_required_vars
+        "FFMPEG_${_ffmpeg_required_vars}_INCLUDE_DIRS"
+        "FFMPEG_${_ffmpeg_required_vars}_LIBRARIES")
+    endif ()
+  endif ()
+endforeach ()
+unset(_ffmpeg_component)
+
+if (FFMPEG_INCLUDE_DIRS)
+  list(REMOVE_DUPLICATES FFMPEG_INCLUDE_DIRS)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFMPEG
+  REQUIRED_VARS FFMPEG_INCLUDE_DIRS FFMPEG_LIBRARIES ${_ffmpeg_required_vars}
+  VERSION_VAR FFMPEG_VERSION
+  HANDLE_COMPONENTS)
+unset(_ffmpeg_required_vars)

--- a/cmake/FindOpenColorIO.cmake
+++ b/cmake/FindOpenColorIO.cmake
@@ -1,0 +1,94 @@
+# - Find OpenColorIO library
+# Find the native OpenColorIO includes and library
+# This module defines
+#  OPENCOLORIO_INCLUDE_DIRS, where to find OpenColorIO.h, Set when
+#                            OPENCOLORIO_INCLUDE_DIR is found.
+#  OPENCOLORIO_LIBRARIES, libraries to link against to use OpenColorIO.
+#  OPENCOLORIO_ROOT_DIR, The base directory to search for OpenColorIO.
+#                        This can also be an environment variable.
+#  OPENCOLORIO_FOUND, If false, do not try to use OpenColorIO.
+#
+# also defined, but not for general use are
+#  OPENCOLORIO_LIBRARY, where to find the OpenColorIO library.
+
+#=============================================================================
+# Copyright 2012 Blender Foundation.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+
+# If OPENCOLORIO_ROOT_DIR was defined in the environment, use it.
+IF(NOT OPENCOLORIO_ROOT_DIR AND NOT $ENV{OPENCOLORIO_ROOT_DIR} STREQUAL "")
+  SET(OPENCOLORIO_ROOT_DIR $ENV{OPENCOLORIO_ROOT_DIR})
+ENDIF()
+
+SET(_opencolorio_FIND_COMPONENTS
+  OpenColorIO
+  yaml-cpp
+  tinyxml
+)
+
+SET(_opencolorio_SEARCH_DIRS
+  ${OPENCOLORIO_ROOT_DIR}
+  /usr/local
+  /sw # Fink
+  /opt/local # DarwinPorts
+  /opt/lib/ocio
+)
+
+FIND_PATH(OPENCOLORIO_INCLUDE_DIR
+  NAMES
+    OpenColorIO/OpenColorIO.h
+  HINTS
+    ${_opencolorio_SEARCH_DIRS}
+  PATH_SUFFIXES
+    include
+)
+
+SET(_opencolorio_LIBRARIES)
+FOREACH(COMPONENT ${_opencolorio_FIND_COMPONENTS})
+  STRING(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+
+  FIND_LIBRARY(OPENCOLORIO_${UPPERCOMPONENT}_LIBRARY
+    NAMES
+      ${COMPONENT}
+    HINTS
+      ${_opencolorio_SEARCH_DIRS}
+    PATH_SUFFIXES
+      lib64 lib lib64/static lib/static
+    )
+  IF(OPENCOLORIO_${UPPERCOMPONENT}_LIBRARY)
+    LIST(APPEND _opencolorio_LIBRARIES "${OPENCOLORIO_${UPPERCOMPONENT}_LIBRARY}")
+  ENDIF()
+ENDFOREACH()
+
+
+# handle the QUIETLY and REQUIRED arguments and set OPENCOLORIO_FOUND to TRUE if
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(OpenColorIO DEFAULT_MSG
+    _opencolorio_LIBRARIES OPENCOLORIO_INCLUDE_DIR)
+
+IF(OPENCOLORIO_FOUND)
+  SET(OPENCOLORIO_LIBRARIES ${_opencolorio_LIBRARIES})
+  SET(OPENCOLORIO_INCLUDE_DIRS ${OPENCOLORIO_INCLUDE_DIR})
+ENDIF(OPENCOLORIO_FOUND)
+
+MARK_AS_ADVANCED(
+  OPENCOLORIO_INCLUDE_DIR
+  OPENCOLORIO_LIBRARY
+  OPENCOLORIO_OPENCOLORIO_LIBRARY
+  OPENCOLORIO_TINYXML_LIBRARY
+  OPENCOLORIO_YAML-CPP_LIBRARY
+)
+
+UNSET(COMPONENT)
+UNSET(UPPERCOMPONENT)
+UNSET(_opencolorio_FIND_COMPONENTS)
+UNSET(_opencolorio_LIBRARIES)
+UNSET(_opencolorio_SEARCH_DIRS)

--- a/cmake/Findfrei0r.cmake
+++ b/cmake/Findfrei0r.cmake
@@ -1,0 +1,42 @@
+
+# CMake module to search for frei0r
+# Author: Rohit Yadav <rohityadav89@gmail.com>
+#
+# If it's found it sets FREI0R_FOUND to TRUE
+# and following variables are set:
+#    FREI0R_INCLUDE_DIR
+
+# Put here path to custom location
+# example: /home/username/frei0r/include etc..
+find_path(FREI0R_INCLUDE_DIR NAMES frei0r.h
+  PATHS
+    "$ENV{LIB_DIR}/include"
+    "/usr/include"
+    "/usr/include/frei0r"
+    "/usr/local/include"
+    "/usr/local/include/frei0r"
+    # Mac OS
+    "${CMAKE_CURRENT_SOURCE_DIR}/contribs/include"
+    # MingW
+    c:/msys/local/include
+)
+
+find_path(FREI0R_INCLUDE_DIR PATHS "${CMAKE_INCLUDE_PATH}" NAMES frei0r.h)
+
+# TODO: If required, add code to link to some library
+
+if(FREI0R_INCLUDE_DIR)
+  set(FREI0R_FOUND TRUE)
+endif()
+
+if(FREI0R_FOUND)
+  if(NOT FREI0R_FIND_QUIETLY)
+    message(STATUS "Found frei0r include-dir path: ${FREI0R_INCLUDE_DIR}")
+  endif()
+else()
+  if(FREI0R_FIND_REQUIRED)
+    message(FATAL_ERROR "Could not find frei0r")
+  elseif(NOT FREI0R_FIND_QUIETLY)
+    message(STATUS "Could not find frei0r")
+  endif()
+endif()


### PR DESCRIPTION
advantages:
* easy to add new dependencies(+checking)
* fast with ninja back-end (`cmake -G Ninja`): https://ninja-build.org
* a lot of tools support it much better than qmake
* Qt 6 will be using cmake: https://lists.qt-project.org/pipermail/development/2018-October/034023.html
* clang-tidy integration: https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_CLANG_TIDY.html