### PR TITLE
suggest: Event based design

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -32,6 +32,7 @@ add_subdirectory(tool)
 add_subdirectory(ui)
 add_subdirectory(widget)
 add_subdirectory(window)
+add_subdirectory(platform)
 
 set(OLIVE_TARGET "olive-editor")
 if(APPLE)

--- a/app/core.cpp
+++ b/app/core.cpp
@@ -36,6 +36,8 @@
 #include "ui/style/style.h"
 #include "widget/menu/menushared.h"
 
+#include "platform/theme/themeservice-impl.h"
+
 Core olive::core;
 
 Core::Core() :
@@ -73,6 +75,9 @@ void Core::Start()
   if (!args.isEmpty()) {
     startup_project_ = args.first();
   }
+
+  // Initialize Services
+  olive::ThemeService::Initialize();
 
 
 

--- a/app/panel/timeline/timeline.cpp
+++ b/app/panel/timeline/timeline.cpp
@@ -20,9 +20,30 @@
 
 #include "timeline.h"
 
+#include "platform/theme/themeservice-impl.h"
+#include "widget/timeline/timelinewidget.h"
+#include "project/sequence/sequence.h"
+#include "project/sequence/track.h"
+#include "project/sequence/clip.h"
+
+#include <iostream>
+
 TimelinePanel::TimelinePanel(QWidget *parent) :
   PanelWidget(parent)
 {
+  // Create Sequence mock data
+  auto sequence = new olive::Sequence();
+  sequence->addTrack();
+  auto track1 = sequence->addTrack();
+  auto track2 = sequence->addTrack();
+  track1->addClip(new olive::Clip(30, 150));
+  track2->addClip(new olive::Clip(120, 260));
+
+  auto widget = new olive::TimelineWidget(this, olive::ThemeService::instance());
+  widget->setSequence(sequence);
+
+  setWidget(widget);
+
   Retranslate();
 }
 

--- a/app/platform/CMakeLists.txt
+++ b/app/platform/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_subdirectory(theme)
+
+set(OLIVE_SOURCES
+  ${OLIVE_SOURCES}
+  PARENT_SCOPE
+)

--- a/app/platform/theme/CMakeLists.txt
+++ b/app/platform/theme/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(OLIVE_SOURCES
+  ${OLIVE_SOURCES}
+  platform/theme/theme.h
+  platform/theme/themeservice.h
+  platform/theme/themeservice-impl.h
+  platform/theme/themeservice-impl.cpp
+  PARENT_SCOPE
+)

--- a/app/platform/theme/theme.h
+++ b/app/platform/theme/theme.h
@@ -1,0 +1,63 @@
+#ifndef _OLIVE_THEME_H_
+#define _OLIVE_THEME_H_
+
+#include <string>
+#include <QColor>
+
+using namespace std;
+
+namespace olive {
+
+class Theme {
+
+private:
+  QColor primaryColor_;
+  QColor secondaryColor_;
+  QColor surfaceColor_;
+  QColor surfaceDarkColor_;
+  QColor surfaceBrightColor_;
+  QColor surfaceTextColor_;
+  QColor surfaceContrastColor_;
+
+
+public:
+  Theme(
+    QColor primaryColor,
+    QColor secondaryColor,
+    QColor surfaceColor,
+    QColor surfaceDarkColor,
+    QColor surfaceBrightColor,
+    QColor surfaceTextColor,
+    QColor surfaceContrastColor) : 
+    primaryColor_(primaryColor),
+    secondaryColor_(secondaryColor),
+    surfaceColor_(surfaceColor),
+    surfaceDarkColor_(surfaceDarkColor),
+    surfaceBrightColor_(surfaceBrightColor),
+    surfaceTextColor_(surfaceTextColor),
+    surfaceContrastColor_(surfaceContrastColor) {
+  }
+
+  Theme(Theme const& rhs) : 
+    primaryColor_(rhs.primaryColor()),
+    secondaryColor_(rhs.secondaryColor()),
+    surfaceColor_(rhs.surfaceColor()),
+    surfaceDarkColor_(rhs.surfaceDarkColor()),
+    surfaceBrightColor_(rhs.surfaceBrightColor()),
+    surfaceTextColor_(rhs.surfaceTextColor()),
+    surfaceContrastColor_(rhs.surfaceContrastColor()) {
+  }
+
+  inline const QColor& primaryColor() const { return primaryColor_; }
+  inline const QColor& secondaryColor() const { return secondaryColor_; }
+  inline const QColor& surfaceColor() const { return surfaceColor_; }
+  inline const QColor& surfaceDarkColor() const { return surfaceDarkColor_; }
+  inline const QColor& surfaceBrightColor() const { return surfaceBrightColor_; }
+  inline const QColor& surfaceTextColor() const { return surfaceTextColor_; }
+  inline const QColor& surfaceContrastColor() const { return surfaceContrastColor_; }
+
+};
+
+}
+
+#endif

