### PR TITLE
Update coefficients to use REC.709

### DIFF
--- a/effects/shaders/chromakey.frag
+++ b/effects/shaders/chromakey.frag
@@ -12,22 +12,26 @@ uniform float tola;
 uniform float tolb;
 uniform bool opt;
 uniform int mode;
- 
-float rgb2y (vec3 c) { 
-	/*a utility function to convert colors in RGB into YCbCr*/ 
-	return (0.299*c.r + 0.587*c.g + 0.114*c.b);
-} 
- 
+
+// This isn’t colour managed and is a huge mess, but in the
+// short term, using correct weights will give significantly
+// more ideal results. The correct weights for REC.709 are
+// 0.2126 R, 0.7152 G, and 0.722 B. Easy change.
+// The coefficients for YCbCr are calculated off of the
+// REC.709 values.
+	return (0.2126*c.r + 0.7152*c.g + 0.0722*c.b);
+}
+
 float rgb2cb (vec3 c) { 
 	/*a utility function to convert colors in RGB into YCbCr*/ 
-	return (0.5 + -0.168736*c.r - 0.331264*c.g + 0.5*c.b);
-} 
- 
+	return (0.5 + -0.1145721061*c.r - 0.3854278939*c.g + 0.5*c.b);
+}
+
 float rgb2cr (vec3 c) { 
 	/*a utility function to convert colors in RGB into YCbCr*/ 
-	return (0.5 + 0.5*c.r - 0.418688*c.g - 0.081312*c.b);
-} 
- 
+	return (0.5 + 0.5*c.r - 0.4541529083*c.g - 0.0458470917*c.b);
+}
+
 float colorclose(float Cb_p,float Cr_p,float Cb_key,float Cr_key,float tola,float tolb) { 
 	/*decides if a color is close to the specified hue*/ 
 	float temp = sqrt(((Cb_key-Cb_p)*(Cb_key-Cb_p))+((Cr_key-Cr_p)*(Cr_key-Cr_p)));
@@ -35,7 +39,7 @@ float colorclose(float Cb_p,float Cr_p,float Cb_key,float Cr_key,float tola,floa
 	if (temp < tolb) {return ((temp-tola)/(tolb-tola));} 
 	return (1.0); 
 }
- 
+
 void main(void) {
 	float cb_key = rgb2cb(key_color);
 	float cr_key = rgb2cr(key_color);


### PR DESCRIPTION
While still not colour managed, and grossly assuming REC.709
display referred buffers, the effect as it currently stands can be
improved to use the proper coefficients for REC.709, as opposed
to legacy REC.601. Ideally there'd be a flag somewhere to flip between
the two coefficient sets. It also assumes "full range" data, which is also
complex given that there are three variants of ranges available.