### PR TITLE
Don't render TextEffect when size is less than or equal to 0

### DIFF
--- a/effects/internal/texteffect.cpp
+++ b/effects/internal/texteffect.cpp
@@ -160,6 +160,9 @@ void TextEffect::redraw(double timecode) {
   bkg.setAlpha(0);
   img.fill(bkg);
 
+  if (size_val->GetDoubleAt(timecode) <= 0)
+      return;
+
   QPainter p(&img);
   p.setRenderHint(QPainter::Antialiasing);
   int padding = qRound(padding_field->GetDoubleAt(timecode));


### PR DESCRIPTION
Previously, setting TextEffect size to 0 would cause a warning
`[WARNING] QFont::setPointSize: Point size <= 0 (0), must be greater than 0`
and could result in unexpected behavior.
This disables rendering for TextEffect with size smaller or equal to 0 completely. It should fix issue #870.