--- a/app/platform/theme/themeservice-impl.cpp
+++ b/app/platform/theme/themeservice-impl.cpp
@@ -1,0 +1,34 @@
+#include "platform/theme/themeservice-impl.h"
+
+#include <QColor>
+
+namespace olive {
+
+ThemeService* ThemeService::instance_ = nullptr;
+
+void ThemeService::Initialize() {
+  ThemeService::instance_ = new ThemeService();
+}
+
+ThemeService::ThemeService() :
+  theme_(
+    QColor("#28aaff"),
+    QColor("#ff5040"),
+    QColor("#212624"),
+    QColor("#1a1a1a"),
+    QColor("#616161"),
+    QColor("#BDBDBD"),
+    QColor("#BDBDBD")) {
+
+}
+
+void ThemeService::setTheme(Theme const& theme) {
+  theme_ = theme;
+  emit onDidChangeTheme(theme_);
+}
+
+const Theme& ThemeService::getTheme() const {
+  return theme_;
+}
+
+}

--- a/app/platform/theme/themeservice-impl.h
+++ b/app/platform/theme/themeservice-impl.h
@@ -1,0 +1,31 @@
+#ifndef _OLIVE_ITHEME_SERVICE_IMPL_H_
+#define _OLIVE_ITHEME_SERVICE_IMPL_H_
+
+#include "platform/theme/themeservice.h"
+
+namespace olive {
+
+class ThemeService : public IThemeService {
+
+private:
+  static ThemeService* instance_;
+
+  Theme theme_;
+
+protected:
+  ThemeService();
+
+public:
+  static void Initialize();
+  inline static ThemeService* const instance() {
+    return ThemeService::instance_;
+  }
+
+  void setTheme(Theme const& theme) override;
+  const Theme& getTheme() const override;
+
+};
+
+}
+
+#endif

--- a/app/platform/theme/themeservice.h
+++ b/app/platform/theme/themeservice.h
@@ -1,0 +1,26 @@
+#ifndef _OLIVE_ITHEME_SERVICE_H_
+#define _OLIVE_ITHEME_SERVICE_H_
+
+#include <QObject>
+#include "platform/theme/theme.h"
+
+namespace olive {
+
+class IThemeService : public QObject {
+  Q_OBJECT
+
+protected:
+  inline IThemeService() {}
+
+public:
+  virtual void setTheme(Theme const& theme) = 0;
+  virtual const Theme& getTheme() const = 0;
+
+signals:
+  void onDidChangeTheme(Theme const& theme) const;
+
+};
+
+}
+
+#endif

