### PR TITLE
Add Indonesian translation

### DIFF
--- a/olive.pro
+++ b/olive.pro
@@ -316,7 +316,8 @@ TRANSLATIONS += \
     ts/olive_ru.ts \
     ts/olive_uk.ts \
     ts/olive_bs.ts \
-    ts/olive_sr.ts
+    ts/olive_sr.ts \
+    ts/olive_id.ts
 
 win32 {
     RC_FILE = packaging/windows/resources.rc

--- a/ts/olive_id.ts
+++ b/ts/olive_id.ts
@@ -1,0 +1,3625 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id_ID">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../dialogs/aboutdialog.cpp" line="49"/>
+        <source>Olive is a non-linear video editor. This software is free and protected by the GNU GPL.</source>
+        <translation>Olive adalah aplikasi pengedit video yang bersifat non-linier. Aplikasi ini bebas, gratis, dan terlindungi GNU GPL.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/aboutdialog.cpp" line="51"/>
+        <source>Olive Team is obliged to inform users that Olive source code is available for download from its website.</source>
+        <translation>Olive Team berkewajiban memberitahu pengguna bahwa kode sumber aplikasi ini dapat diunduh dari situs resminya.</translation>
+    </message>
+</context>
+<context>
+    <name>ActionSearch</name>
+    <message>
+        <location filename="../dialogs/actionsearch.cpp" line="57"/>
+        <source>Search for action...</source>
+        <translation>Cari Aksi...</translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedVideoDialog</name>
+    <message>
+        <location filename="../dialogs/advancedvideodialog.cpp" line="41"/>
+        <source>Advanced Video Settings</source>
+        <translation>Pengaturan Video Lanjutan</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/advancedvideodialog.cpp" line="53"/>
+        <source>Pixel Format:</source>
+        <translation>Bentuk piksel:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/advancedvideodialog.cpp" line="77"/>
+        <source>Threads:</source>
+        <translation>Jumlah thread/utas:</translation>
+    </message>
+</context>
+<context>
+    <name>Audio</name>
+    <message>
+        <location filename="../rendering/audio.cpp" line="333"/>
+        <source>%1 Audio</source>
+        <translation>Audio %1</translation>
+    </message>
+    <message>
+        <location filename="../rendering/audio.cpp" line="346"/>
+        <source>Recording %1</source>
+        <translation>Merekam %1</translation>
+    </message>
+</context>
+<context>
+    <name>AudioNoiseEffect</name>
+    <message>
+        <location filename="../effects/internal/audionoiseeffect.cpp" line="24"/>
+        <source>Amount</source>
+        <translation>Kenyaringan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/audionoiseeffect.cpp" line="30"/>
+        <source>Mix</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>Cacher</name>
+    <message>
+        <location filename="../rendering/cacher.cpp" line="921"/>
+        <location filename="../rendering/cacher.cpp" line="930"/>
+        <source>Could not open %1 - %2</source>
+        <translation>Tidak dapat membuka %1 - %2</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelLayoutName</name>
+    <message>
+        <location filename="../project/media.cpp" line="53"/>
+        <source>Invalid</source>
+        <translation>Salah</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="54"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="55"/>
+        <source>Stereo</source>
+        <translation>Stereo</translation>
+    </message>
+</context>
+<context>
+    <name>ClipPropertiesDialog</name>
+    <message>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="14"/>
+        <source>&quot;%1&quot; Properties</source>
+        <translation>Properti untuk &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="15"/>
+        <source>Multiple Clip Properties</source>
+        <translation>Properti untuk Beberapa Klip</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="24"/>
+        <source>Name:</source>
+        <translation>Nama:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="33"/>
+        <source>Duration:</source>
+        <translation>Durasi:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="71"/>
+        <source>(multiple)</source>
+        <translation>(beberapa)</translation>
+    </message>
+</context>
+<context>
+    <name>CollapsibleWidget</name>
+    <message>
+        <location filename="../ui/collapsiblewidget.cpp" line="54"/>
+        <source>&lt;untitled&gt;</source>
+        <translation>&lt;belum dinamai&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>ColorButton</name>
+    <message>
+        <location filename="../ui/colorbutton.cpp" line="47"/>
+        <source>Set Color</source>
+        <translation>Pilih Warna</translation>
+    </message>
+</context>
+<context>
+    <name>CornerPinEffect</name>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="30"/>
+        <source>Top Left</source>
+        <translation>Kiri Atas</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="34"/>
+        <source>Top Right</source>
+        <translation>Kanan Atas</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="38"/>
+        <source>Bottom Left</source>
+        <translation>Kiri Bawah</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="42"/>
+        <source>Bottom Right</source>
+        <translation>Kanan Bawah</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="46"/>
+        <source>Perspective</source>
+        <translation>Perspektif</translation>
+    </message>
+</context>
+<context>
+    <name>DebugDialog</name>
+    <message>
+        <location filename="../dialogs/debugdialog.cpp" line="44"/>
+        <source>Debug Log</source>
+        <translation>Awakutu / Debug</translation>
+    </message>
+</context>
+<context>
+    <name>DemoNotice</name>
+    <message>
+        <location filename="../dialogs/demonotice.cpp" line="30"/>
+        <location filename="../dialogs/demonotice.cpp" line="45"/>
+        <source>Welcome to Olive!</source>
+        <translation>Selamat datang di Olive!</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/demonotice.cpp" line="47"/>
+        <source>Olive is a free open-source video editor released under the GNU GPL. If you have paid for this software, you have been scammed.</source>
+        <translatorcomment>differentiate &quot;free&quot; as in &quot;free of charge&quot; and &quot;free&quot; as in &quot;freedom/libre&quot;</translatorcomment>
+        <translation>Olive adalah aplikasi edit video yang bebas, gratis dan terbuka sumbernya, terlisensi GNU GPL. Jika Anda membayar untuk aplikasi ini, Anda telah tertipu.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/demonotice.cpp" line="49"/>
+        <source>This software is currently in ALPHA which means it is unstable and very likely to crash, have bugs, and have missing features. We offer no warranty so use at your own risk. Please report any bugs or feature requests at %1</source>
+        <translation>Aplikasi ini masih dalam tahap ALPHA, artinya aplikasi ini belum stabil dan kemungkinan besar akan crash, memiliki bug/kutu, dan banyak fitur yang belum ada. Kami tidak menjamin apapun, jadi Anda dipersilahkan menggunakan aplikasi ini dengan menanggung resikonya. Jika menemukan bug/kutu atau ingin meminta suatu fitur, silahkan lapor di %1</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/demonotice.cpp" line="51"/>
+        <source>Thank you for trying Olive and we hope you enjoy it!</source>
+        <translation>Terima kasih Anda telah mencoba Olive dan kami harap Anda menyukainya!</translation>
+    </message>
+</context>
+<context>
+    <name>Effect</name>
+    <message>
+        <location filename="../effects/effect.cpp" line="100"/>
+        <source>Invalid effect</source>
+        <translation>Efek tidak ada</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="101"/>
+        <source>No candidate for effect &apos;%1&apos;. This effect may be corrupt. Try reinstalling it or Olive.</source>
+        <translation>Tidak ada kandidat untuk efek &apos;%1&apos;. Efek mungkin korup. Coba menginstal ulang efek tersebut, atau menginstal ulang Olive.</translation>
+    </message>
+    <message>
+        <source>Cu&amp;t</source>
+        <translation type="vanished">&amp;Potong</translation>
+    </message>
+    <message>
+        <source>Move &amp;Up</source>
+        <translation type="vanished">Pindah ke &amp;Atas</translation>
+    </message>
+    <message>
+        <source>Move &amp;Down</source>
+        <translation type="vanished">Pindah ke &amp;Bawah</translation>
+    </message>
+    <message>
+        <source>D&amp;elete</source>
+        <translation type="vanished">&amp;Hapus</translation>
+    </message>
+    <message>
+        <source>Load Settings From File</source>
+        <translation type="vanished">Buka Pengaturan Efek dari File</translation>
+    </message>
+    <message>
+        <source>Save Settings to File</source>
+        <translation type="vanished">Simpan Pengaturan ke File</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="448"/>
+        <source>Save Effect Settings</source>
+        <translation>Simpan Pengaturan Efek</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="450"/>
+        <location filename="../effects/effect.cpp" line="480"/>
+        <source>Effect XML Settings %1</source>
+        <translation>Pengaturan XML Efek %1</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="468"/>
+        <source>Save Settings Failed</source>
+        <translation>Gagal Menyimpan Pengaturan</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="469"/>
+        <source>Failed to open &quot;%1&quot; for writing.</source>
+        <translation>Gagal menulis file &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="478"/>
+        <source>Load Effect Settings</source>
+        <translation>Buka Pengaturan Efek</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="494"/>
+        <location filename="../effects/effect.cpp" line="682"/>
+        <source>Load Settings Failed</source>
+        <translation>Gagal Membuka Pengaturan</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="495"/>
+        <source>Failed to open &quot;%1&quot; for reading.</source>
+        <translatorcomment>considering changing &quot;file&quot; to the defined equivalent &quot;berkas&quot;, but it might not be familiar to most people</translatorcomment>
+        <translation>Gagal membaca file &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../effects/effect.cpp" line="683"/>
+        <source>This settings file doesn&apos;t match this effect.</source>
+        <translation>File pengaturan ini tidak cocok dengan efek yang dipilih.</translation>
+    </message>
+</context>
+<context>
+    <name>EffectControls</name>
+    <message>
+        <source>&amp;Paste</source>
+        <translation type="vanished">&amp;Tempel</translation>
+    </message>
+    <message>
+        <location filename="../panels/effectcontrols.cpp" line="325"/>
+        <source>(none)</source>
+        <translation>(tidak ada)</translation>
+    </message>
+    <message>
+        <location filename="../panels/effectcontrols.cpp" line="507"/>
+        <source>Effects: </source>
+        <translation>Efek: </translation>
+    </message>
+    <message>
+        <location filename="../panels/effectcontrols.cpp" line="509"/>
+        <source>Add Video Effect</source>
+        <translation>Masukkan Efek Video</translation>
+    </message>
+    <message>
+        <location filename="../panels/effectcontrols.cpp" line="510"/>
+        <source>VIDEO EFFECTS</source>
+        <translation>EFEK VIDEO</translation>
+    </message>
+    <message>
+        <location filename="../panels/effectcontrols.cpp" line="511"/>
+        <source>Add Video Transition</source>
+        <translation>Masukkan Transisi Video</translation>
+    </message>
+    <message>
+        <location filename="../panels/effectcontrols.cpp" line="512"/>
+        <source>Add Audio Effect</source>
+        <translation>Masukkan Efek Audio</translation>
+    </message>
+    <message>
+        <location filename="../panels/effectcontrols.cpp" line="513"/>
+        <source>AUDIO EFFECTS</source>
+        <translation>EFEK AUDIO</translation>
+    </message>
+    <message>
+        <location filename="../panels/effectcontrols.cpp" line="514"/>
+        <source>Add Audio Transition</source>
+        <translation>Masukkan Transisi Audio</translation>
+    </message>
+    <message>
+        <source>(Multiple clips selected)</source>
+        <translation type="vanished">(Beberapa klip terseleksi)</translation>
+    </message>
+</context>
+<context>
+    <name>EffectRow</name>
+    <message>
+        <location filename="../effects/effectrow.cpp" line="109"/>
+        <source>Disable Keyframes</source>
+        <translation>Matikan Keyframe</translation>
+    </message>
+    <message>
+        <location filename="../effects/effectrow.cpp" line="110"/>
+        <source>Disabling keyframes will delete all current keyframes. Are you sure you want to do this?</source>
+        <translation>Mematikan keyframe akan menghapus semua keyframe di efek ini. Benarkah Anda ingin melakukan hal tersebut?</translation>
+    </message>
+</context>
+<context>
+    <name>EffectUI</name>
+    <message>
+        <location filename="../ui/effectui.cpp" line="54"/>
+        <source>%1 (Opening)</source>
+        <translation>%1 (Membuka)</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="56"/>
+        <source>%1 (Closing)</source>
+        <translation>%1 (Menutup)</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="157"/>
+        <source>%1 (multiple)</source>
+        <translation>%1 (beberapa)</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="285"/>
+        <source>Cu&amp;t</source>
+        <translation>&amp;Potong</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="288"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Salin</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="299"/>
+        <source>Move &amp;Up</source>
+        <translation>Pindah ke &amp;Atas</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="303"/>
+        <source>Move &amp;Down</source>
+        <translation>Pindah ke &amp;Bawah</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="308"/>
+        <source>D&amp;elete</source>
+        <translation>&amp;Hapus</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="325"/>
+        <source>Load Settings From File</source>
+        <translation>Buka Pengaturan Efek dari File</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="327"/>
+        <source>Save Settings to File</source>
+        <translation>Simpan Pengaturan ke File</translation>
+    </message>
+</context>
+<context>
+    <name>EmbeddedFileChooser</name>
+    <message>
+        <location filename="../ui/embeddedfilechooser.cpp" line="52"/>
+        <source>File:</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>ExportDialog</name>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="74"/>
+        <source>Export &quot;%1&quot;</source>
+        <translation>Ekspor &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="127"/>
+        <source>Unknown codec name %1</source>
+        <translation>Kodek %1 tidak diketahui</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="341"/>
+        <source>Export Failed</source>
+        <translation>Gagal Mengekspor</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="342"/>
+        <source>Export failed - %1</source>
+        <translation>Gagal mengekspor - %1</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="384"/>
+        <source>Invalid dimensions</source>
+        <translation>Dimensi salah</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="385"/>
+        <source>Export width and height must both be even numbers/divisible by 2.</source>
+        <translation>Lebar dan tinggi video ekspor harus genap/habis dibagi 2.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="441"/>
+        <source>Invalid codec</source>
+        <translation>Kodek salah</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="442"/>
+        <source>Couldn&apos;t determine output parameters for the selected codec. This is a bug, please contact the developers.</source>
+        <translation>Tidak dapat menset pengaturan keluaran/output. Ini merupakan kesalahan, silahkan hubungi pengembang aplikasi.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="511"/>
+        <source>Invalid format</source>
+        <translation>Format salah</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="512"/>
+        <source>Couldn&apos;t determine output format. This is a bug, please contact the developers.</source>
+        <translation>Tidak dapat memilih format keluaran/output. Ini merupakan kutu/bug, silahkan hubungi pengembang aplikasi.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="519"/>
+        <source>Export Media</source>
+        <translation>Ekspor Media</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="600"/>
+        <source>%p% (Total: %1:%2:%3)</source>
+        <translation>%p% (lama: %1:%2:%3)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="605"/>
+        <source>%p% (ETA: %1:%2:%3)</source>
+        <translation>%p% (perkiraan: %1:%2:%3)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="620"/>
+        <source>Quality-based (Constant Rate Factor)</source>
+        <translation>Berbasis kualitas (CRF)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="624"/>
+        <source>Constant Bitrate</source>
+        <translation>Laju bit konstan (CBR)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="633"/>
+        <location filename="../dialogs/exportdialog.cpp" line="639"/>
+        <source>Invalid Codec</source>
+        <translation>Kodek Salah</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="634"/>
+        <source>Failed to find a suitable encoder for this codec. Export will likely fail.</source>
+        <translation>Tidak dapat mencari enkoder yang cocok untuk kodek ini. Ekspor kemungkinan gagal.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="640"/>
+        <source>Failed to find pixel format for this encoder. Export will likely fail.</source>
+        <translation>Tidak dapat menentukan format piksel untuk enkoder ini. Ekspor kemungkinan gagal.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="653"/>
+        <source>Bitrate (Mbps):</source>
+        <translation>Laju bit (Mbps):</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="657"/>
+        <source>Quality (CRF):</source>
+        <translation>Kualitas (CRF):</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="660"/>
+        <source>Quality Factor:
+
+0 = lossless
+17-18 = visually lossless (compressed, but unnoticeable)
+23 = high quality
+51 = lowest quality possible</source>
+        <translation>Faktor kualitas:
+
+0 = lossless / tidak terkompresi
+17-18 = lossless secara visual (masih terkompresi namun tidak terlihat pecah-pecah)
+23 = kualitas tinggi
+51 = kualitas paling rendah</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="663"/>
+        <source>Target File Size (MB):</source>
+        <translation>Ukuran File yang Ditargetkan (MB):</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="679"/>
+        <source>Format:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="688"/>
+        <source>Range:</source>
+        <translation>Sepanjang:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="691"/>
+        <source>Entire Sequence</source>
+        <translation>Seluruh rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="692"/>
+        <source>In to Out</source>
+        <translation>Masuk hingga Keluar</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="699"/>
+        <source>Video</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="705"/>
+        <location filename="../dialogs/exportdialog.cpp" line="748"/>
+        <source>Codec:</source>
+        <translation>Kodek:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="709"/>
+        <source>Width:</source>
+        <translation>Lebar:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="714"/>
+        <source>Height:</source>
+        <translation>Tinggi:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="719"/>
+        <source>Frame Rate:</source>
+        <translation>Laju frame (fps):</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="725"/>
+        <source>Compression Type:</source>
+        <translation>Jenis Kompresi:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="736"/>
+        <source>Advanced</source>
+        <translation>Pengaturan Lanjut</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="743"/>
+        <source>Audio</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="752"/>
+        <source>Sampling Rate:</source>
+        <translation>Laju sampel:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="758"/>
+        <source>Bitrate (Kbps/CBR):</source>
+        <translation>Laju bit (Kbps/CBR):</translation>
+    </message>
+</context>
+<context>
+    <name>ExportThread</name>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="78"/>
+        <source>failed to send frame to encoder (%1)</source>
+        <translation>gagal mengirim frame ke enkoder (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="89"/>
+        <source>failed to receive packet from encoder (%1)</source>
+        <translation>gagal menerima paket dari enkoder (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="110"/>
+        <source>could not video encoder for %1</source>
+        <translation>tidak dapat mencari enkoder video untuk %1</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="119"/>
+        <source>could not allocate video stream</source>
+        <translation>tidak dapat mengalokasikan stream video</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="128"/>
+        <source>could not allocate video encoding context</source>
+        <translation>tidak dapat mengalokasikan konteks mengenkode video</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="177"/>
+        <source>could not open output video encoder (%1)</source>
+        <translation>tidak dapat membuka enkoder video keluaran (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="185"/>
+        <source>could not copy video encoder parameters to output stream (%1)</source>
+        <translation>tidak dapat menyalin parameter enkoder video ke stream keluaran (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="222"/>
+        <source>could not audio encoder for %1</source>
+        <translation>tidak dapat mencari enkoder audio untuk %1</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="230"/>
+        <source>could not allocate audio stream</source>
+        <translation>tidak dapat mengalokasikan stream audio</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="244"/>
+        <source>could not allocate audio encoding context</source>
+        <translation>tidak dapat mengalokasikan konteks mengenkode audio</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="269"/>
+        <source>could not open output audio encoder (%1)</source>
+        <translation>tidak dapat membuka enkoder audio keluaran (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="277"/>
+        <source>could not copy audio encoder parameters to output stream (%1)</source>
+        <translation>tidak dapat menyalin parameter enkoder audio ke stream keluaran (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="314"/>
+        <source>could not allocate audio buffer (%1)</source>
+        <translation>tidak dapat mengalokasikan buffer audio (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="345"/>
+        <source>could not create output format context</source>
+        <translation>tidak dapat membuat konteks format keluaran</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="355"/>
+        <source>could not open output file (%1)</source>
+        <translation>tidak dapat membuka file keluaran (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="391"/>
+        <source>could not write output file header (%1)</source>
+        <translation>tidak dapat menulis header untuk file keluaran (%1)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/exportthread.cpp" line="592"/>
+        <source>could not write output file trailer (%1)</source>
+        <translation>tidak dapat menulis trailer untuk file keluaran (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>FillLeftRightEffect</name>
+    <message>
+        <location filename="../effects/internal/fillleftrighteffect.cpp" line="27"/>
+        <source>Type</source>
+        <translation>Tipe</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/fillleftrighteffect.cpp" line="29"/>
+        <source>Fill Left with Right</source>
+        <translation>Penuhi Suara Kiri dengan Kanan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/fillleftrighteffect.cpp" line="30"/>
+        <source>Fill Right with Left</source>
+        <translation>Penuhi Suara Kanan dengan Kiri</translation>
+    </message>
+</context>
+<context>
+    <name>Frei0rEffect</name>
+    <message>
+        <location filename="../effects/internal/frei0reffect.cpp" line="55"/>
+        <source>Failed to load Frei0r plugin &quot;%1&quot;: %2</source>
+        <translation>Gagal membuka plugin Frei0r &quot;%1&quot;: %2</translation>
+    </message>
+    <message>
+        <source>NOTE: You can&apos;t load 32-bit Frei0r plugins into a 64-bit build of Olive. Please find a 64-bit version of this plugin or switch to a 32-bit build of Olive.</source>
+        <translation type="vanished">CATATAN: Plugin Frei0r 32-bit tidak dapat dibuka dalam Olive versi 64-bit. Silahkan mencari versi 64-bit dari plugin ini atau instal Olive versi 32-bit.</translation>
+    </message>
+    <message>
+        <source>NOTE: You can&apos;t load 64-bit Frei0r plugins into a 32-bit build of Olive. Please find a 32-bit version of this plugin or switch to a 64-bit build of Olive.</source>
+        <translation type="vanished">CATATAN: Plugin Frei0r 64-bit tidak dapat dibuka dalam Olive versi 32-bit. Silahkan mencari versi 32-bit dari plugin ini atau instal Olive versi 64-bit.</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/frei0reffect.cpp" line="54"/>
+        <source>Error loading Frei0r plugin</source>
+        <translation>Gagal membuka plugin Frei0r</translation>
+    </message>
+</context>
+<context>
+    <name>GraphEditor</name>
+    <message>
+        <location filename="../panels/grapheditor.cpp" line="140"/>
+        <source>Graph Editor</source>
+        <translation>Pengedit Grafik</translation>
+    </message>
+    <message>
+        <location filename="../panels/grapheditor.cpp" line="141"/>
+        <source>Linear</source>
+        <translation>Linier</translation>
+    </message>
+    <message>
+        <location filename="../panels/grapheditor.cpp" line="142"/>
+        <source>Bezier</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../panels/grapheditor.cpp" line="143"/>
+        <source>Hold</source>
+        <translation>Tahan</translation>
+    </message>
+</context>
+<context>
+    <name>GraphView</name>
+    <message>
+        <location filename="../ui/graphview.cpp" line="80"/>
+        <source>Zoom to Selection</source>
+        <translation>Perbesar ke Seleksi</translation>
+    </message>
+    <message>
+        <location filename="../ui/graphview.cpp" line="87"/>
+        <source>Zoom to Show All</source>
+        <translation>Perlihatkan Semua</translation>
+    </message>
+    <message>
+        <location filename="../ui/graphview.cpp" line="96"/>
+        <source>Reset View</source>
+        <translation>Kembalikan Seperti Semula</translation>
+    </message>
+</context>
+<context>
+    <name>InterlacingName</name>
+    <message>
+        <location filename="../project/media.cpp" line="44"/>
+        <source>None (Progressive)</source>
+        <translation>Tidak ada (Progresif)</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="45"/>
+        <source>Top Field First</source>
+        <translation>Utamakan Bidang Atas</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="46"/>
+        <source>Bottom Field First</source>
+        <translation>Utamakan Bidang Bawah</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="47"/>
+        <source>Invalid</source>
+        <translation>Salah</translation>
+    </message>
+</context>
+<context>
+    <name>KeyframeNavigator</name>
+    <message>
+        <location filename="../ui/keyframenavigator.cpp" line="71"/>
+        <source>Enable Keyframes</source>
+        <translation>Nyalakan Keyframe</translation>
+    </message>
+</context>
+<context>
+    <name>KeyframeView</name>
+    <message>
+        <location filename="../ui/keyframeview.cpp" line="74"/>
+        <source>Linear</source>
+        <translation>Linier</translation>
+    </message>
+    <message>
+        <location filename="../ui/keyframeview.cpp" line="76"/>
+        <source>Bezier</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/keyframeview.cpp" line="78"/>
+        <source>Hold</source>
+        <translation>Tahan</translation>
+    </message>
+</context>
+<context>
+    <name>LabelSlider</name>
+    <message>
+        <location filename="../ui/labelslider.cpp" line="271"/>
+        <source>&amp;Edit</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/labelslider.cpp" line="275"/>
+        <source>&amp;Reset to Default</source>
+        <translation>&amp;Kembalikan seperti Semula</translation>
+    </message>
+    <message>
+        <location filename="../ui/labelslider.cpp" line="306"/>
+        <location filename="../ui/labelslider.cpp" line="345"/>
+        <source>Set Value</source>
+        <translation>Ubah Jumlah</translation>
+    </message>
+    <message>
+        <location filename="../ui/labelslider.cpp" line="307"/>
+        <location filename="../ui/labelslider.cpp" line="346"/>
+        <source>New value:</source>
+        <translatorcomment>&quot;value&quot; actually would be &quot;harga&quot; or &quot;nilai&quot; but it probably won&apos;t fit</translatorcomment>
+        <translation>Jumlah:</translation>
+    </message>
+</context>
+<context>
+    <name>LoadDialog</name>
+    <message>
+        <location filename="../dialogs/loaddialog.cpp" line="37"/>
+        <source>Loading...</source>
+        <translation>Memuat...</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/loaddialog.cpp" line="42"/>
+        <source>Loading &apos;%1&apos;...</source>
+        <translation>Memuat &apos;%1&apos;...</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/loaddialog.cpp" line="48"/>
+        <source>Cancel</source>
+        <translation>Batalkan</translation>
+    </message>
+</context>
+<context>
+    <name>LoadThread</name>
+    <message>
+        <location filename="../project/loadthread.cpp" line="246"/>
+        <source>Version Mismatch</source>
+        <translation>Versi tak Cocok</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="247"/>
+        <source>This project was saved in a different version of Olive and may not be fully compatible with this version. Would you like to attempt loading it anyway?</source>
+        <translation>Proyek ini disimpan menggunakan versi Olive yang lain dan kemungkinan tidak sepenuhnya kompatibel dengan versi ini. Tetap dibuka?</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="570"/>
+        <source>Invalid Clip Link</source>
+        <translation>Tautan Klip Salah</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="571"/>
+        <source>This project contains an invalid clip link. It may be corrupt. Would you like to continue loading it?</source>
+        <translation>Proyek ini terdapat tautan klip yang salah, kemungkinan korup. Tetap memuat?</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="694"/>
+        <source>%1 - Line: %2 Col: %3</source>
+        <translation>%1 - Baris: %2 Kolom: %3</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="721"/>
+        <source>User aborted loading</source>
+        <translation>Pengguna membatalkan pemuatan proyek</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="752"/>
+        <source>XML Parsing Error</source>
+        <translation>Gagal Membaca XML</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="753"/>
+        <source>Couldn&apos;t load &apos;%1&apos;. %2</source>
+        <translation>Tidak dapat membaca &apos;%1&apos;. %2</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="757"/>
+        <source>Project Load Error</source>
+        <translation>Gagal Memuat Proyek</translation>
+    </message>
+    <message>
+        <location filename="../project/loadthread.cpp" line="758"/>
+        <source>Error loading project: %1</source>
+        <translation>Gagal memuat proyek: %1</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="277"/>
+        <source>Welcome to %1</source>
+        <translation>Selamat datang di %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="865"/>
+        <source>&amp;File</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="866"/>
+        <source>&amp;New</source>
+        <translation>&amp;Baru</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="867"/>
+        <source>&amp;Open Project</source>
+        <translation type="unfinished">Buka &amp;Proyek</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="868"/>
+        <source>Clear Recent List</source>
+        <translation>Hapus Daftar &quot;Terakhir Dibuka&quot;</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="869"/>
+        <source>Open Recent</source>
+        <translation>Buka Terakhir</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="870"/>
+        <source>&amp;Save Project</source>
+        <translation>&amp;Simpan Proyek</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="871"/>
+        <source>Save Project &amp;As</source>
+        <translation type="unfinished">Simpan Proyek Seba&amp;gai</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="872"/>
+        <source>&amp;Import...</source>
+        <translation>&amp;Impor...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="873"/>
+        <source>&amp;Export...</source>
+        <translation>&amp;Ekspor...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="874"/>
+        <source>E&amp;xit</source>
+        <translation>&amp;Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="876"/>
+        <source>&amp;Edit</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="877"/>
+        <source>&amp;Undo</source>
+        <translation>&amp;Urung</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="878"/>
+        <source>Redo</source>
+        <translation>Ulangi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="879"/>
+        <source>Select &amp;All</source>
+        <translation>Seleksi &amp;Semua</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="880"/>
+        <source>Deselect All</source>
+        <translation>Batalkan Semua Pilihan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="881"/>
+        <source>Ripple to In Point</source>
+        <translation>Atur hingga Titik Masuk</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="882"/>
+        <source>Ripple to Out Point</source>
+        <translation>Atur hingga Titik Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="883"/>
+        <source>Edit to In Point</source>
+        <translation>Edit ke Titik Masuk</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="884"/>
+        <source>Edit to Out Point</source>
+        <translation>Edit ke Titik Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="885"/>
+        <source>Delete In/Out Point</source>
+        <translation>Hapus Titik Masuk/Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="886"/>
+        <source>Ripple Delete In/Out Point</source>
+        <translation>Hapus dan Sesuaikan Titik Masuk/Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="887"/>
+        <source>Set/Edit Marker</source>
+        <translation>Set/Edit Penanda</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="889"/>
+        <source>&amp;View</source>
+        <translation>&amp;Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="890"/>
+        <source>Zoom In</source>
+        <translation>Perbesar Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="891"/>
+        <source>Zoom Out</source>
+        <translation>Perkecil Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="892"/>
+        <source>Increase Track Height</source>
+        <translation>Lebarkan Trek</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="893"/>
+        <source>Decrease Track Height</source>
+        <translation>Persempit Trek</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="894"/>
+        <source>Toggle Show All</source>
+        <translatorcomment>&quot;show all&quot;</translatorcomment>
+        <translation>Perlihatkan Semua</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="895"/>
+        <source>Track Lines</source>
+        <translation>Garis Trek</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="896"/>
+        <source>Rectified Waveforms</source>
+        <translatorcomment>&quot;flatten&quot; or &quot;center at bottom&quot;</translatorcomment>
+        <translation>Visualisasi Audio Rata Bawah</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="897"/>
+        <source>Frames</source>
+        <translation>Frame</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="898"/>
+        <source>Drop Frame</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="899"/>
+        <source>Non-Drop Frame</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="900"/>
+        <source>Milliseconds</source>
+        <translation>Milisekon</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="902"/>
+        <source>Title/Action Safe Area</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="903"/>
+        <source>Off</source>
+        <translation>Matikan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="904"/>
+        <source>Default</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="905"/>
+        <source>4:3</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="906"/>
+        <source>16:9</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="907"/>
+        <source>Custom</source>
+        <translation>Kustom</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="909"/>
+        <source>Full Screen</source>
+        <translation>Layar Penuh</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="910"/>
+        <source>Full Screen Viewer</source>
+        <translation>Penampil Layar Penuh</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="912"/>
+        <source>&amp;Playback</source>
+        <translation>&amp;Pemutaran</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="913"/>
+        <source>Go to Start</source>
+        <translation>Lompat ke Awal</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="914"/>
+        <source>Previous Frame</source>
+        <translation>Frame sebelumnya</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="915"/>
+        <source>Play/Pause</source>
+        <translation>Mainkan/Berhenti</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="916"/>
+        <source>Play In to Out</source>
+        <translation>Mainkan dari Titik Masuk hingga Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="917"/>
+        <source>Next Frame</source>
+        <translation>Frame berikutnya</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="918"/>
+        <source>Go to End</source>
+        <translation>Lompat ke Akhir</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="920"/>
+        <source>Go to Previous Cut</source>
+        <translation>Lompat ke Cut Sebelumnya</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="921"/>
+        <source>Go to Next Cut</source>
+        <translation>Lompat ke Cut Berikutnya</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="922"/>
+        <source>Go to In Point</source>
+        <translation>Lompat ke Titik Masuk</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="923"/>
+        <source>Go to Out Point</source>
+        <translation>Lompat ke Titik Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="925"/>
+        <source>Shuttle Left</source>
+        <translation>Jalankan ke Kiri</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="926"/>
+        <source>Shuttle Stop</source>
+        <translation>Hentikan jalan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="927"/>
+        <source>Shuttle Right</source>
+        <translation>Jalankan ke Kanan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="929"/>
+        <source>Loop</source>
+        <translation>Putar secara Berulang</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="931"/>
+        <source>&amp;Window</source>
+        <translation>&amp;Jendela</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="933"/>
+        <source>Project</source>
+        <translation>Proyek</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="934"/>
+        <source>Effect Controls</source>
+        <translation>Pengaturan Efek</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="935"/>
+        <source>Timeline</source>
+        <translation>Garis Waktu</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="936"/>
+        <source>Graph Editor</source>
+        <translation>Pengedit Grafik</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="937"/>
+        <source>Media Viewer</source>
+        <translation>Penampil Media</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="938"/>
+        <source>Sequence Viewer</source>
+        <translation>Penampil Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="940"/>
+        <source>Maximize Panel</source>
+        <translation>Lebarkan Panel</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="941"/>
+        <source>Lock Panels</source>
+        <translation>Kunci Panel</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="942"/>
+        <source>Reset to Default Layout</source>
+        <translation>Kembalikan Layout Semula</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="944"/>
+        <source>&amp;Tools</source>
+        <translation>&amp;Alat</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="946"/>
+        <source>Pointer Tool</source>
+        <translation>Alat Tunjuk</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="947"/>
+        <source>Edit Tool</source>
+        <translation>Alat Edit</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="948"/>
+        <source>Ripple Tool</source>
+        <translation>Alat Pengatur</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="949"/>
+        <source>Razor Tool</source>
+        <translation>Alat Potong</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="950"/>
+        <source>Slip Tool</source>
+        <translation>Alat Slip</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="951"/>
+        <source>Slide Tool</source>
+        <translation>Alat Geser Klip</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="952"/>
+        <source>Hand Tool</source>
+        <translation>Alat Geser Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="953"/>
+        <source>Transition Tool</source>
+        <translation>Alat Transisi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="954"/>
+        <source>Enable Snapping</source>
+        <translation>Nyalakan Lekatan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="955"/>
+        <source>Selecting Also Seeks</source>
+        <translatorcomment>idk how to translate this</translatorcomment>
+        <translation type="unfinished">Menyeleksi Juga Menggeser</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="956"/>
+        <source>Edit Tool Also Seeks</source>
+        <translation type="unfinished">Alat Edit Juga Menggeser</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="957"/>
+        <source>Edit Tool Selects Links</source>
+        <translation>Alat Edit Menyeleksi Tautan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="958"/>
+        <source>Seek Also Selects</source>
+        <translation type="unfinished">Menggeser Juga Menyeleksi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="959"/>
+        <source>Seek to the End of Pastes</source>
+        <translation type="unfinished">Geser hingga Akhir Tempelan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="960"/>
+        <source>Scroll Wheel Zooms</source>
+        <translation>Scroll Wheel Memperbesar/Memperkecil Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="961"/>
+        <source>Hold CTRL to toggle this setting</source>
+        <translation>Tekan CTRL untuk mengaktifkan pengaturan ini</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="962"/>
+        <source>Invert Timeline Scroll Axes</source>
+        <translation>Balikkan Arah Gulir Garis Waktu</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="963"/>
+        <source>Enable Drag Files to Timeline</source>
+        <translation>Seret dan Lepas file ke Timeline</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="964"/>
+        <source>Auto-Scale By Default</source>
+        <translation>Atur Ukuran Video secara Default</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="965"/>
+        <source>Enable Seek to Import</source>
+        <translation type="unfinished">Nyalakan Geser-untuk-Impor</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="966"/>
+        <source>Audio Scrubbing</source>
+        <translation>Nyalakan Audio Scrubbing</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="967"/>
+        <source>Enable Drop on Media to Replace</source>
+        <translation>Seret pada Media untuk Menggantikan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="968"/>
+        <source>Enable Hover Focus</source>
+        <translation>Nyalakan Fokus Melayang</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="969"/>
+        <source>Ask For Name When Setting Marker</source>
+        <translation>Tanyakan Nama ketika Menaruh Penanda</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="971"/>
+        <source>No Auto-Scroll</source>
+        <translation>Matikan Gulir Otomatis</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="972"/>
+        <source>Page Auto-Scroll</source>
+        <translation>Gulir Halaman Otomatis</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="973"/>
+        <source>Smooth Auto-Scroll</source>
+        <translation>Gulir Halus Otomatis</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="975"/>
+        <source>Preferences</source>
+        <translation>Preferensi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="977"/>
+        <source>Clear Undo</source>
+        <translation>Hapus Daftar Urung (Undo)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="980"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Bantuan</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="982"/>
+        <source>A&amp;ction Search</source>
+        <translation>&amp;Cari Aksi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="983"/>
+        <source>Debug Log</source>
+        <translation>Awakutu / Debug</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="984"/>
+        <source>&amp;About...</source>
+        <translation>&amp;Tentang...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1002"/>
+        <source>&lt;untitled&gt;</source>
+        <translation>&lt;belum dinamai&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>Marker</name>
+    <message>
+        <location filename="../timeline/marker.cpp" line="64"/>
+        <source>Set Marker</source>
+        <translation>Masukkan Penanda</translation>
+    </message>
+    <message>
+        <location filename="../timeline/marker.cpp" line="66"/>
+        <source>Set clip marker name:</source>
+        <translation>Masukkan nama penanda:</translation>
+    </message>
+    <message>
+        <location filename="../timeline/marker.cpp" line="67"/>
+        <source>Set sequence marker name:</source>
+        <translation>Masukkan nama penanda rangkaian:</translation>
+    </message>
+</context>
+<context>
+    <name>Media</name>
+    <message>
+        <location filename="../project/media.cpp" line="94"/>
+        <source>New Folder</source>
+        <translation>Folder Baru</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="119"/>
+        <source>Name:</source>
+        <translation>Nama:</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="119"/>
+        <source>Filename:</source>
+        <translation>Nama file:</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="123"/>
+        <source>Video Dimensions:</source>
+        <translation>Dimensi Video:</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="133"/>
+        <source>Frame Rate:</source>
+        <translation>Laju frame:</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="143"/>
+        <source>%1 field(s) (%2 frame(s))</source>
+        <translation>%1 baris (%2 frame)</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="152"/>
+        <source>Interlacing:</source>
+        <translation>Mode interlace:</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="164"/>
+        <source>Audio Frequency:</source>
+        <translation>Frekuensi Audio:</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="173"/>
+        <source>Audio Channels:</source>
+        <translation>Kanal Audio:</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="191"/>
+        <source>Name: %1
+Video Dimensions: %2x%3
+Frame Rate: %4
+Audio Frequency: %5
+Audio Layout: %6</source>
+        <translation>Nama: %1
+Dimensi Video: %2x%3
+Laju Frame: %4
+Frekuensi Audio: %5
+Tata Audio: %6</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="304"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="306"/>
+        <source>Duration</source>
+        <translation>Durasi</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="323"/>
+        <source>Rate</source>
+        <translation>Laju</translation>
+    </message>
+</context>
+<context>
+    <name>MediaPropertiesDialog</name>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="44"/>
+        <source>&quot;%1&quot; Properties</source>
+        <translation>Properti &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="53"/>
+        <source>Tracks:</source>
+        <translation>Jumlah trek:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="61"/>
+        <source>Video %1: %2x%3 %4FPS</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="77"/>
+        <source>Audio %1: %2Hz %3</source>
+        <translation></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="80"/>
+        <source>%n channel(s)</source>
+        <translation>
+            <numerusform>%n kanal</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="95"/>
+        <source>Conform to Frame Rate:</source>
+        <translation>Ubah laju frame jadi:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="105"/>
+        <source>Alpha is Premultiplied</source>
+        <translatorcomment>Idk how to translate this either</translatorcomment>
+        <translation type="unfinished">Alpha dipremultiplikasi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="114"/>
+        <source>Auto (%1)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="127"/>
+        <source>Interlacing:</source>
+        <translation>Mode interlace:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="134"/>
+        <source>Name:</source>
+        <translation>Nama:</translation>
+    </message>
+</context>
+<context>
+    <name>MenuHelper</name>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="161"/>
+        <source>&amp;Project</source>
+        <translation>&amp;Proyek</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="162"/>
+        <source>&amp;Sequence</source>
+        <translation>&amp;Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="163"/>
+        <source>&amp;Folder</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="164"/>
+        <source>Set In Point</source>
+        <translation>Set Titik Masuk</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="165"/>
+        <source>Set Out Point</source>
+        <translation>Set Titik Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="166"/>
+        <source>Reset In Point</source>
+        <translation>Kembalikan Titik Masuk</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="167"/>
+        <source>Reset Out Point</source>
+        <translation>Kembalikan Titik Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="168"/>
+        <source>Clear In/Out Point</source>
+        <translation>Hapus Titik Masuk/Keluar</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="169"/>
+        <source>Add Default Transition</source>
+        <translation>Masukkan Transisi Biasa</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="170"/>
+        <source>Link/Unlink</source>
+        <translation>Tautkan/Lepaskan</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="171"/>
+        <source>Enable/Disable</source>
+        <translation>Nyalakan/Matikan</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="172"/>
+        <source>Nest</source>
+        <translation>Sarangkan</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="173"/>
+        <source>Cu&amp;t</source>
+        <translation>&amp;Potong</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="174"/>
+        <source>Cop&amp;y</source>
+        <translation>&amp;Salin</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="175"/>
+        <location filename="../ui/menuhelper.cpp" line="270"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Tempel</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="176"/>
+        <source>Paste Insert</source>
+        <translation>Tempel dan Masukkan</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="177"/>
+        <source>Duplicate</source>
+        <translation>Gandakan</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="178"/>
+        <source>Delete</source>
+        <translation>Hapus</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="179"/>
+        <source>Ripple Delete</source>
+        <translatorcomment>literally the function of ripple delete: &quot;delete and adjust&quot;</translatorcomment>
+        <translation>Hapus dan Sesuaikan</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="180"/>
+        <source>Split</source>
+        <translation>Pisahkan</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="223"/>
+        <source>Invalid aspect ratio</source>
+        <translation>Rasio aspek salah</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="223"/>
+        <source>The aspect ratio &apos;%1&apos; is invalid. Please try again.</source>
+        <translation>Rasio aspek &apos;%1&apos; salah. Silahkan coba lagi.</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="226"/>
+        <source>Enter custom aspect ratio</source>
+        <translation>Masukkan rasio aspek kustom</translation>
+    </message>
+    <message>
+        <location filename="../ui/menuhelper.cpp" line="226"/>
+        <source>Enter the aspect ratio to use for the title/action safe area (e.g. 16:9):</source>
+        <translation>Masukkan rasio aspek yang ingin dipakai untuk safe area judul/aksi (contohnya 16:9)</translation>
+    </message>
+</context>
+<context>
+    <name>NewSequenceDialog</name>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="55"/>
+        <source>Editing &quot;%1&quot;</source>
+        <translation>Mengedit &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="75"/>
+        <source>New Sequence</source>
+        <translation>Rangkaian Baru</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="184"/>
+        <source>Preset:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="188"/>
+        <source>Film 4K</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="189"/>
+        <source>TV 4K (Ultra HD/2160p)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="190"/>
+        <source>1080p</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="191"/>
+        <source>720p</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="192"/>
+        <source>480p</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="193"/>
+        <source>360p</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="194"/>
+        <source>240p</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="195"/>
+        <source>144p</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="196"/>
+        <source>NTSC (480i)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="197"/>
+        <source>PAL (576i)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="198"/>
+        <source>Custom</source>
+        <translation>Kustom</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="206"/>
+        <source>Video</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="210"/>
+        <source>Width:</source>
+        <translation>Lebar:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="216"/>
+        <source>Height:</source>
+        <translation>Tinggi:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="222"/>
+        <source>Frame Rate:</source>
+        <translation>Laju frame (fps):</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="238"/>
+        <source>Pixel Aspect Ratio:</source>
+        <translation>Rasio aspek piksel:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="240"/>
+        <source>Square Pixels (1.0)</source>
+        <translation>Persegi (1.0)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="243"/>
+        <source>Interlacing:</source>
+        <translation>Mode interlace:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="245"/>
+        <source>None (Progressive)</source>
+        <translation>Tidak ada (Progresif)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="253"/>
+        <source>Audio</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="257"/>
+        <source>Sample Rate: </source>
+        <translation>Laju sampel: </translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="271"/>
+        <source>Name:</source>
+        <translation>Nama:</translation>
+    </message>
+</context>
+<context>
+    <name>OliveGlobal</name>
+    <message>
+        <location filename="../global/global.cpp" line="67"/>
+        <source>Olive Project %1</source>
+        <translation>Proyek Olive %1</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="95"/>
+        <source>Auto-recovery</source>
+        <translation>Auto-pulih</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="96"/>
+        <source>Olive didn&apos;t close properly and an autorecovery file was detected. Would you like to open it?</source>
+        <translation>Olive tidak ditutup sebagaimana mestinya, dan ditemukan sebuah file auto-pulih. Buka?</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="238"/>
+        <source>Open Project...</source>
+        <translation>Buka Proyek...</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="249"/>
+        <source>Missing recent project</source>
+        <translation>Proyek Terakhir Tidak Ada</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="250"/>
+        <source>The project &apos;%1&apos; no longer exists. Would you like to remove it from the recent projects list?</source>
+        <translation>Proyek &apos;%1&apos; tidak ada lagi. Hapus dari daftar &quot;proyek terakhir&quot;?</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="261"/>
+        <source>Save Project As...</source>
+        <translation>Simpan Proyek Sebagai...</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="286"/>
+        <source>Unsaved Project</source>
+        <translation>Proyek Belum Disimpan</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="287"/>
+        <source>This project has changed since it was last saved. Would you like to save it before closing?</source>
+        <translation>Proyek ini diubah sejak terakhir disimpan. Simpan sebelum ditutup?</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="306"/>
+        <source>No active sequence</source>
+        <translation>Tidak ada rangkaian aktif</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="307"/>
+        <source>Please open the sequence you wish to export.</source>
+        <translation>Buka dahulu rangkaian/sequence yang ingin diekspor.</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="323"/>
+        <source>Missing Project File</source>
+        <translation>File Proyek Tidak Ada</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="324"/>
+        <source>Specified project &apos;%1&apos; does not exist.</source>
+        <translation>Proyek yang dipilih, &apos;%1&apos;, tidak ditemukan.</translation>
+    </message>
+</context>
+<context>
+    <name>PanEffect</name>
+    <message>
+        <location filename="../effects/internal/paneffect.cpp" line="32"/>
+        <source>Pan</source>
+        <translation>Geser/Pan</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesDialog</name>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="83"/>
+        <source>Preferences</source>
+        <translation>Preferensi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="178"/>
+        <source>Invalid CSS File</source>
+        <translation>File CSS Salah</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="179"/>
+        <source>CSS file &apos;%1&apos; does not exist.</source>
+        <translation>Tidak ditemukan file CSS &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="336"/>
+        <source>Confirm Reset All Shortcuts</source>
+        <translation>Konfirmasi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="337"/>
+        <source>Are you sure you wish to reset all keyboard shortcuts to their defaults?</source>
+        <translation>Anda ingin mengembalikan semua pintasan keyboard seperti semula. Yakin?</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="387"/>
+        <source>Import Keyboard Shortcuts</source>
+        <translation>Impor Pintasan Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="411"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="435"/>
+        <source>Error saving shortcuts</source>
+        <translation>Gagal menyimpan pintasan</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="412"/>
+        <source>Failed to open file for reading</source>
+        <translation>Gagal membuka file</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="419"/>
+        <source>Export Keyboard Shortcuts</source>
+        <translation>Ekspor Pintasan Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="433"/>
+        <source>Export Shortcuts</source>
+        <translation>Ekspor Pintasan</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="433"/>
+        <source>Shortcuts exported successfully</source>
+        <translation>Pintasan berhasil diekspor</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="435"/>
+        <source>Failed to open file for writing</source>
+        <translation>Gagal membaca file</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="441"/>
+        <source>Browse for CSS file</source>
+        <translation>Telusuri file CSS</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="449"/>
+        <source>Delete All Previews</source>
+        <translation>Hapus Semua Pratinjau</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="450"/>
+        <source>Are you sure you want to delete all previews?</source>
+        <translation>Yakin menghapus semua pratinjau?</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="454"/>
+        <source>Previews Deleted</source>
+        <translation>Pratinjau Dihapus</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="455"/>
+        <source>All previews deleted succesfully. You may have to re-open your current project for changes to take effect.</source>
+        <translation>Semua pratinjau berhasil dihapus. Anda mungkin perlu membuka proyek kembali.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="472"/>
+        <source>Language:</source>
+        <translation>Bahasa:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="565"/>
+        <source>Automatically Seek to the Beginning When Playing at the End of a Sequence</source>
+        <translation>Pindahkan Kursor secara Otomatis ke Awal Ketika Mencapai Akhir Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="601"/>
+        <source>Custom CSS:</source>
+        <translation>CSS Custom:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="607"/>
+        <source>Browse</source>
+        <translation>Telusur</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="509"/>
+        <source>Image sequence formats:</source>
+        <translation>Format rangkaian gambar:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="724"/>
+        <source>Audio Recording:</source>
+        <translation>Rekaman Audio:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="727"/>
+        <source>Mono</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="728"/>
+        <source>Stereo</source>
+        <translation>Stereo</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="614"/>
+        <source>Effect Textbox Lines:</source>
+        <translation>Baris Teks Efek:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="519"/>
+        <source>Thumbnail Resolution:</source>
+        <translatorcomment>according to kbbi it should be &quot;keluku&quot; but not a lot of people know that</translatorcomment>
+        <translation>Resolusi Thumbnail:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="527"/>
+        <source>Waveform Resolution:</source>
+        <translation>Resolusi Waveform:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="535"/>
+        <source>Delete Previews</source>
+        <translation>Hapus Pratinjau</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="543"/>
+        <source>Use Software Fallbacks When Possible</source>
+        <translation>Gunakan Software Fallback Sebisa Mungkin</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="550"/>
+        <source>Default Sequence Settings</source>
+        <translation>Pengaturan Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="553"/>
+        <source>General</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="557"/>
+        <source>Behavior</source>
+        <translation>Kelakuan</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="561"/>
+        <source>Add Default Effects to New Clips</source>
+        <translation>Tambahkan Efek-Efek Biasa pada Klip Baru</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="571"/>
+        <source>Appearance</source>
+        <translation>Penampilan</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="578"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="581"/>
+        <source>Olive Dark (Default)</source>
+        <translation>Gelap (Default)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="582"/>
+        <source>Olive Light</source>
+        <translation>Terang</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="583"/>
+        <source>Native</source>
+        <translation>Selaras/native</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="584"/>
+        <source>Native (Light Icons)</source>
+        <translation>Selaras (Ikon Terang)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="593"/>
+        <source>Use Native Menu Styling</source>
+        <translation>Gunakan Gaya Menu Selaras</translation>
+    </message>
+    <message>
+        <source>Seeking</source>
+        <translatorcomment>&quot;geser&quot; may not be understood well</translatorcomment>
+        <translation type="vanished">Tampilan Frame</translation>
+    </message>
+    <message>
+        <source>Accurate Seeking
+Always show the correct frame (visual may pause briefly as correct frame is retrieved)</source>
+        <translation type="vanished">Tampilan Akurat
+Selalu tampilkan frame yang sebenarnya (dapat terhenti sejenak sembari mencari frame yang benar)</translation>
+    </message>
+    <message>
+        <source>Fast Seeking
+Seek quickly (may briefly show inaccurate frames when seeking - doesn&apos;t affect playback/export)</source>
+        <translation type="vanished">Tampilan Cepat
+Tampilkan frame dengan cepat (dapat menampilkan frame yang salah ketika menggeser kursor di timeline - tidak berpengaruh pada pemutaran/ekspor)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="629"/>
+        <source>Memory Usage</source>
+        <translation>Pemakaian Memori</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="631"/>
+        <source>Upcoming Frame Queue:</source>
+        <translation>Antri Frame Ke Depan:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="636"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="645"/>
+        <source>frames</source>
+        <translation>frame</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="637"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="646"/>
+        <source>seconds</source>
+        <translation>detik</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="640"/>
+        <source>Previous Frame Queue:</source>
+        <translation>Antri Frame Ke Belakang:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="651"/>
+        <source>Playback</source>
+        <translation>Pemutaran</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="662"/>
+        <source>Output Device:</source>
+        <translation>Peranti Output:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="665"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="688"/>
+        <source>Default</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="685"/>
+        <source>Input Device:</source>
+        <translation>Peranti Masukan:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="708"/>
+        <source>Sample Rate:</source>
+        <translation>Laju sampel:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="734"/>
+        <source>Audio</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="742"/>
+        <source>Search for action or shortcut</source>
+        <translation>Cari aksi atau pintasan</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="749"/>
+        <source>Action</source>
+        <translation>Aksi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="750"/>
+        <source>Shortcut</source>
+        <translation>Pintasan</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="755"/>
+        <source>Import</source>
+        <translation>Impor</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="759"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="765"/>
+        <source>Reset Selected</source>
+        <translation>Kembalikan Seleksi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="769"/>
+        <source>Reset All</source>
+        <translation>Kembalikan Semua</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="775"/>
+        <source>Keyboard</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>PreviewGenerator</name>
+    <message>
+        <location filename="../project/previewgenerator.cpp" line="205"/>
+        <source>Failed to find any valid video/audio streams</source>
+        <translation>Gagal mencari stream video/audio yang benar</translation>
+    </message>
+    <message>
+        <location filename="../project/previewgenerator.cpp" line="563"/>
+        <source>Could not open file - %1</source>
+        <translation>Tidak dapat membuka file - %1</translation>
+    </message>
+    <message>
+        <location filename="../project/previewgenerator.cpp" line="570"/>
+        <source>Could not find stream information - %1</source>
+        <translation>Tidak dapat mencari informasi stream - %1</translation>
+    </message>
+</context>
+<context>
+    <name>Project</name>
+    <message>
+        <location filename="../panels/project.cpp" line="225"/>
+        <source>Search media, markers, etc.</source>
+        <translation>Cari media, penanda, dll.</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="226"/>
+        <source>Project</source>
+        <translation>Proyek</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="230"/>
+        <source>Sequence</source>
+        <translation>Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="352"/>
+        <source>Replace &apos;%1&apos;</source>
+        <translation>Ganti &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="354"/>
+        <location filename="../panels/project.cpp" line="1003"/>
+        <source>All Files</source>
+        <translation>Semua file</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="365"/>
+        <location filename="../panels/project.cpp" line="1015"/>
+        <source>No active sequence</source>
+        <translation>Tidak ada rangkaian aktif</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="366"/>
+        <source>No sequence is active, please open the sequence you want to replace clips from.</source>
+        <translation>Tidak ada rangkaian aktif, silahkan buka rangkaian yang akan diganti klipnya.</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="374"/>
+        <source>Active sequence selected</source>
+        <translation>Rangkaian aktif terseleksi</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="375"/>
+        <source>You cannot insert a sequence into itself, so no clips of this media would be in this sequence.</source>
+        <translation>Anda tak dapat memasukkan rangkaian ke dalam rangkaian itu sendiri, jadi tidak ada klip sejenis ini dalam rangkaian.</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="406"/>
+        <source>Rename &apos;%1&apos;</source>
+        <translation>Ganti nama &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="407"/>
+        <source>Enter new name:</source>
+        <translation>Masukkan nama pengganti:</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="577"/>
+        <source>Delete media in use?</source>
+        <translation>Hapus media yang sedang dipakai?</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="578"/>
+        <source>The media &apos;%1&apos; is currently used in &apos;%2&apos;. Deleting it will remove all instances in the sequence. Are you sure you want to do this?</source>
+        <translation>Media &apos;%1&apos; sedang dipakai dalam &apos;%2&apos;. Menghapus media tersebut akan menghapus semua instans media dalam rangkaian. Yakin akan melakukan hal tersebut?</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="581"/>
+        <source>Skip</source>
+        <translation>Lewati</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="744"/>
+        <source>Import a Project</source>
+        <translation>Impor Proyek</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="745"/>
+        <source>&quot;%1&quot; is an Olive project file. It will merge with this project. Do you wish to continue?</source>
+        <translation>&quot;%1&quot; adalah file proyek Olive. File tersebut akan bergabung dengan proyek ini. Lanjutkan?</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="848"/>
+        <source>Image sequence detected</source>
+        <translation>Rangkaian gambar terdeteksi</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="849"/>
+        <source>The file &apos;%1&apos; appears to be part of an image sequence. Would you like to import it as such?</source>
+        <translation>File &apos;%1&apos; sepertinya merupakan rangkaian gambar. Apakah Anda ingin mengimpornya sebaga rangkaian gambar?</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="1003"/>
+        <source>Import media...</source>
+        <translation>Impor media...</translation>
+    </message>
+    <message>
+        <location filename="../panels/project.cpp" line="1016"/>
+        <source>No sequence is active, please open the sequence you want to delete clips from.</source>
+        <translation>Tidak ada rangkaian aktif, silahkan buka rangkaian yang Anda ingin hapus klipnya.</translation>
+    </message>
+</context>
+<context>
+    <name>ProxyDialog</name>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="41"/>
+        <source>Create Proxy</source>
+        <translation>Buat Proksi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="44"/>
+        <source>Proxy</source>
+        <translation>Proksi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="50"/>
+        <source>Dimensions:</source>
+        <translation>Ukuran:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="53"/>
+        <source>Same Size as Source</source>
+        <translation>Sama dengan Sumber</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="54"/>
+        <source>Half Resolution (1/2)</source>
+        <translation>Resolusi setengah (1/2)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="55"/>
+        <source>Quarter Resolution (1/4)</source>
+        <translation>Resolusi seperempat (1/4)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="56"/>
+        <source>Eighth Resolution (1/8)</source>
+        <translation>Resolusi seperdelapan (1/8)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="57"/>
+        <source>Sixteenth Resolution (1/16)</source>
+        <translation>Resolusi seperenambelas (1/16)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="61"/>
+        <source>Format:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="64"/>
+        <source>ProRes HQ</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="72"/>
+        <source>Location:</source>
+        <translation>Lokasi:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="75"/>
+        <source>Same as Source (in &quot;%1&quot; folder)</source>
+        <translation>Sama dengan Sumber (dalam folder &quot;%1&quot;)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="128"/>
+        <source>Proxy file exists</source>
+        <translation>File proksi sudah ada</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="129"/>
+        <source>The file &quot;%1&quot; already exists. Do you wish to replace it?</source>
+        <translation>File &quot;%1&quot; sudah ada. Ganti?</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/proxydialog.cpp" line="182"/>
+        <source>Custom Location</source>
+        <translation>Lokasi Kustom</translation>
+    </message>
+</context>
+<context>
+    <name>ProxyGenerator</name>
+    <message>
+        <location filename="../project/proxygenerator.cpp" line="332"/>
+        <source>Finished generating proxy for &quot;%1&quot;</source>
+        <translation>Selesai membuat proksi untuk &quot;%1&quot;</translation>
+    </message>
+</context>
+<context>
+    <name>ReplaceClipMediaDialog</name>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="37"/>
+        <source>Replace clips using &quot;%1&quot;</source>
+        <translation>Ganti klip dengan &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="43"/>
+        <source>Select which media you want to replace this media&apos;s clips with:</source>
+        <translation>Pilih media pengganti media dari klip:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="49"/>
+        <source>Keep the same media in-points</source>
+        <translation>Samakan titik masuk media</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="57"/>
+        <source>Replace</source>
+        <translation>Ganti</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="61"/>
+        <source>Cancel</source>
+        <translation>Batalkan</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="77"/>
+        <source>No media selected</source>
+        <translation>Tidak ada media yang dipilih</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="78"/>
+        <source>Please select a media to replace with or click &apos;Cancel&apos;.</source>
+        <translation>Pilih media pengganti atau klik &quot;Batalkan&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="86"/>
+        <source>Same media selected</source>
+        <translation>Terpilih media sama</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="87"/>
+        <source>You selected the same media that you&apos;re replacing. Please select a different one or click &apos;Cancel&apos;.</source>
+        <translation>Anda memilih media yang sama dengan yang akan diganti. Silahkan pilih yang lain atau klik &quot;Batalkan&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="93"/>
+        <source>Folder selected</source>
+        <translation>Folder terpilih</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="94"/>
+        <source>You cannot replace footage with a folder.</source>
+        <translation>Anda tidak dapat mengganti media dengan folder.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="101"/>
+        <source>Active sequence selected</source>
+        <translation>Rangkaian aktif terseleksi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="102"/>
+        <source>You cannot insert a sequence into itself.</source>
+        <translation>Anda tidak dapat memasukkan rangkaian pada rangkaian itu sendiri.</translation>
+    </message>
+</context>
+<context>
+    <name>RichTextEffect</name>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="22"/>
+        <source>Text</source>
+        <translation>Teks</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="26"/>
+        <source>Padding</source>
+        <translation>Ruang Border</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="30"/>
+        <source>Position</source>
+        <translation>Posisi</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="34"/>
+        <source>Vertical Align:</source>
+        <translation>Rata Vertikal:</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="36"/>
+        <source>Top</source>
+        <translation>Atas</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="37"/>
+        <source>Center</source>
+        <translation>Tengah</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="38"/>
+        <source>Bottom</source>
+        <translation>Bawah</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="42"/>
+        <source>Auto-Scroll</source>
+        <translation>Gulir otomatis</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="44"/>
+        <source>Off</source>
+        <translation>Matikan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="45"/>
+        <source>Up</source>
+        <translation>Ke atas</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="46"/>
+        <source>Down</source>
+        <translation>Ke bawah</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="47"/>
+        <source>Left</source>
+        <translation>Ke kiri</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="48"/>
+        <source>Right</source>
+        <translation>Ke kanan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="51"/>
+        <source>Shadow</source>
+        <translation>Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="55"/>
+        <source>Shadow Color</source>
+        <translation>Warna Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="59"/>
+        <source>Shadow Angle</source>
+        <translation>Arah Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="63"/>
+        <source>Shadow Distance</source>
+        <translation>Jarak Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="68"/>
+        <source>Shadow Softness</source>
+        <translation>Kehalusan Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="73"/>
+        <source>Shadow Opacity</source>
+        <translatorcomment>&quot;opacity&quot; is a hard word to find a suitable meaning for</translatorcomment>
+        <translation>Intensitas Bayangan</translation>
+    </message>
+</context>
+<context>
+    <name>Sequence</name>
+    <message>
+        <location filename="../timeline/sequence.cpp" line="41"/>
+        <source>%1 (copy)</source>
+        <translation>%1 (salinan)</translation>
+    </message>
+</context>
+<context>
+    <name>ShakeEffect</name>
+    <message>
+        <location filename="../effects/internal/shakeeffect.cpp" line="38"/>
+        <source>Intensity</source>
+        <translation>Intensitas</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/shakeeffect.cpp" line="43"/>
+        <source>Rotation</source>
+        <translation>Rotasi</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/shakeeffect.cpp" line="48"/>
+        <source>Frequency</source>
+        <translation>Frekuensi</translation>
+    </message>
+</context>
+<context>
+    <name>SolidEffect</name>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="43"/>
+        <source>Type</source>
+        <translation>Tipe</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="45"/>
+        <source>Solid Color</source>
+        <translation>Warna</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="46"/>
+        <source>SMPTE Bars</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="47"/>
+        <source>Checkerboard</source>
+        <translation>Kotak-Kotak</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="49"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="55"/>
+        <source>Color</source>
+        <translation>Warna</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="59"/>
+        <source>Checkerboard Size</source>
+        <translation>Ukuran Kotak-Kotak</translation>
+    </message>
+</context>
+<context>
+    <name>SourcesCommon</name>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="83"/>
+        <source>Import...</source>
+        <translation>Impor...</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="86"/>
+        <source>New</source>
+        <translation>Baru</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="90"/>
+        <source>View</source>
+        <translation>Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="93"/>
+        <source>Tree View</source>
+        <translation>Tampilan Pohon</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="96"/>
+        <source>Icon View</source>
+        <translation>Tampilan Ikon</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="99"/>
+        <source>Show Toolbar</source>
+        <translation>Tampilkan Toolbar</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="104"/>
+        <source>Show Sequences</source>
+        <translation>Tampilkan Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="116"/>
+        <source>Replace/Relink Media</source>
+        <translation>Ganti/Taut Media</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="120"/>
+        <source>Reveal in Explorer</source>
+        <translation>Buka di Explorer</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="122"/>
+        <source>Reveal in Finder</source>
+        <translation>Buka di Finder</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="124"/>
+        <source>Reveal in File Manager</source>
+        <translation>Buka di Manajer Berkas</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="129"/>
+        <source>Replace Clips Using This Media</source>
+        <translation>Ganti Klip dengan Media Ini</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="152"/>
+        <source>Create Sequence With This Media</source>
+        <translation>Buat Rangkaian dengan Media Ini</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="158"/>
+        <source>Duplicate</source>
+        <translation>Gandakan</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="164"/>
+        <source>Delete All Clips Using This Media</source>
+        <translation>Hapus Semua Klip yang Menggunakan Media Ini</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="167"/>
+        <source>Proxy</source>
+        <translation>Proksi</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="174"/>
+        <source>Generating proxy: %1% complete</source>
+        <translation>Membuat proksi: %1%</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="198"/>
+        <source>Create/Modify Proxy</source>
+        <translation>Buat/Ubah Proksi</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="201"/>
+        <source>Create Proxy</source>
+        <translation>Buat Proksi</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="212"/>
+        <source>Modify Proxy</source>
+        <translation>Ubah Proksi</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="215"/>
+        <source>Restore Original</source>
+        <translation>Kembalikan Seperti Semula</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="221"/>
+        <source>Delete</source>
+        <translation>Hapus</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="228"/>
+        <source>Preview in Media Viewer</source>
+        <translation>Pratayang di Penampil Media</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="234"/>
+        <source>Properties...</source>
+        <translation>Properti...</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="291"/>
+        <source>Replace Media</source>
+        <translation>Ganti Media</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="292"/>
+        <source>You dropped a file onto &apos;%1&apos;. Would you like to replace it with the dropped file?</source>
+        <translation>Anda menjatuhkan file ke &apos;%1&apos;. Ganti klip dengan file tersebut?</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="421"/>
+        <source>Delete proxy</source>
+        <translation>Hapus proksi</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="422"/>
+        <source>Would you like to delete the proxy file &quot;%1&quot; as well?</source>
+        <translation>Hapus file proksi &quot;%1&quot; juga?</translation>
+    </message>
+</context>
+<context>
+    <name>SpeedDialog</name>
+    <message>
+        <location filename="../dialogs/speeddialog.cpp" line="40"/>
+        <source>Speed/Duration</source>
+        <translation>Kecepatan/Durasi</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/speeddialog.cpp" line="49"/>
+        <source>Speed:</source>
+        <translation>Kecepatan:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/speeddialog.cpp" line="56"/>
+        <source>Frame Rate:</source>
+        <translation>Laju frame (fps):</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/speeddialog.cpp" line="61"/>
+        <source>Duration:</source>
+        <translation>Durasi:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/speeddialog.cpp" line="69"/>
+        <source>Reverse</source>
+        <translation>Terbalik</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/speeddialog.cpp" line="70"/>
+        <source>Maintain Audio Pitch</source>
+        <translation>Tahan Pitch</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/speeddialog.cpp" line="71"/>
+        <source>Ripple Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TextEditDialog</name>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="35"/>
+        <source>Edit Text</source>
+        <translation>Edit Teks</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="68"/>
+        <source>Thin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="69"/>
+        <source>Extra Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="70"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="71"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="72"/>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="73"/>
+        <source>Demi Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="74"/>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="75"/>
+        <source>Extra Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/texteditdialog.cpp" line="76"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TextEditEx</name>
+    <message>
+        <location filename="../ui/texteditex.cpp" line="40"/>
+        <source>Edit Text</source>
+        <translation>Edit Teks</translation>
+    </message>
+    <message>
+        <location filename="../ui/texteditex.cpp" line="88"/>
+        <source>&amp;Edit Text</source>
+        <translation>&amp;Edit Teks</translation>
+    </message>
+</context>
+<context>
+    <name>TextEffect</name>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="51"/>
+        <source>Text</source>
+        <translation>Teks</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="55"/>
+        <source>Font</source>
+        <translation>Fon</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="59"/>
+        <source>Size</source>
+        <translation>Ukuran</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="64"/>
+        <source>Color</source>
+        <translation>Warna</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="68"/>
+        <source>Alignment</source>
+        <translation>Rata</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="70"/>
+        <source>Left</source>
+        <translation>Kiri</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="71"/>
+        <location filename="../effects/internal/texteffect.cpp" line="77"/>
+        <source>Center</source>
+        <translation>Tengah</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="72"/>
+        <source>Right</source>
+        <translation>Kanan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="73"/>
+        <source>Justify</source>
+        <translation>Kanan-Kiri</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="76"/>
+        <source>Top</source>
+        <translation>Atas</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="78"/>
+        <source>Bottom</source>
+        <translation>Bawah</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="80"/>
+        <source>Word Wrap</source>
+        <translatorcomment>&quot;bungkus kata&quot; is also possible but feels weird</translatorcomment>
+        <translation>Sesuaikan Lebar Kata</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="84"/>
+        <source>Padding</source>
+        <translation>Ruang Border</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="88"/>
+        <source>Position</source>
+        <translation>Posisi</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="92"/>
+        <source>Outline</source>
+        <translation>Garis Teks</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="96"/>
+        <source>Outline Color</source>
+        <translation>Warna Garis</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="100"/>
+        <source>Outline Width</source>
+        <translation>Ketebalan Garis</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="105"/>
+        <source>Shadow</source>
+        <translation>Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="109"/>
+        <source>Shadow Color</source>
+        <translation>Warna Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="113"/>
+        <source>Shadow Angle</source>
+        <translation>Arah Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="117"/>
+        <source>Shadow Distance</source>
+        <translation>Jarak Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="122"/>
+        <source>Shadow Softness</source>
+        <translation>Kehalusan Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="127"/>
+        <source>Shadow Opacity</source>
+        <translation>Intensitas Bayangan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="134"/>
+        <source>Sample Text</source>
+        <translation>Masukkan teks disini</translation>
+    </message>
+</context>
+<context>
+    <name>TimecodeEffect</name>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="51"/>
+        <source>Timecode</source>
+        <translation>Kode Waktu</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="53"/>
+        <source>Sequence</source>
+        <translation>Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="54"/>
+        <source>Media</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="57"/>
+        <source>Scale</source>
+        <translation>Ukuran</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="64"/>
+        <source>Color</source>
+        <translation>Warna</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="69"/>
+        <source>Background Color</source>
+        <translation>Warna Latar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="74"/>
+        <source>Background Opacity</source>
+        <translation>Transparansi Latar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="81"/>
+        <source>Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="85"/>
+        <source>Prepend</source>
+        <translation>Teks Sebelum</translation>
+    </message>
+</context>
+<context>
+    <name>Timeline</name>
+    <message>
+        <location filename="../panels/timeline.cpp" line="124"/>
+        <source>Pointer Tool</source>
+        <translation>Alat Tunjuk</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="125"/>
+        <source>Edit Tool</source>
+        <translation>Alat Edit</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="126"/>
+        <source>Ripple Tool</source>
+        <translation>Alat Pengatur</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="127"/>
+        <source>Razor Tool</source>
+        <translation>Alat Potong</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="128"/>
+        <source>Slip Tool</source>
+        <translation>Alat Slip</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="129"/>
+        <source>Slide Tool</source>
+        <translation>Alat Geser Klip</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="130"/>
+        <source>Hand Tool</source>
+        <translation>Alat Geser Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="131"/>
+        <source>Transition Tool</source>
+        <translation>Alat Transisi</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="132"/>
+        <source>Snapping</source>
+        <translation>Lekatan</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="133"/>
+        <source>Zoom In</source>
+        <translation>Perbesar Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="134"/>
+        <source>Zoom Out</source>
+        <translation>Perkecil Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="135"/>
+        <source>Record audio</source>
+        <translation>Rekam suara</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="136"/>
+        <source>Add title, solid, bars, etc.</source>
+        <translation>Masukkan judul, warna, bars, dll.</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="440"/>
+        <source>Nested Sequence</source>
+        <translation>Rangkaian Bersarang</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1280"/>
+        <source>Effect already exists</source>
+        <translation>Efek sudah ada</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1281"/>
+        <source>Clip &apos;%1&apos; already contains a &apos;%2&apos; effect. Would you like to replace it with the pasted one or add it as a separate effect?</source>
+        <translation>Klip &apos;%1&apos; sudah memiliki efek &apos;%2&apos;. Ganti dengan yang akan ditempel atau tambahkan sebagai efek sendiri?</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1286"/>
+        <source>Add</source>
+        <translation>Tambah</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1287"/>
+        <source>Replace</source>
+        <translation>Ganti</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1288"/>
+        <source>Skip</source>
+        <translation>Lewati</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1290"/>
+        <source>Do this for all conflicts found</source>
+        <translation>Lakukan untuk semua konflik yang ditemukan</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1753"/>
+        <source>Title...</source>
+        <translation>Judul...</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1758"/>
+        <source>Solid Color...</source>
+        <translation>Warna...</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1763"/>
+        <source>Bars...</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1770"/>
+        <source>Tone...</source>
+        <translation>Nada...</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1775"/>
+        <source>Noise...</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1798"/>
+        <source>Unsaved Project</source>
+        <translation>Proyek Belum Disimpan</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1799"/>
+        <source>You must save this project before you can record audio in it.</source>
+        <translation>Proyek ini harus disimpan sebelum merekam suara.</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1805"/>
+        <source>Click on the timeline where you want to start recording (drag to limit the recording to a certain timeframe)</source>
+        <translation>Klik tempat dimana Anda akan mulai merekam (seret untuk membatasi rekaman dalam waktu tertentu)</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1866"/>
+        <source>Timeline: </source>
+        <translation>Garis Waktu:</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="1868"/>
+        <source>(none)</source>
+        <translation>(tidak ada)</translation>
+    </message>
+</context>
+<context>
+    <name>TimelineHeader</name>
+    <message>
+        <location filename="../ui/timelineheader.cpp" line="482"/>
+        <source>Center Timecodes</source>
+        <translation>Ratakan Kode Waktu</translation>
+    </message>
+</context>
+<context>
+    <name>TimelineWidget</name>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="90"/>
+        <source>&amp;Undo</source>
+        <translatorcomment>&quot;takjadi&quot; and &quot;batalkan&quot; are also possible translations</translatorcomment>
+        <translation>&amp;Urung</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="91"/>
+        <source>&amp;Redo</source>
+        <translatorcomment>&quot;kembalikan&quot; is also possible</translatorcomment>
+        <translation>&amp;Ulangi</translation>
+    </message>
+    <message>
+        <source>&amp;Paste</source>
+        <translation type="obsolete">&amp;Tempel</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="111"/>
+        <source>R&amp;ipple Delete Empty Space</source>
+        <translation>Hapus dan Sesuaikan Ruang Kosong</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="115"/>
+        <source>Sequence Settings</source>
+        <translation>Pengaturan Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="123"/>
+        <source>&amp;Speed/Duration</source>
+        <translation>&amp;Kecepatan/Durasi</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="125"/>
+        <source>Auto-s&amp;cale</source>
+        <translation>Per&amp;besar otomatis</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="160"/>
+        <source>&amp;Reveal in Project</source>
+        <translation>&amp;Buka di Proyek</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="164"/>
+        <source>Properties</source>
+        <translation>Properti</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="192"/>
+        <source>%1
+Start: %2
+End: %3
+Duration: %4</source>
+        <translation>%1
+Mulai: %2
+Akhir: %3
+Durasi: %4</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="218"/>
+        <source>Error</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="218"/>
+        <source>Couldn&apos;t locate media wrapper for sequence.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="1026"/>
+        <source>Title</source>
+        <translation>Judul</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="1030"/>
+        <source>Solid Color</source>
+        <translation>Warna</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="1035"/>
+        <source>Bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="1046"/>
+        <source>Tone</source>
+        <translation>Nada</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="1050"/>
+        <source>Noise</source>
+        <translation>Kebisingan/Noise</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinewidget.cpp" line="1979"/>
+        <source>Duration:</source>
+        <translation>Durasi:</translation>
+    </message>
+</context>
+<context>
+    <name>ToneEffect</name>
+    <message>
+        <location filename="../effects/internal/toneeffect.cpp" line="31"/>
+        <source>Type</source>
+        <translation>Tipe</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/toneeffect.cpp" line="33"/>
+        <source>Sine</source>
+        <translation>Sinus</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/toneeffect.cpp" line="35"/>
+        <source>Frequency</source>
+        <translation>Frekuensi</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/toneeffect.cpp" line="41"/>
+        <source>Amount</source>
+        <translation>Kenyaringan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/toneeffect.cpp" line="47"/>
+        <source>Mix</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>TransformEffect</name>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="49"/>
+        <source>Position</source>
+        <translation>Posisi</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="54"/>
+        <source>Scale</source>
+        <translation>Ukuran</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="64"/>
+        <source>Uniform Scale</source>
+        <translation>Ukuran Merata</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="68"/>
+        <source>Rotation</source>
+        <translation>Rotasi</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="72"/>
+        <source>Anchor Point</source>
+        <translation>Titik Poros</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="77"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="84"/>
+        <source>Blend Mode</source>
+        <translation>Mode Penggabungan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="89"/>
+        <source>Normal</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>Transition</name>
+    <message>
+        <location filename="../effects/transition.cpp" line="48"/>
+        <source>Length</source>
+        <translation>Panjang</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateNotification</name>
+    <message>
+        <location filename="../ui/updatenotification.cpp" line="35"/>
+        <source>An update is available from the Olive website. Visit www.olivevideoeditor.org to download it.</source>
+        <translation>Pembaruan aplikasi telah tersedia. Silahkan kunjungi www.olivevideoeditor.org untuk mengunduhnya.</translation>
+    </message>
+</context>
+<context>
+    <name>VSTHost</name>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="130"/>
+        <location filename="../effects/internal/vsthost.cpp" line="146"/>
+        <source>Error loading VST plugin</source>
+        <translation>Gagal membuka plugin VST</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="131"/>
+        <source>Failed to load VST plugin &quot;%1&quot;: %2</source>
+        <translation>Gagal membuka plugin VST &quot;%1&quot;: %2</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="147"/>
+        <source>Failed to locate entry point for dynamic library.</source>
+        <translation>Gagal mencari titik masuk untuk pustaka dinamis (dynamic library)</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="172"/>
+        <source>VST Error</source>
+        <translation>Galat VST</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="172"/>
+        <source>Plugin&apos;s magic number is invalid</source>
+        <translation>Identifikasi plugin salah</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="254"/>
+        <source>Plugin</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="258"/>
+        <source>Interface</source>
+        <translation>Antarmuka</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="260"/>
+        <source>Show</source>
+        <translation>Tampilkan</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="228"/>
+        <source>VST Plugin</source>
+        <translation>Plugin VST</translation>
+    </message>
+</context>
+<context>
+    <name>Viewer</name>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="986"/>
+        <source>Sequence Viewer</source>
+        <translation>Tampilan Rangkaian</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="987"/>
+        <source>Media Viewer</source>
+        <translation>Tampilan Media</translation>
+    </message>
+    <message>
+        <location filename="../panels/viewer.cpp" line="610"/>
+        <source>(none)</source>
+        <translation>(tidak ada)</translation>
+    </message>
+    <message>
+        <location filename="../panels/viewer.cpp" line="746"/>
+        <source>Drag video only</source>
+        <translation>Tarik video saja</translation>
+    </message>
+    <message>
+        <location filename="../panels/viewer.cpp" line="753"/>
+        <source>Drag audio only</source>
+        <translation>Tarik audio saja</translation>
+    </message>
+</context>
+<context>
+    <name>ViewerWidget</name>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="113"/>
+        <source>Save Frame as Image...</source>
+        <translation>Simpan Frame sebagai Gambar...</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="116"/>
+        <source>Show Fullscreen</source>
+        <translation>Tampilkan Layar Penuh</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="120"/>
+        <source>Disable</source>
+        <translation>Matikan</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="123"/>
+        <source>Screen %1: %2x%3</source>
+        <translation>Layar %1: %2x%3</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="131"/>
+        <source>Zoom</source>
+        <translation>Pembesaran</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="132"/>
+        <source>Fit</source>
+        <translation>Pas</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="142"/>
+        <source>Custom</source>
+        <translation>Kustom</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="148"/>
+        <source>Close Media</source>
+        <translation>Tutup Media</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="158"/>
+        <source>Save Frame</source>
+        <translation>Simpan Frame</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="192"/>
+        <source>Viewer Zoom</source>
+        <translation>Pembesaran Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="193"/>
+        <source>Set Custom Zoom Value:</source>
+        <translation>Masukkan pembesaran kustom:</translation>
+    </message>
+</context>
+<context>
+    <name>ViewerWindow</name>
+    <message>
+        <location filename="../ui/viewerwindow.cpp" line="135"/>
+        <source>Exit Fullscreen</source>
+        <translation>Keluar dari Layar Penuh</translation>
+    </message>
+</context>
+<context>
+    <name>VoidEffect</name>
+    <message>
+        <location filename="../effects/internal/voideffect.cpp" line="33"/>
+        <source>(unknown)</source>
+        <translation>(tidak diketahui)</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/voideffect.cpp" line="37"/>
+        <source>Missing Effect</source>
+        <translation>Efek Hilang</translation>
+    </message>
+</context>
+<context>
+    <name>VolumeEffect</name>
+    <message>
+        <location filename="../effects/internal/volumeeffect.cpp" line="32"/>
+        <source>Volume</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>transition</name>
+    <message>
+        <location filename="../effects/transition.cpp" line="117"/>
+        <source>Invalid transition</source>
+        <translation>Transisi salah</translation>
+    </message>
+    <message>
+        <location filename="../effects/transition.cpp" line="118"/>
+        <source>No candidate for transition &apos;%1&apos;. This transition may be corrupt. Try reinstalling it or Olive.</source>
+        <translation>Tidak ada kandidat untuk efek &apos;%1&apos;. Efek mungkin korup. Coba menginstal ulang efek tersebut, atau menginstal ulang Olive.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Adds support for `Bahasa Indonesia` in Olive.
You could probably ignore the commit that modifies `olive.pro`, I used it to test my translation.

Is the autosave dialog, etc. translatable now? Can't seem to find it when I updated my `ts` file.