### PR TITLE
Fix #853 lower_control_layout QSizePolicy

### DIFF
--- a/panels/viewer.cpp
+++ b/panels/viewer.cpp
@@ -669,7 +669,7 @@ void Viewer::setup_ui() {
   lower_control_layout->setMargin(0);
 
   QSizePolicy timecode_container_policy(QSizePolicy::Minimum, QSizePolicy::Maximum);
-  QSizePolicy lower_control_policy(QSizePolicy::Expanding, QSizePolicy::Maximum);
+  QSizePolicy lower_control_policy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 
   // Current time code container
   QWidget* current_timecode_container = new QWidget();


### PR DESCRIPTION
Changing the QSizePolicy to `Maximum` prevents the
central control buttons from wiggling as the variable width
font changes width dimensions.

Fixes #853.