--- a/app/project/CMakeLists.txt
+++ b/app/project/CMakeLists.txt
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 add_subdirectory(item)
+add_subdirectory(sequence)
 
 set(OLIVE_SOURCES
   ${OLIVE_SOURCES}

--- a/app/project/sequence/CMakeLists.txt
+++ b/app/project/sequence/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(OLIVE_SOURCES
+  ${OLIVE_SOURCES}
+  project/sequence/sequence.h
+  project/sequence/sequence.cpp
+  project/sequence/track.h
+  project/sequence/track.cpp
+  project/sequence/clip.h
+  project/sequence/clip.cpp
+  PARENT_SCOPE
+)

--- a/app/project/sequence/clip.cpp
+++ b/app/project/sequence/clip.cpp
@@ -1,0 +1,30 @@
+#include "project/sequence/clip.h"
+
+namespace olive {
+
+namespace {
+  int __next_id = 0;
+}
+
+Clip::Clip(int in, int out):
+  in_(in), out_(out), id_(__next_id++) {
+
+}
+
+void Clip::setTime(int in, int out) {
+  int oldIn = in_;
+  int oldOut = out_;
+  in_ = in;
+  out_ = out;
+  emit onDidChangeTime(oldIn, oldOut);
+}
+
+int Clip::in() const { return in_; }
+int Clip::out() const { return out_; }
+int Clip::id() const { return id_; }
+
+bool Clip::operator<(const Clip& rhs) const {
+  return id_ < rhs.id_;
+}
+
+}

--- a/app/project/sequence/clip.h
+++ b/app/project/sequence/clip.h
@@ -1,0 +1,35 @@
+#ifndef _OLIVE_CLIP_H_
+#define _OLIVE_CLIP_H_
+
+#include <QObject>
+
+namespace olive {
+
+class Clip : public QObject {
+  Q_OBJECT
+
+private:
+  int id_;
+  int clip_in_;
+  int in_;
+  int out_;
+
+signals:
+  void onDidChangeTime(int oldIn, int oldOut);
+
+public:
+  Clip(int in, int out);
+
+  void setTime(int in, int out);
+
+  int in() const;
+  int out() const;
+  int id() const;
+
+  bool operator<(const Clip& rhs) const;
+
+};
+
+}
+
+#endif

--- a/app/project/sequence/sequence.cpp
+++ b/app/project/sequence/sequence.cpp
@@ -1,0 +1,53 @@
+#include "project/sequence/sequence.h"
+
+namespace olive {
+
+Sequence::Sequence() {
+
+}
+
+Track* const Sequence::addTrack() {
+  return doAddTrack();
+}
+
+Track* const Sequence::doAddTrack() {
+  // Stack allocation would be enough but leave it now
+  Track* track = new Track();
+  tracks_.emplace_back(track);
+  onDidAddTrack(track, tracks_.size() - 1);
+  return track;
+}
+
+void Sequence::removeTrackAt(int index) {
+  doRemoveTrackAt(index);
+}
+
+void Sequence::doRemoveTrackAt(int index) {
+  if (index < 0 || tracks_.size() >= index) return;
+  Track* track = tracks_[index];
+  onWillRemoveTrack(track, index);
+  tracks_.erase(tracks_.begin() + index);
+}
+
+Track* const Sequence::getTrackAt(int index) {
+  if (index < 0 || tracks_.size() >= index) return nullptr;
+  return tracks_[index];
+}
+
+void Sequence::setDuration(int value) {
+  duration_ = value;
+}
+
+int Sequence::duration() const {
+  return duration_;
+}
+
+const std::vector<Track*>& Sequence::tracks() {
+  return tracks_;
+}
+
+int Sequence::track_size() const {
+  return tracks_.size();
+}
+
+}

--- a/app/project/sequence/sequence.h
+++ b/app/project/sequence/sequence.h
@@ -1,0 +1,42 @@
+#ifndef _OLIVE_SEQUENCE_H_
+#define _OLIVE_SEQUENCE_H_
+
+#include <QObject>
+#include <vector>
+#include "project/sequence/track.h"
+
+namespace olive {
+
+class Sequence : public QObject {
+  Q_OBJECT
+
+private:
+  int duration_;
+
+  std::vector<Track*> tracks_;
+
+  Track* const doAddTrack();
+  void doRemoveTrackAt(int index);
+
+public:
+  Sequence();
+
+  Track* const addTrack();
+  void removeTrackAt(int index);
+  Track* const getTrackAt(int index);
+
+  void setDuration(int value);
+  int duration() const;
+
+  const std::vector<Track*>& tracks();
+  int track_size() const;
+
+signals:
+  void onDidAddTrack(Track* const track, int index);
+  void onWillRemoveTrack(Track* const track, int index);
+
+};
+
+}
+
+#endif

--- a/app/project/sequence/track.cpp
+++ b/app/project/sequence/track.cpp
@@ -1,0 +1,37 @@
+#include "project/sequence/track.h"
+
+namespace olive {
+
+Track::Track() {
+
+}
+
+void Track::addClip(Clip* const clip) {
+  doAddClip(clip);
+}
+
+void Track::doAddClip(Clip* const clip) {
+  if (hasClip(clip)) return;
+  clips_.insert(clip);
+  onDidAddClip(clip);
+}
+
+void Track::removeClip(Clip* const clip) {
+  doRemoveClip(clip);
+}
+
+void Track::doRemoveClip(Clip* const clip) {
+  if (!hasClip(clip)) return;
+  onWillRemoveClip(clip);
+  clips_.erase(clip);
+}
+
+bool Track::hasClip(Clip* const clip) const {
+  return clips_.count(clip) > 0;
+}
+
+const std::set<Clip*>& Track::clips() {
+  return clips_;
+}
+
+}

--- a/app/project/sequence/track.h
+++ b/app/project/sequence/track.h
@@ -1,0 +1,36 @@
+#ifndef _OLIVE_TRACK_H_
+#define _OLIVE_TRACK_H_
+
+#include <set>
+#include <QObject>
+#include "project/sequence/clip.h"
+
+namespace olive {
+
+class Track : public QObject {
+  Q_OBJECT
+
+private:
+  std::set<Clip*> clips_;
+  
+  void doAddClip(Clip* const clip);
+  void doRemoveClip(Clip* const clip);
+
+public:
+  Track();
+
+  void addClip(Clip* const clip);
+  void removeClip(Clip* const clip);
+  bool hasClip(Clip* const clip) const;
+
+  const std::set<Clip*>& clips();
+
+signals:
+  void onDidAddClip(Clip* const clip);
+  void onWillRemoveClip(Clip* const clip);
+
+};
+
+}
+
+#endif

--- a/app/ui/style/style.cpp
+++ b/app/ui/style/style.cpp
@@ -23,6 +23,7 @@
 #include <QApplication>
 #include <QPalette>
 #include <QStyleFactory>
+#include <QStyle>
 
 void olive::style::AppSetDefault()
 {

--- a/app/widget/CMakeLists.txt
+++ b/app/widget/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(projecttoolbar)
 add_subdirectory(taskview)
 add_subdirectory(toolbar)
 add_subdirectory(viewer)
+add_subdirectory(timeline)
 
 set(OLIVE_SOURCES
   ${OLIVE_SOURCES}

--- a/app/widget/timeline/CMakeLists.txt
+++ b/app/widget/timeline/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(OLIVE_SOURCES
+  ${OLIVE_SOURCES}
+  widget/timeline/timelinewidget.h
+  widget/timeline/timelinewidget.cpp
+  widget/timeline/sequencescrollview.h
+  widget/timeline/sequencescrollview.cpp
+  widget/timeline/sequenceview.h
+  widget/timeline/sequenceview.cpp
+  widget/timeline/trackview.h
+  widget/timeline/trackview.cpp
+  widget/timeline/clipview.h
+  widget/timeline/clipview.cpp
+  PARENT_SCOPE
+)

--- a/app/widget/timeline/clipview.cpp
+++ b/app/widget/timeline/clipview.cpp
@@ -1,0 +1,72 @@
+#include "widget/timeline/clipview.h"
+
+#include <QPainter>
+
+#include "project/sequence/clip.h"
+#include "widget/timeline/sequencescrollview.h"
+#include "platform/theme/themeservice.h"
+
+#include <iostream>
+
+namespace olive {
+
+TimelineWidgetClipView::TimelineWidgetClipView(
+  QWidget* const parent,
+  Clip* const clip,
+  SequenceScrollView* const scrollView,
+  IThemeService* const theme_service) : 
+  QWidget(parent), clip_(clip), focused_(false), scrollView_(scrollView), theme_service_(theme_service) {
+
+  updateView();
+  QObject::connect(clip, &Clip::onDidChangeTime, this, [this](int oldStart, int oldEnd) {
+    updateView();
+  });
+  QObject::connect(scrollView, &SequenceScrollView::onDidUpdate, this, [this]() {
+    updateView();
+  });
+}
+
+void TimelineWidgetClipView::mousePressEvent(QMouseEvent* event) {
+  focus();
+}
+
+void TimelineWidgetClipView::focus() {
+  focused_ = true;
+  updateView();
+  emit onDidFocus();
+}
+
+void TimelineWidgetClipView::blur() {
+  focused_ = false;
+  updateView();
+  emit onDidBlur();
+}
+
+bool TimelineWidgetClipView::focused() const {
+  return focused_;
+}
+
+void TimelineWidgetClipView::updateView() {
+  int left = scrollView_->getPositionRelativeToView(clip_->in());
+  int right = scrollView_->getPositionRelativeToView(clip_->out());
+  move(left, 0);
+  resize(right - left, height());
+  repaint();
+}
+
+void TimelineWidgetClipView::resizeEvent(QResizeEvent* event) {
+  updateView();
+
+  QWidget::resizeEvent(event);
+}
+
+void TimelineWidgetClipView::paintEvent(QPaintEvent* event) {
+  auto& theme = theme_service_->getTheme();
+  QPainter p(this);
+  p.fillRect(0, 0, width(), height(),
+    focused_ ? theme.secondaryColor() : theme.primaryColor());
+  
+  QWidget::paintEvent(event);
+}
+
+}

--- a/app/widget/timeline/clipview.h
+++ b/app/widget/timeline/clipview.h
@@ -1,0 +1,50 @@
+#ifndef _OLIVE_TIMELINE_WIDGET_CLIP_VIEW_H_
+#define _OLIVE_TIMELINE_WIDGET_CLIP_VIEW_H_
+
+#include <QWidget>
+
+namespace olive {
+
+class Clip;
+class SequenceScrollView;
+class IThemeService;
+
+class TimelineWidgetClipView : public QWidget {
+  Q_OBJECT
+
+private:
+  Clip* clip_;
+  SequenceScrollView* scrollView_;
+
+  bool focused_;
+
+  IThemeService* theme_service_;
+
+  void updateView();
+
+protected:
+  void mousePressEvent(QMouseEvent * event) override;
+
+  void resizeEvent(QResizeEvent* event) override;
+  void paintEvent(QPaintEvent* event) override;
+
+public:
+  TimelineWidgetClipView(
+    QWidget* const parent,
+    Clip* const clip,
+    SequenceScrollView* const scrollView,
+    IThemeService* const themeService);
+
+  void focus();
+  void blur();
+  bool focused() const;
+
+signals:
+  void onDidFocus();
+  void onDidBlur();
+
+};
+
+}
+
+#endif

--- a/app/widget/timeline/sequencescrollview.cpp
+++ b/app/widget/timeline/sequencescrollview.cpp
@@ -1,0 +1,40 @@
+#include "widget/timeline/sequencescrollview.h"
+
+#include "project/sequence/sequence.h"
+
+namespace olive {
+
+SequenceScrollView::SequenceScrollView(
+  QWidget* const parent,
+  Sequence* const sequence) :
+  QWidget(parent),
+  sequence_(sequence) {
+
+  update();
+}
+
+void SequenceScrollView::update() {
+  // Todo : implement
+  startTime_ = 0;
+  endTime_ = sequence_->duration();
+  pxPerFrame_ = 1.0f;
+  emit onDidUpdate();
+}
+
+int SequenceScrollView::getTimeRelativeToView(int pixel) const {
+  return roundf(startTime_ + pixel / pxPerFrame_);
+}
+
+int SequenceScrollView::getTimeAmountRelativeToView(int pixel) const {
+  return roundf(pixel / pxPerFrame_);
+}
+
+int SequenceScrollView::getPositionRelativeToView(int time) const {
+  return floorf((time - startTime_) * pxPerFrame_);
+}
+
+int SequenceScrollView::getPixelAmountRelativeToView(int time) const {
+  return roundf(time * pxPerFrame_);
+}
+
+}

--- a/app/widget/timeline/sequencescrollview.h
+++ b/app/widget/timeline/sequencescrollview.h
@@ -1,0 +1,53 @@
+#ifndef _OLIVE_SEQUENCE_SCROLL_VIEW_H_
+#define _OLIVE_SEQUENCE_SCROLL_VIEW_H_
+
+#include <QWidget>
+
+namespace olive {
+
+class Sequence;
+
+class SequenceScrollView : public QWidget {
+  Q_OBJECT
+
+private:
+  Sequence* sequence_;
+  SequenceScrollView* scrollView_;
+
+  int startTime_;
+  int endTime_;
+  float pxPerFrame_;
+  int width_;
+  float unitFrameTime_;
+  float unitWidth_;
+
+  float scrollStart_;
+  float scrollEnd_;
+
+  void update();
+
+public:
+  SequenceScrollView(
+    QWidget* const parent,
+    Sequence* const sequence);
+
+  int getTimeRelativeToView(int pixel) const;
+  int getTimeAmountRelativeToView(int pixel) const;
+  int getPositionRelativeToView(int time) const;
+  int getPixelAmountRelativeToView(int time) const;
+
+  int startTime() const;
+  int endTime() const;
+  int width() const;
+  float pxPerFrame() const;
+  float unitFrameTime() const;
+  float unitWidth() const;
+
+signals:
+  void onDidUpdate();
+
+};
+
+}
+
+#endif

--- a/app/widget/timeline/sequenceview.cpp
+++ b/app/widget/timeline/sequenceview.cpp
@@ -1,0 +1,65 @@
+#include "widget/timeline/sequenceview.h"
+
+#include "project/sequence/track.h"
+#include "project/sequence/sequence.h"
+#include "widget/timeline/trackview.h"
+#include "widget/timeline/sequencescrollview.h"
+#include "platform/theme/themeservice.h"
+
+#include <QPainter>
+#include <iostream>
+
+namespace olive {
+
+TimelineWidgetSequenceView::TimelineWidgetSequenceView(
+  QWidget* parent,
+  Sequence* const sequence,
+  SequenceScrollView* const scrollView,
+  IThemeService* const themeService) :
+  QWidget(parent),
+  sequence_(sequence),
+  scrollView_(scrollView),
+  theme_service_(themeService) {
+
+  auto tracks = sequence->tracks();
+  for (int i = 0; i < tracks.size(); i ++) handleDidAddTrack(tracks[i], i);
+  QObject::connect(sequence, &Sequence::onDidAddTrack, this, &TimelineWidgetSequenceView::handleDidAddTrack);
+}
+
+void TimelineWidgetSequenceView::handleDidAddTrack(Track* const track, int index) {
+  // Create and add Track view
+  std::cout << "Add Track View\n";
+  auto view = new TimelineWidgetTrackView(this, track, scrollView_, theme_service_);
+  track_views_.emplace(track_views_.begin() + index, view);
+}
+
+void TimelineWidgetSequenceView::handleWillRemoveTrack(Track* const track, int index) {
+  // Delete Track view
+  track_views_.erase(track_views_.begin() + index);
+}
+
+void TimelineWidgetSequenceView::resizeEvent(QResizeEvent* event) {
+  for (int i = 0; i < track_views_.size(); i ++) {
+    auto& track_view = track_views_[i];
+    track_view->resize(width(), 29);
+    track_view->move(0, i * 30);
+  }
+
+  QWidget::resizeEvent(event);
+}
+
+void TimelineWidgetSequenceView::paintEvent(QPaintEvent* event) {
+  auto& theme = theme_service_->getTheme();
+  QPainter p(this);
+  p.setPen(theme.surfaceBrightColor());
+  // Draw track border
+  p.drawLine(0, 0, width(), 0);
+  for (int i = 0; i < track_views_.size(); i ++) {
+    auto& track_view = track_views_[i];
+    p.drawLine(0, (i + 1) * 30 - 1, width(), (i + 1) * 30 - 1);
+  }
+  QWidget::paintEvent(event);
+}
+
+
+}

--- a/app/widget/timeline/sequenceview.h
+++ b/app/widget/timeline/sequenceview.h
@@ -1,0 +1,45 @@
+#ifndef _OLIVE_TIMELINE_WIDGET_SEQUENCE_VIEW_H_
+#define _OLIVE_TIMELINE_WIDGET_SEQUENCE_VIEW_H_
+
+#include <QWidget>
+#include <vector>
+
+namespace olive {
+
+class Track;
+class Sequence;
+class TimelineWidgetTrackView;
+class SequenceScrollView;
+class IThemeService;
+
+class TimelineWidgetSequenceView : public QWidget {
+  Q_OBJECT
+
+private:
+  Sequence* sequence_;
+  SequenceScrollView* scrollView_;
+
+  std::vector<TimelineWidgetTrackView*> track_views_;
+
+  IThemeService* theme_service_;
+  
+private slots:
+  void handleDidAddTrack(Track* const track, int index);
+  void handleWillRemoveTrack(Track* const track, int index);
+
+protected:
+  void resizeEvent(QResizeEvent* event) override;
+  void paintEvent(QPaintEvent* event) override;
+
+public:
+  TimelineWidgetSequenceView(
+    QWidget* parent,
+    Sequence* const sequence,
+    SequenceScrollView* const scrollView,
+    IThemeService* const themeService);
+
+};
+
+}
+
+#endif

--- a/app/widget/timeline/themeablewidget.cpp
+++ b/app/widget/timeline/themeablewidget.cpp
@@ -1,0 +1,22 @@
+#include "widget/timeline/themeablewidget.h"
+
+#include <QPaintEvent>
+#include <QStyleOption>
+#include <QStyle>
+#include <QPainter>
+
+namespace olive {
+
+ThemeableWidget::ThemeableWidget(QWidget* parent, Qt::WindowFlags f) :
+  QWidget(parent, f) {}
+
+void ThemeableWidget::paintEvent(QPaintEvent* event) {
+  QStyleOption opt;
+  opt.init(this);
+  QPainter p(this);
+  style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
+
+  QWidget::paintEvent(event);
+}
+
+}

--- a/app/widget/timeline/themeablewidget.h
+++ b/app/widget/timeline/themeablewidget.h
@@ -1,0 +1,22 @@
+#ifndef _OLIVE_THEMEABLE_WIDGET_H_
+#define _OLIVE_THEMEABLE_WIDGET_H_
+
+#include <Qt>
+#include <QWidget>
+
+namespace olive {
+
+class ThemeableWidget : public QWidget {
+  Q_OBJECT
+
+protected:
+  void ThemeableWidget::paintEvent(QPaintEvent* event);
+
+public:
+  ThemeableWidget(QWidget* parent = (QWidget *)nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+
+};
+
+}
+
+#endif

--- a/app/widget/timeline/timelinewidget.cpp
+++ b/app/widget/timeline/timelinewidget.cpp
@@ -1,0 +1,58 @@
+#include "widget/timeline/timelinewidget.h"
+
+#include <QStyle>
+#include <QPainter>
+#include <QStyleOption>
+
+#include "project/sequence/sequence.h"
+#include "widget/timeline/sequencescrollview.h"
+#include "widget/timeline/sequenceview.h"
+#include "platform/theme/themeservice.h"
+#include "widget/panel/panel.h"
+
+#include <iostream>
+
+namespace olive {
+
+TimelineWidget::TimelineWidget(
+  QWidget* parent,
+  IThemeService* const theme_service) :
+  QWidget(parent),
+  sequence_(nullptr),
+  sequence_view_(nullptr),
+  sequence_scroll_view_(nullptr),
+  theme_service_(theme_service) {
+
+}
+
+void TimelineWidget::resizeEvent(QResizeEvent* event) {
+  if (sequence_scroll_view_ != nullptr) {
+    sequence_scroll_view_->resize(width(), height());
+    sequence_view_->resize(width(), height());
+  }
+
+  QWidget::resizeEvent(event);
+}
+
+void TimelineWidget::paintEvent(QPaintEvent* event) {
+  QStyleOption opt;
+  opt.init(this);
+  QPainter p(this);
+  style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
+
+  QWidget::paintEvent(event);
+}
+
+void TimelineWidget::setSequence(Sequence* sequence) {
+  if (sequence_view_ != nullptr) {
+    sequence_ = nullptr;
+    delete sequence_view_;
+    delete sequence_scroll_view_;
+  }
+  if (sequence == nullptr) return;
+  sequence_ = sequence_;
+  sequence_scroll_view_ = new SequenceScrollView(this, sequence);
+  sequence_view_ = new TimelineWidgetSequenceView(sequence_scroll_view_, sequence, sequence_scroll_view_, theme_service_);
+}
+
+}

--- a/app/widget/timeline/timelinewidget.h
+++ b/app/widget/timeline/timelinewidget.h
@@ -1,0 +1,36 @@
+#ifndef _OLIVE_TIMELINE_WIDGET_H_
+#define _OLIVE_TIMELINE_WIDGET_H_
+
+#include <QWidget>
+
+namespace olive {
+
+class Sequence;
+class SequenceScrollView;
+class TimelineWidgetSequenceView;
+class IThemeService;
+
+class TimelineWidget : public QWidget {
+  Q_OBJECT;
+
+private:
+  IThemeService* theme_service_;
+
+  Sequence* sequence_;
+  SequenceScrollView* sequence_scroll_view_;
+  TimelineWidgetSequenceView* sequence_view_;
+
+protected:
+  void resizeEvent(QResizeEvent* event) override;
+  void paintEvent(QPaintEvent* event) override;
+
+public:
+  TimelineWidget(QWidget* parent, IThemeService* const themeService);
+
+  void setSequence(Sequence* sequence);
+
+};
+
+}
+
+#endif

--- a/app/widget/timeline/trackview.cpp
+++ b/app/widget/timeline/trackview.cpp
@@ -1,0 +1,47 @@
+#include "widget/timeline/trackview.h"
+
+#include <QPainter>
+
+#include "project/sequence/track.h"
+#include "project/sequence/clip.h"
+#include "platform/theme/themeservice.h"
+#include "widget/timeline/sequencescrollview.h"
+
+#include <iostream>
+
+namespace olive {
+
+TimelineWidgetTrackView::TimelineWidgetTrackView(
+  QWidget* const parent,
+  Track* const track,
+  SequenceScrollView* const scrollView,
+  IThemeService* const theme_service) : 
+  QWidget(parent), track_(track), scrollView_(scrollView), theme_service_(theme_service) {
+
+  auto& clips = track->clips();
+  for (auto& clip : clips) handleDidAddClip(clip);
+  QObject::connect(track, &Track::onDidAddClip, this, &TimelineWidgetTrackView::handleDidAddClip);
+  QObject::connect(track, &Track::onWillRemoveClip, this, &TimelineWidgetTrackView::handleWillRemoveClip);
+
+}
+
+void TimelineWidgetTrackView::handleDidAddClip(Clip* const clip) {
+  // Create and add Clip view
+  auto view = new TimelineWidgetClipView(this, clip, scrollView_, theme_service_);
+  clipViews_.emplace(clip->id(), view);
+}
+
+void TimelineWidgetTrackView::handleWillRemoveClip(Clip* const clip) {
+  // Delete Track view
+  clipViews_.erase(clip->id());
+}
+
+void TimelineWidgetTrackView::paintEvent(QPaintEvent* event) {
+  auto& theme = theme_service_->getTheme();
+  QPainter p(this);
+  // p.fillRect(0, 0, width(), height(), theme.primaryColor());
+  
+  QWidget::paintEvent(event);
+}
+
+}

--- a/app/widget/timeline/trackview.h
+++ b/app/widget/timeline/trackview.h
@@ -1,0 +1,51 @@
+#ifndef _OLIVE_TIMELINE_WIDGET_TRACK_VIEW_H_
+#define _OLIVE_TIMELINE_WIDGET_TRACK_VIEW_H_
+
+#include <QWidget>
+#include <set>
+#include "widget/timeline/clipview.h"
+
+namespace olive {
+
+class Track;
+class Clip;
+class SequenceScrollView;
+class IThemeService;
+
+class TimelineWidgetTrackView : public QWidget {
+  Q_OBJECT
+
+private:
+  SequenceScrollView* scrollView_;
+  IThemeService* theme_service_;
+
+  Track* track_;
+
+  std::map<int, TimelineWidgetClipView*> clipViews_;
+
+private slots:
+  void handleDidAddClip(Clip* const track);
+  void handleWillRemoveClip(Clip* const track);
+
+protected:
+  void paintEvent(QPaintEvent* event) override;
+
+public:
+  TimelineWidgetTrackView(
+    QWidget* const parent,
+    Track* const track,
+    SequenceScrollView* const scrollView,
+    IThemeService* const themeService);
+
+  TimelineWidgetClipView* const getClipView(const Clip* const clip);
+
+signals:
+  // These signals are kind of a relay which will be emitted when TimelineWidegtClipView emits `onDid...Clip()`
+  void onDidFocusClip();
+  void onDidFocusBlur();
+
+};
+
+}
+
+#endif


### PR DESCRIPTION
This PR suggests a core design of current rewriting of Olive, especially in how modularize should be done.

First, let's see how directory structure looks like. (.cpp files are omitted for convenience.)
```
.
+-- app
|   +-- platform
|      +-- theme
|         +-- themeservice.h
|         +-- themeservice-impl.h
|   +-- project
|      +-- sequence
|         +-- sequence.h
|         +-- track.h
|         +-- clip.h
|   +-- widget
|      +-- timeline
|         +-- timelinewidget.h
|         +-- sequenceview.h
|         +-- trackview.h
|         +-- clipview.h
```

If you compile it successfully, you can see,
![3](https://user-images.githubusercontent.com/17820596/60395301-857f5a80-9b6c-11e9-902f-8dbb78622212.PNG)


There are three main philosophy
1. **Use event to communicate**
2. **Do not make circular dependency as possible**
3. **Use Service and Dependency Injection**


## **1. Use event to communicate**
Usually Model should not know about View. One common way to achieve it is event based design.
Qt supports a great builtin event system. *Signal and Slot*. See how `Track` utilize it.

**track.h**
```c++
class Track : public QObject {
  Q_OBJECT

private:
  std::set<Clip*> clips_;
  
  void doAddClip(Clip* const clip);
  void doRemoveClip(Clip* const clip);

public:
  Track();

  void addClip(Clip* const clip);
  void removeClip(Clip* const clip);
  bool hasClip(Clip* const clip) const;

  const std::set<Clip*>& clips();

signals:
  void onDidAddClip(Clip* const clip);
  void onWillRemoveClip(Clip* const clip);

};
```

`Track` has two events, `onDidAddClip` and `onWillRemoveClip`. Each event will be emitted when clip is added or will be removed.

**track.cpp**
```c++
void Track::doAddClip(Clip* const clip) {
  if (hasClip(clip)) return;
  clips_.insert(clip);
  onDidAddClip(clip);
}

void Track::doRemoveClip(Clip* const clip) {
  if (!hasClip(clip)) return;
  onWillRemoveClip(clip);
  clips_.erase(clip);
}
```

So everytime `Track` has some changes, the corresponding `signal` will be emitted and it will be consumed in somewhere. For example, `TrackView` can consume these events by,

**trackview.cpp**
```c++
TimelineWidgetTrackView::TimelineWidgetTrackView(
  Track* const track ...
  // Let just omit unrelated things right now.

  auto& clips = track->clips();
  for (auto& clip : clips) handleDidAddClip(clip);
  QObject::connect(track, &Track::onDidAddClip, this, &TimelineWidgetTrackView::handleDidAddClip);
  QObject::connect(track, &Track::onWillRemoveClip, this, &TimelineWidgetTrackView::handleWillRemoveClip);
}

void TimelineWidgetTrackView::handleDidAddClip(Clip* const clip) {
  // Create and add Clip view
  auto view = new TimelineWidgetClipView(this, clip, scrollView_, theme_service_);
  clipViews_.emplace(clip->id(), view);
}

void TimelineWidgetTrackView::handleWillRemoveClip(Clip* const clip) {
  // Delete Clip view
  clipViews_.erase(clip->id());
}
```

`TimelineWidgetTrackView` renders a track as a UI in **Timeline widget**. It listens `Track::onDidAddClip` and `Track::onWillClip` so when tracks are added or removed, Track UIs are also added or removed.

You can use lambda function as `slot` when needed.

Notice that `TimelineWidgetTrackView` is a **View** for `Track` used in **Timeline widget**. If you want to display any model in a UI form, you must create corresponding View to display it and every view related properties should be only there.

## **2. Do not make circular dependency as possible**
This is rather usual one. Circular dependency makes source hard to understand and increases coupling.
Whenever possible, makes them **Top to Bottom**.

For example, in Sequence model,
`Sequence --> Track --> Clip`
`Sequence` knows `Track` and `Clip`.
`Track` knows `Clip`
but `Clip` never knows `Track` and `Sequence`.
`Track` never knows `Sequence`.

## 3. **Use Service and Dependency Injection**
Notice that there's a file named `themeservice.h`
Although it's been a few days I've joined Olive discord channel, One of the request that I've seen many time was about Theme support.
One possible way to implement this is creating a `ThemeService`.
`ThemeService` provides `Theme`.

**themeservice.h**
```c++
class IThemeService : public QObject {
  Q_OBJECT

protected:
  inline IThemeService() {}

public:
  virtual void setTheme(Theme const& theme) = 0;
  virtual const Theme& getTheme() const = 0;

signals:
  void onDidChangeTheme(Theme const& theme) const;

};
```

We can get `Theme` from `ThemeService`. Sometimes theme can get changed. Notice that `ThemeService` has also an event, `onDidChangeTheme`. UIs can listen this event and when theme is changed, they can repaint themselves. For example, in `TimelineWidgetClipView`,

**clipview.cpp**
```c++
TimelineWidgetClipView::TimelineWidgetClipView(
  QWidget* const parent,
  Clip* const clip,
  SequenceScrollView* const scrollView,
  // Provide ThemeService
  IThemeService* const theme_service) : 
  QWidget(parent), clip_(clip), focused_(false), scrollView_(scrollView), theme_service_(theme_service) {
... some codes
}

... some codes

void TimelineWidgetClipView::paintEvent(QPaintEvent* event) {
  // Get current theme
  auto& theme = theme_service_->getTheme();
  QPainter p(this);
  p.fillRect(0, 0, width(), height(),
    // Draw with theme color
    focused_ ? theme.secondaryColor() : theme.primaryColor());
  
  QWidget::paintEvent(event);
}
```

One problem is "**How to provide ThemeService?**"
The simplest way is using *Singleton*. However singleton pattern is usually bad. It makes test hard and increases coupling.
Sometimes `Service locator` is used but it also increase coupling and decreases source readability.
Using DI framework may be the best solution but so far, I haven't found any good DI framework for C++. [Google fruit](https://github.com/google/fruit) is one of them.

There's no go-to solution yet. For the time being, I prefer **Use singleton only when you must need**. (The naming is little awkward so see the source below)

**core.cpp**
```c++
... some codes
  // Initialize ThemeService singleton
  olive::ThemeService::Initialize();
... some codes
```

**timeline.cpp** (pannel/project/timeline)
```c++
TimelinePanel::TimelinePanel(QWidget *parent) :
  PanelWidget(parent)
{
  ... some codes
  auto widget = new olive::TimelineWidget(this, olive::ThemeService::instance());
  setWidget(widget);
  ... some codes
}
```
Notice that `TimelineWidget` depends on `ThemeService` and `ThemeService` instance is being injected. The point is `ThemeService` instance itself comes from `ThemeService::instance()`, which is singleton instance.
But once singleton instance is injected to `TimelineWidget`, `TimelineWidget` can pass `ThemeService` instance without using singleton. For example,

**timelinewidget.cpp**
```cpp
TimelineWidget::TimelineWidget(
  QWidget* parent,
  IThemeService* const theme_service) :
  QWidget(parent),
  sequence_(nullptr),
  sequence_view_(nullptr),
  sequence_scroll_view_(nullptr),
  // Store ThemeService instance as private member
  theme_service_(theme_service) {
}

... some codes

// setSequence creates a `TimelineWidgetSequenceView` which depends on `ThemeService`
void TimelineWidget::setSequence(Sequence* sequence) {
  if (sequence_view_ != nullptr) {
    sequence_ = nullptr;
    delete sequence_view_;
    delete sequence_scroll_view_;
  }
  if (sequence == nullptr) return;
  sequence_ = sequence_;
  sequence_scroll_view_ = new SequenceScrollView(this, sequence);
  // ThemeService instance can be injected since TimelineWidget has theme_service_ as a private member.
  sequence_view_ = new TimelineWidgetSequenceView(sequence_scroll_view_, sequence, sequence_scroll_view_, theme_service_);
}
```

Like `ThemeService`, a specific functions can be provided by using Service pattern. For example, `FileService` can be implemented to manage file system or `TimelineWidgetService` can be implemented to manage which timeline widget is currently focused etc..


### Some small improvements may be considered

1. **namespace guard**
`namespace olive { ...`

2. **[include guard prefix](https://google.github.io/styleguide/cppguide.html#The__define_Guard)**
It is rarely possible but include guard might collide with other libraries
`#ifndef OLIVE_~~~_H_`


Please see the source code for more information.