### PR TITLE
Remove makeCurrent() call that causes no current context

### DIFF
--- a/ui/viewerwidget.cpp
+++ b/ui/viewerwidget.cpp
@@ -545,8 +545,6 @@ void ViewerWidget::paintGL() {
 
     tex_lock->lock();
 
-    makeCurrent();
-
     // clear to solid black
     glClearColor(0.0, 0.0, 0.0, 0.0);
     glClear(GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
"If surface is 0 this is equivalent to calling `doneCurrent()`. [...] This results in no context being current in the current thread."

For me the `makeCurrent()` call led to the "Media Viewer" and "Sequence Viewer" not rendering anything other than solid black.

See for more details: <https://github.com/olive-editor/olive/issues/892>