### PR TITLE
Fixes #871 - off-by-one error in OCIO look UI

### DIFF
--- a/dialogs/preferencesdialog.cpp
+++ b/dialogs/preferencesdialog.cpp
@@ -220,7 +220,8 @@ void PreferencesDialog::populate_ocio_menus(OCIO::ConstConfigRcPtr config)
       ocio_look->addItem(look, look);
 
       if (look == olive::config.ocio_look) {
-        ocio_look->setCurrentIndex(i);
+        // +1 to take "(None)" into account
+        ocio_look->setCurrentIndex(i+1);
       }
     }
 


### PR DESCRIPTION
This should address the problem described in #871.

The counter variable `i` is reused to set the current index, but it is used to iterate over actual looks in the range 0..numLooks, whereas the first entry of the dropdown menu is the artificial entry *(None)*.