### PR TITLE
Make the user able to change the default image clip duration

### DIFF
--- a/dialogs/preferencesdialog.cpp
+++ b/dialogs/preferencesdialog.cpp
@@ -318,6 +318,9 @@ void PreferencesDialog::accept() {
     delete_previews(delete_match);
   }
 
+  // Save default image duration
+  olive::CurrentConfig.default_image_duration = default_image_duration_timeedit->time();
+
   // Save keyboard shortcuts
   for (int i=0;i<key_shortcut_fields.size();i++) {
     key_shortcut_fields.at(i)->set_action_shortcut();
@@ -569,6 +572,17 @@ void PreferencesDialog::setup_ui() {
   QPushButton* delete_preview_btn = new QPushButton(tr("Delete Previews"));
   general_layout->addWidget(delete_preview_btn, row, 4);
   connect(delete_preview_btn, SIGNAL(clicked(bool)), this, SLOT(delete_all_previews()));
+
+  row++;
+
+  // General -> Default Image Duration
+  general_layout->addWidget(new QLabel(tr("Default Image Duration:"), this), row, 0);
+
+  default_image_duration_timeedit = new QTimeEdit(this);
+  default_image_duration_timeedit->setDisplayFormat("HH:mm:ss.zzz");
+  default_image_duration_timeedit->setMinimumTime(QTime(0, 0, 0, 1));
+  default_image_duration_timeedit->setTime(olive::CurrentConfig.default_image_duration);
+  general_layout->addWidget(default_image_duration_timeedit, row, 1);
 
   row++;
 

--- a/dialogs/preferencesdialog.h
+++ b/dialogs/preferencesdialog.h
@@ -33,6 +33,7 @@
 #include <QCheckBox>
 #include <QDoubleSpinBox>
 #include <QSpinBox>
+#include <QTimeEdit>
 
 #include "timeline/sequence.h"
 
@@ -242,6 +243,11 @@ private:
    * @brief UI widget for selecting the resolution of the waveforms to generate
    */
   QSpinBox* waveform_res_spinbox;
+
+  /**
+   * @brief UI widget for selecting the default length of an image footage
+   */
+  QTimeEdit* default_image_duration_timeedit;
 
   /**
    * @brief UI widget for selecting the current UI style

--- a/global/config.cpp
+++ b/global/config.cpp
@@ -76,6 +76,7 @@ Config::Config()
     use_native_menu_styling(true),
     default_sequence_width(1920),
     default_sequence_height(1080),
+    default_image_duration(QTime(0, 0, 6)),
     default_sequence_framerate(29.97),
     default_sequence_audio_frequency(48000),
     default_sequence_audio_channel_layout(3),
@@ -216,6 +217,9 @@ void Config::load(QString path) {
         } else if (stream.name() == "WaveformResolution") {
           stream.readNext();
           waveform_resolution = stream.text().toInt();
+        } else if (stream.name() == "DefaultImageDuration") {
+          stream.readNext();
+          default_image_duration = QTime::fromString(stream.text().toString(), olive::kDefaultTimeFormat);
         } else if (stream.name() == "AddDefaultEffectsToClips") {
           stream.readNext();
           add_default_effects_to_clips = (stream.text() == "1");
@@ -309,6 +313,7 @@ void Config::save(QString path) {
   stream.writeTextElement("LanguageFile", language_file);
   stream.writeTextElement("ThumbnailResolution", QString::number(thumbnail_resolution));
   stream.writeTextElement("WaveformResolution", QString::number(waveform_resolution));
+  stream.writeTextElement("DefaultImageDuration", default_image_duration.toString(olive::kDefaultTimeFormat));
   stream.writeTextElement("AddDefaultEffectsToClips", QString::number(add_default_effects_to_clips));
   stream.writeTextElement("Style", QString::number(style));
   stream.writeTextElement("NativeMenuStyling", QString::number(use_native_menu_styling));

--- a/global/config.h
+++ b/global/config.h
@@ -22,6 +22,7 @@
 #define CONFIG_H
 
 #include <QString>
+#include <QTime>
 
 #include "ui/styling.h"
 
@@ -54,6 +55,12 @@ namespace olive {
    * constant stays the same forever, but in this early stage it's not strictly necessary.
    */
   const int kMinimumSaveVersion = 190219; // lowest compatible project version
+
+
+  /**
+   * @brief Default time format used for saving QTime data
+   */
+  const QString kDefaultTimeFormat = "HH:mm:ss.zzz";
 
   /**
    * @brief The TimecodeType enum
@@ -542,6 +549,11 @@ struct Config {
    * @brief Default Sequence video height
    */
   int default_sequence_height;
+
+  /**
+   * @brief Default Image duration
+   */
+  QTime default_image_duration;
 
   /**
    * @brief Default Sequence video frame rate

--- a/panels/timeline.cpp
+++ b/panels/timeline.cpp
@@ -294,7 +294,8 @@ void Timeline::create_ghosts_from_media(Sequence* seq, long entry_point, QVector
       case MEDIA_TYPE_FOOTAGE:
         // is video source a still image?
         if (m->video_tracks.size() > 0 && m->video_tracks.at(0).infinite_length && m->audio_tracks.size() == 0) {
-          g.out = g.in + 100;
+          double length = qFloor(QTime(0,0).secsTo(olive::CurrentConfig.default_image_duration) * seq->frame_rate);
+          g.out = g.in + length;
         } else {
           long length = m->get_length_in_frames(seq->frame_rate);
           g.out = entry_point + length - default_clip_in;


### PR DESCRIPTION
This adds a setting in the preferences window for setting the default duration of an image, instead of using  the hardcoded '100' value.