### PR TITLE
Update coefficients from busted up REC.601

### DIFF
--- a/effects/internal/despill.frag
+++ b/effects/internal/despill.frag
@@ -1,0 +1,59 @@
+/***
+    Despill - for cleaning up keying residue.
+    Implementation by unfa for Olive-Editor Community
+***/
+
+uniform sampler2D tex;
+varying vec2 uTexCoord;
+uniform vec2 resolution;
+uniform int channel;
+
+const vec2 renderScale = vec2(1,1);
+
+void main(void)
+{
+    vec2 uv = gl_FragCoord.xy/resolution.xy;
+
+    vec4 col = texture2D(tex, uv);
+    
+    // separate channels
+    
+    float r = col.r;
+    float g = col.g;
+    float b = col.b;
+    float a = col.a;
+    
+    // Select despilled channel: 0 = RED; 1 = GREEN; 2 = BLUE;
+    
+    if (channel == 0) // RED
+    { 
+        // replace new green channel by avaraging between existing red and blue channels
+        float r2 = (g + b) * 0.5;
+        
+        // now composite the original and new gree channel using the "darken" mode
+        r = min(r, r2);
+    }
+    
+    if (channel == 1) // GREEN
+    { 
+        // replace new green channel by avaraging between existing red and blue channels
+        float g2 = (r + b) * 0.5;
+        
+        // now composite the original and new gree channel using the "darken" mode
+        g = min(g, g2);
+    }
+    
+    if (channel == 2) // BLUE
+    { 
+        // replace new green channel by avaraging between existing red and blue channels
+        float b2 = (r + g) * 0.5;
+        
+        // now composite the original and new gree channel using the "darken" mode
+        b = min(b, b2);
+    }
+        
+
+    // and return the result
+
+    gl_FragColor = vec4(r, g, b, a);
+}

--- a/effects/internal/despill.frag
+++ b/effects/internal/despill.frag
@@ -1,6 +1,6 @@
 /***
     Despill - for cleaning up keying residue.
-    Implementation by unfa for Olive-Editor Community
+    Written by unfa for Olive Video Editor.
 ***/
 
 uniform sampler2D tex;

--- a/effects/internal/despill.xml
+++ b/effects/internal/despill.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<effect name="Despill" category="Keying">
+    <row name="Channel">
+		<field type="combo" default="1" id="channel">
+			<option>Red</option>
+			<option>Green</option>
+			<option>Blue</option>
+		</field>
+	</row>
+        <shader vert="../COMMON/common.vert" frag="despill.frag"/>
+</effect>

--- a/effects/shaders/chromakey.frag
+++ b/effects/shaders/chromakey.frag
@@ -22,7 +22,7 @@ float rgb2y (vec3 c) {
 // 0.2126 R, 0.7152 G, and 0.722 B. Easy change.
 // The coefficients for YCbCr are calculated off of the
 // REC.709 values.
-	return (0.2126*c.r + 0.7152*c.g + 0.0.722*c.b);
+	return (0.2126*c.r + 0.7152*c.g + 0.0722*c.b);
 } 
  
 float rgb2cb (vec3 c) { 

--- a/effects/shaders/chromakey.frag
+++ b/effects/shaders/chromakey.frag
@@ -15,17 +15,24 @@ uniform int mode;
  
 float rgb2y (vec3 c) { 
 	/*a utility function to convert colors in RGB into YCbCr*/ 
-	return (0.299*c.r + 0.587*c.g + 0.114*c.b);
+
+// This isn’t colour managed and is a huge mess, but in the
+// short term, using correct weights will give significantly
+// more ideal results. The correct weights for REC.709 are
+// 0.2126 R, 0.7152 G, and 0.722 B. Easy change.
+// The coefficients for YCbCr are calculated off of the
+// REC.709 values.
+	return (0.2126*c.r + 0.7152*c.g + 0.0.722*c.b);
 } 
  
 float rgb2cb (vec3 c) { 
 	/*a utility function to convert colors in RGB into YCbCr*/ 
-	return (0.5 + -0.168736*c.r - 0.331264*c.g + 0.5*c.b);
+	return (0.5 + -0.1145721061*c.r - 0.3854278939*c.g + 0.5*c.b);
 } 
  
 float rgb2cr (vec3 c) { 
 	/*a utility function to convert colors in RGB into YCbCr*/ 
-	return (0.5 + 0.5*c.r - 0.418688*c.g - 0.081312*c.b);
+	return (0.5 + 0.5*c.r - 0.4541529083*c.g - 0.0458470917*c.b);
 } 
  
 float colorclose(float Cb_p,float Cr_p,float Cb_key,float Cr_key,float tola,float tolb) { 


### PR DESCRIPTION
The Chromakey fragment shader is a complete mess, isn't colour managed, and
likely a terrible choice of colour encoding model for keying work, but I've updated
it anyways.

The existing coefficients are assuming the RGB colourspace as being the rather
batshit loopy REC.601 definition. This patch should update it to use the assumed
input of REC.709, as well as change the YCbCr values for REC.709 input.

No promises...