### PR TITLE
Update olive_es.ts

### DIFF
--- a/ts/olive_es.ts
+++ b/ts/olive_es.ts
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="es_ES">
+<TS version="2.1" language="es">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../dialogs/aboutdialog.cpp" line="49"/>
         <source>Olive is a non-linear video editor. This software is free and protected by the GNU GPL.</source>
-        <translation type="unfinished"></translation>
+        <translation>Olive es un editor de vídeo no lineal. Esta aplicación es gratuita y está protegida bajo la licencia GNU GPL.</translation>
     </message>
     <message>
         <location filename="../dialogs/aboutdialog.cpp" line="51"/>
         <source>Olive Team is obliged to inform users that Olive source code is available for download from its website.</source>
-        <translation type="unfinished"></translation>
+        <translation>El equipo de Olive está obligado a informar a los usuarios que el código fuente de la aplicación esta disponible para su descarga desde su sitio web.</translation>
     </message>
 </context>
 <context>
@@ -19,7 +19,7 @@
     <message>
         <location filename="../dialogs/actionsearch.cpp" line="57"/>
         <source>Search for action...</source>
-        <translation type="unfinished"></translation>
+        <translation>Búsqueda de acción...</translation>
     </message>
 </context>
 <context>
@@ -27,43 +27,53 @@
     <message>
         <location filename="../dialogs/advancedvideodialog.cpp" line="41"/>
         <source>Advanced Video Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuraciones Avanzadas de Vídeo</translation>
     </message>
     <message>
         <location filename="../dialogs/advancedvideodialog.cpp" line="53"/>
         <source>Pixel Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Formato de Píxel:</translation>
     </message>
     <message>
         <location filename="../dialogs/advancedvideodialog.cpp" line="77"/>
         <source>Threads:</source>
-        <translation type="unfinished"></translation>
+        <translation>Hilos (Threads):</translation>
     </message>
 </context>
 <context>
     <name>Audio</name>
     <message>
-        <location filename="../rendering/audio.cpp" line="333"/>
+        <location filename="../rendering/audio.cpp" line="326"/>
         <source>%1 Audio</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Audio</translation>
     </message>
     <message>
-        <location filename="../rendering/audio.cpp" line="346"/>
+        <location filename="../rendering/audio.cpp" line="339"/>
         <source>Recording %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Grabación %1</translation>
     </message>
 </context>
 <context>
     <name>AudioNoiseEffect</name>
     <message>
-        <location filename="../effects/internal/audionoiseeffect.cpp" line="24"/>
+        <location filename="../effects/internal/audionoiseeffect.cpp" line="27"/>
         <source>Amount</source>
-        <translation type="unfinished"></translation>
+        <translation>Cantidad</translation>
     </message>
     <message>
-        <location filename="../effects/internal/audionoiseeffect.cpp" line="30"/>
+        <location filename="../effects/internal/audionoiseeffect.cpp" line="32"/>
         <source>Mix</source>
-        <translation type="unfinished"></translation>
+        <translation>Mezclar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/audionoiseeffect.cpp" line="38"/>
+        <source>Noise</source>
+        <translation>Ruido</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/audionoiseeffect.cpp" line="48"/>
+        <source>Generate audio noise that can be mixed with this clip.</source>
+        <translation>Generar ruido de audio que se puede mezclar con este clip.</translation>
     </message>
 </context>
 <context>
@@ -71,90 +81,90 @@
     <message>
         <location filename="../dialogs/autocutsilencedialog.cpp" line="38"/>
         <source>Cut Silence</source>
-        <translation type="unfinished"></translation>
+        <translation>Corte de silencio</translation>
     </message>
     <message>
         <location filename="../dialogs/autocutsilencedialog.cpp" line="44"/>
         <source>Attack Threshold:</source>
-        <translation type="unfinished"></translation>
+        <translation>Umbral de ataque:</translation>
     </message>
     <message>
         <location filename="../dialogs/autocutsilencedialog.cpp" line="49"/>
         <source>Attack Time:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiempo de ataque:</translation>
     </message>
     <message>
         <location filename="../dialogs/autocutsilencedialog.cpp" line="54"/>
         <source>Release Threshold:</source>
-        <translation type="unfinished"></translation>
+        <translation>Umbral de liberación:</translation>
     </message>
     <message>
         <location filename="../dialogs/autocutsilencedialog.cpp" line="59"/>
         <source>Release Time:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiempo de liberación:</translation>
     </message>
 </context>
 <context>
     <name>Cacher</name>
     <message>
-        <location filename="../rendering/cacher.cpp" line="922"/>
-        <location filename="../rendering/cacher.cpp" line="931"/>
+        <location filename="../rendering/cacher.cpp" line="932"/>
+        <location filename="../rendering/cacher.cpp" line="941"/>
         <source>Could not open %1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>No se pudo abrir %1 - %2</translation>
     </message>
 </context>
 <context>
     <name>ChannelLayoutName</name>
     <message>
-        <location filename="../project/media.cpp" line="53"/>
+        <location filename="../project/footage.cpp" line="170"/>
         <source>Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation>Inválido</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="54"/>
+        <location filename="../project/footage.cpp" line="171"/>
         <source>Mono</source>
-        <translation type="unfinished"></translation>
+        <translation>Monoaural</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="55"/>
+        <location filename="../project/footage.cpp" line="172"/>
         <source>Stereo</source>
-        <translation type="unfinished"></translation>
+        <translation>Estéreo</translation>
     </message>
 </context>
 <context>
     <name>ClipPropertiesDialog</name>
     <message>
-        <location filename="../dialogs/clippropertiesdialog.cpp" line="14"/>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="34"/>
         <source>&quot;%1&quot; Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;%1&quot; Propiedades</translation>
     </message>
     <message>
-        <location filename="../dialogs/clippropertiesdialog.cpp" line="15"/>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="35"/>
         <source>Multiple Clip Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Propiedades de múltiples clips</translation>
     </message>
     <message>
-        <location filename="../dialogs/clippropertiesdialog.cpp" line="24"/>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="44"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../dialogs/clippropertiesdialog.cpp" line="33"/>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="53"/>
         <source>Duration:</source>
-        <translation type="unfinished"></translation>
+        <translation>Duración:</translation>
     </message>
     <message>
-        <location filename="../dialogs/clippropertiesdialog.cpp" line="71"/>
+        <location filename="../dialogs/clippropertiesdialog.cpp" line="91"/>
         <source>(multiple)</source>
-        <translation type="unfinished"></translation>
+        <translation>(múltiple)</translation>
     </message>
 </context>
 <context>
     <name>CollapsibleWidget</name>
     <message>
-        <location filename="../ui/collapsiblewidget.cpp" line="54"/>
+        <location filename="../ui/collapsiblewidget.cpp" line="57"/>
         <source>&lt;untitled&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;SinTítulo&gt;</translation>
     </message>
 </context>
 <context>
@@ -162,7 +172,7 @@
     <message>
         <location filename="../ui/colorbutton.cpp" line="47"/>
         <source>Set Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer color</translation>
     </message>
 </context>
 <context>
@@ -170,27 +180,68 @@
     <message>
         <location filename="../effects/internal/cornerpineffect.cpp" line="30"/>
         <source>Top Left</source>
-        <translation type="unfinished"></translation>
+        <translation>Arriba Izquierda</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="32"/>
+        <source>Top Right</source>
+        <translation>Arriba Derecha</translation>
     </message>
     <message>
         <location filename="../effects/internal/cornerpineffect.cpp" line="34"/>
-        <source>Top Right</source>
-        <translation type="unfinished"></translation>
+        <source>Bottom Left</source>
+        <translation>Abajo Izquierda</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="36"/>
+        <source>Bottom Right</source>
+        <translation>Abajo Derecha</translation>
     </message>
     <message>
         <location filename="../effects/internal/cornerpineffect.cpp" line="38"/>
-        <source>Bottom Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/cornerpineffect.cpp" line="42"/>
-        <source>Bottom Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/cornerpineffect.cpp" line="46"/>
         <source>Perspective</source>
-        <translation type="unfinished"></translation>
+        <translation>Perspectiva</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="63"/>
+        <source>Corner Pin</source>
+        <translation>Fijar Esquinas Para Deformar (Corner Pin)</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="73"/>
+        <source>Distort</source>
+        <translation>Distorsionar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/cornerpineffect.cpp" line="78"/>
+        <source>Distort/warp this clip by pinning each of its four corners.</source>
+        <translation>Distorsionar/deformar este clip fijando cada una de sus cuatro esquinas.</translation>
+    </message>
+</context>
+<context>
+    <name>CrashDialog</name>
+    <message>
+        <location filename="../dialogs/crashdialog.cpp" line="16"/>
+        <source>We&apos;re very sorry, Olive has crashed. Please send the following data to developers:</source>
+        <translation>Lo sentimos mucho, se ha producido un error en la aplicación. Por favor envíe los siguientes datos a los desarrolladores de Olive para falcilitar la resolución del problema, gracias:</translation>
+    </message>
+</context>
+<context>
+    <name>CrossDissolveTransition</name>
+    <message>
+        <location filename="../effects/internal/crossdissolvetransition.cpp" line="31"/>
+        <source>Cross Dissolve</source>
+        <translation>Fundido Cruzado</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/crossdissolvetransition.cpp" line="41"/>
+        <source>Dissolves</source>
+        <translation>Fundido</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/crossdissolvetransition.cpp" line="46"/>
+        <source>Dissolve clips evenly.</source>
+        <translation>Fundir uniformemente los clips.</translation>
     </message>
 </context>
 <context>
@@ -198,7 +249,7 @@
     <message>
         <location filename="../dialogs/debugdialog.cpp" line="44"/>
         <source>Debug Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Registro de depuración</translation>
     </message>
 </context>
 <context>
@@ -207,186 +258,118 @@
         <location filename="../dialogs/demonotice.cpp" line="30"/>
         <location filename="../dialogs/demonotice.cpp" line="45"/>
         <source>Welcome to Olive!</source>
-        <translation type="unfinished"></translation>
+        <translation>¡Bienvenido a Olive Video Editor!</translation>
     </message>
     <message>
         <location filename="../dialogs/demonotice.cpp" line="47"/>
         <source>Olive is a free open-source video editor released under the GNU GPL. If you have paid for this software, you have been scammed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Olive es un editor de video gratuito de código abierto lanzado bajo la licencia GPL de GNU. Si ha pagado por este software, ha sido estafado.</translation>
     </message>
     <message>
         <location filename="../dialogs/demonotice.cpp" line="49"/>
         <source>This software is currently in ALPHA which means it is unstable and very likely to crash, have bugs, and have missing features. We offer no warranty so use at your own risk. Please report any bugs or feature requests at %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Este software se encuentra actualmente en desarrollo y es una versión ALPHA, lo que significa que es inestable y es muy probable que se bloquee, tenga errores y carezca de algunas características. No podemos ofrecerle ninguna garantía, así que úselo bajo su propia responsabilidad. Por favor, informe de cualquier error y no dude en notificarnos características que le gustaría que se incluyan en la aplicación en la siguiente web  %1</translation>
     </message>
     <message>
         <location filename="../dialogs/demonotice.cpp" line="51"/>
         <source>Thank you for trying Olive and we hope you enjoy it!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Effect</name>
-    <message>
-        <location filename="../effects/effect.cpp" line="100"/>
-        <source>Invalid effect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="101"/>
-        <source>No candidate for effect &apos;%1&apos;. This effect may be corrupt. Try reinstalling it or Olive.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="448"/>
-        <source>Save Effect Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="450"/>
-        <location filename="../effects/effect.cpp" line="480"/>
-        <source>Effect XML Settings %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="468"/>
-        <source>Save Settings Failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="469"/>
-        <source>Failed to open &quot;%1&quot; for writing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="478"/>
-        <source>Load Effect Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="494"/>
-        <location filename="../effects/effect.cpp" line="682"/>
-        <source>Load Settings Failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="495"/>
-        <source>Failed to open &quot;%1&quot; for reading.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effect.cpp" line="683"/>
-        <source>This settings file doesn&apos;t match this effect.</source>
-        <translation type="unfinished"></translation>
+        <translation>¡Gracias por probar Olive Vídeo Editor, esperamos que lo disfrutes!</translation>
     </message>
 </context>
 <context>
     <name>EffectControls</name>
     <message>
-        <location filename="../panels/effectcontrols.cpp" line="507"/>
+        <location filename="../panels/effectcontrols.cpp" line="296"/>
         <source>Effects: </source>
-        <translation type="unfinished"></translation>
+        <translation>Efectos:</translation>
     </message>
     <message>
-        <location filename="../panels/effectcontrols.cpp" line="325"/>
+        <location filename="../panels/effectcontrols.cpp" line="114"/>
         <source>(none)</source>
-        <translation type="unfinished"></translation>
+        <translation>(ninguno)</translation>
     </message>
     <message>
-        <location filename="../panels/effectcontrols.cpp" line="509"/>
+        <location filename="../panels/effectcontrols.cpp" line="298"/>
         <source>Add Video Effect</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir Efecto de Vídeo</translation>
     </message>
     <message>
-        <location filename="../panels/effectcontrols.cpp" line="510"/>
+        <location filename="../panels/effectcontrols.cpp" line="299"/>
         <source>VIDEO EFFECTS</source>
-        <translation type="unfinished"></translation>
+        <translation>EFECTOS DE VÍDEO</translation>
     </message>
     <message>
-        <location filename="../panels/effectcontrols.cpp" line="511"/>
+        <location filename="../panels/effectcontrols.cpp" line="300"/>
         <source>Add Video Transition</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir Transición de Vídeo</translation>
     </message>
     <message>
-        <location filename="../panels/effectcontrols.cpp" line="512"/>
+        <location filename="../panels/effectcontrols.cpp" line="301"/>
         <source>Add Audio Effect</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir Efecto de Audio</translation>
     </message>
     <message>
-        <location filename="../panels/effectcontrols.cpp" line="513"/>
+        <location filename="../panels/effectcontrols.cpp" line="302"/>
         <source>AUDIO EFFECTS</source>
-        <translation type="unfinished"></translation>
+        <translation>EFECTOS DE AUDIO</translation>
     </message>
     <message>
-        <location filename="../panels/effectcontrols.cpp" line="514"/>
+        <location filename="../panels/effectcontrols.cpp" line="303"/>
         <source>Add Audio Transition</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EffectRow</name>
-    <message>
-        <location filename="../effects/effectrow.cpp" line="104"/>
-        <source>Disable Keyframes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/effectrow.cpp" line="105"/>
-        <source>Disabling keyframes will delete all current keyframes. Are you sure you want to do this?</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir Transición de Audio</translation>
     </message>
 </context>
 <context>
     <name>EffectUI</name>
     <message>
-        <location filename="../ui/effectui.cpp" line="54"/>
+        <location filename="../ui/effectui.cpp" line="74"/>
         <source>%1 (Opening)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (Abriendo)</translation>
     </message>
     <message>
-        <location filename="../ui/effectui.cpp" line="56"/>
+        <location filename="../ui/effectui.cpp" line="76"/>
         <source>%1 (Closing)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (Cerrando)</translation>
     </message>
     <message>
-        <location filename="../ui/effectui.cpp" line="158"/>
+        <location filename="../ui/effectui.cpp" line="175"/>
         <source>%1 (multiple)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (múltiple)</translation>
     </message>
     <message>
-        <location filename="../ui/effectui.cpp" line="286"/>
+        <location filename="../ui/effectui.cpp" line="312"/>
         <source>Cu&amp;t</source>
-        <translation type="unfinished"></translation>
+        <translation>Cor&amp;tar</translation>
     </message>
     <message>
-        <location filename="../ui/effectui.cpp" line="289"/>
+        <location filename="../ui/effectui.cpp" line="315"/>
         <source>&amp;Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/effectui.cpp" line="300"/>
-        <source>Move &amp;Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/effectui.cpp" line="304"/>
-        <source>Move &amp;Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/effectui.cpp" line="309"/>
-        <source>D&amp;elete</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Copiar</translation>
     </message>
     <message>
         <location filename="../ui/effectui.cpp" line="326"/>
-        <source>Load Settings From File</source>
-        <translation type="unfinished"></translation>
+        <source>Move &amp;Up</source>
+        <translation>Mover Arriba (&amp;Up)</translation>
     </message>
     <message>
-        <location filename="../ui/effectui.cpp" line="328"/>
+        <location filename="../ui/effectui.cpp" line="330"/>
+        <source>Move &amp;Down</source>
+        <translation>Mover Abajo (&amp;Down)</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="335"/>
+        <source>D&amp;elete</source>
+        <translation>&amp;Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="352"/>
+        <source>Load Settings From File</source>
+        <translation>Cargar configuración predefinida desde un archivo</translation>
+    </message>
+    <message>
+        <location filename="../ui/effectui.cpp" line="354"/>
         <source>Save Settings to File</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar configuración predefinida en un archivo</translation>
     </message>
 </context>
 <context>
@@ -394,303 +377,349 @@
     <message>
         <location filename="../ui/embeddedfilechooser.cpp" line="52"/>
         <source>File:</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivo:</translation>
+    </message>
+</context>
+<context>
+    <name>ExponentialFadeTransition</name>
+    <message>
+        <location filename="../effects/internal/exponentialfadetransition.cpp" line="32"/>
+        <source>Exponential Fade</source>
+        <translation>Desvanecimiento exponencial</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/exponentialfadetransition.cpp" line="42"/>
+        <source>An exponential audio fade that starts slow and ends fast.</source>
+        <translation>Desvanecimiento de audio exponencial, comienza lento y termina rápido.</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="74"/>
+        <location filename="../dialogs/exportdialog.cpp" line="75"/>
         <source>Export &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="127"/>
+        <location filename="../dialogs/exportdialog.cpp" line="128"/>
         <source>Unknown codec name %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/exportdialog.cpp" line="341"/>
-        <source>Export Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre de códec desconocido %1</translation>
     </message>
     <message>
         <location filename="../dialogs/exportdialog.cpp" line="342"/>
-        <source>Export failed - %1</source>
-        <translation type="unfinished"></translation>
+        <source>Export Failed</source>
+        <translation>La exportación ha fallado</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="384"/>
-        <source>Invalid dimensions</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/exportdialog.cpp" line="343"/>
+        <source>Export failed - %1</source>
+        <translation>La exportación ha fallado - %1</translation>
     </message>
     <message>
         <location filename="../dialogs/exportdialog.cpp" line="385"/>
-        <source>Export width and height must both be even numbers/divisible by 2.</source>
-        <translation type="unfinished"></translation>
+        <source>Invalid dimensions</source>
+        <translation>Dimensiones no válidas</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="441"/>
-        <source>Invalid codec</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/exportdialog.cpp" line="386"/>
+        <source>Export width and height must both be even numbers/divisible by 2.</source>
+        <translation>El ancho y el alto de la exportación deben ser números pares/divisibles entre 2.</translation>
     </message>
     <message>
         <location filename="../dialogs/exportdialog.cpp" line="442"/>
-        <source>Couldn&apos;t determine output parameters for the selected codec. This is a bug, please contact the developers.</source>
-        <translation type="unfinished"></translation>
+        <source>Invalid codec</source>
+        <translation>Códec no valido</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="511"/>
-        <source>Invalid format</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/exportdialog.cpp" line="443"/>
+        <source>Couldn&apos;t determine output parameters for the selected codec. This is a bug, please contact the developers.</source>
+        <translation>No se pudieron determinar los parámetros de salida para el códec seleccionado. Si esto es un error, por favor, póngase en contacto con los desarrolladores.</translation>
     </message>
     <message>
         <location filename="../dialogs/exportdialog.cpp" line="512"/>
+        <source>Invalid format</source>
+        <translation>Formato no válido</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/exportdialog.cpp" line="513"/>
         <source>Couldn&apos;t determine output format. This is a bug, please contact the developers.</source>
-        <translation type="unfinished"></translation>
+        <translation>No se pudo determinar el formato de salida. Si esto es un error, por favor, póngase en contacto con los desarrolladores.</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="519"/>
+        <location filename="../dialogs/exportdialog.cpp" line="520"/>
         <source>Export Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar Medios</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="603"/>
+        <location filename="../dialogs/exportdialog.cpp" line="605"/>
         <source>%p% (Total: %1:%2:%3)</source>
-        <translation type="unfinished"></translation>
+        <translation>%p% (Total: %1:%2:%3)</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="608"/>
+        <location filename="../dialogs/exportdialog.cpp" line="610"/>
         <source>%p% (ETA: %1:%2:%3)</source>
-        <translation type="unfinished"></translation>
+        <translation>%p% (ETA: %1:%2:%3)</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="623"/>
+        <location filename="../dialogs/exportdialog.cpp" line="625"/>
         <source>Quality-based (Constant Rate Factor)</source>
-        <translation type="unfinished"></translation>
+        <translation>Basado en la Calidad de Factor de Ratio Constante</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="627"/>
+        <location filename="../dialogs/exportdialog.cpp" line="629"/>
         <source>Constant Bitrate</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad de bits constante</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="636"/>
-        <location filename="../dialogs/exportdialog.cpp" line="642"/>
+        <location filename="../dialogs/exportdialog.cpp" line="638"/>
+        <location filename="../dialogs/exportdialog.cpp" line="644"/>
         <source>Invalid Codec</source>
-        <translation type="unfinished"></translation>
+        <translation>Códec no valido</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="637"/>
+        <location filename="../dialogs/exportdialog.cpp" line="639"/>
         <source>Failed to find a suitable encoder for this codec. Export will likely fail.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al encontrar un codificador adecuado para este códec. La exportación probablemente fallará.</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="643"/>
+        <location filename="../dialogs/exportdialog.cpp" line="645"/>
         <source>Failed to find pixel format for this encoder. Export will likely fail.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al encontrar el formato de píxel adecuado para este codificador. La exportación probablemente fallará.</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="656"/>
+        <location filename="../dialogs/exportdialog.cpp" line="658"/>
         <source>Bitrate (Mbps):</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad de Bits (Mbps):</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="660"/>
+        <location filename="../dialogs/exportdialog.cpp" line="662"/>
         <source>Quality (CRF):</source>
-        <translation type="unfinished"></translation>
+        <translation>Calidad (CRF):</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="663"/>
+        <location filename="../dialogs/exportdialog.cpp" line="665"/>
         <source>Quality Factor:
 
 0 = lossless
 17-18 = visually lossless (compressed, but unnoticeable)
 23 = high quality
 51 = lowest quality possible</source>
-        <translation type="unfinished"></translation>
+        <translation>Factor de Calidad:
+
+0 = Sin pérdida, sin compresión. (La mejor calidad pero mayor tamaño de archivo)
+17-18 = Muy alta calidad, sin pérdida visual. (RECOMENDADO) (Comprimido, pero de manera imperceptible.)
+23 = Alta calidad (Recomendado en la mayoría de casos para mantener una buena relación calidad tamaño)
+51 = La peor calidad posible (No se recomienda salvo excepciónes donde sea más importante el menor tamaño de archivo que la calidad del vídeo)</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="666"/>
+        <location filename="../dialogs/exportdialog.cpp" line="668"/>
         <source>Target File Size (MB):</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamaño del archivo de destino (MB):</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="682"/>
+        <location filename="../dialogs/exportdialog.cpp" line="684"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Formato:</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="691"/>
+        <location filename="../dialogs/exportdialog.cpp" line="693"/>
         <source>Range:</source>
-        <translation type="unfinished"></translation>
+        <translation>Rango:</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="694"/>
+        <location filename="../dialogs/exportdialog.cpp" line="696"/>
         <source>Entire Sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Secuencia entera</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="695"/>
+        <location filename="../dialogs/exportdialog.cpp" line="697"/>
         <source>In to Out</source>
-        <translation type="unfinished"></translation>
+        <translation>De entrada a salida</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="702"/>
+        <location filename="../dialogs/exportdialog.cpp" line="704"/>
         <source>Video</source>
-        <translation type="unfinished"></translation>
+        <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="708"/>
-        <location filename="../dialogs/exportdialog.cpp" line="751"/>
+        <location filename="../dialogs/exportdialog.cpp" line="710"/>
+        <location filename="../dialogs/exportdialog.cpp" line="753"/>
         <source>Codec:</source>
-        <translation type="unfinished"></translation>
+        <translation>Codificación (Códec):</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="712"/>
+        <location filename="../dialogs/exportdialog.cpp" line="714"/>
         <source>Width:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ancho:</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="717"/>
+        <location filename="../dialogs/exportdialog.cpp" line="719"/>
         <source>Height:</source>
-        <translation type="unfinished"></translation>
+        <translation>Alto:</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="722"/>
+        <location filename="../dialogs/exportdialog.cpp" line="724"/>
         <source>Frame Rate:</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotogramas por segundo:</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="728"/>
+        <location filename="../dialogs/exportdialog.cpp" line="730"/>
         <source>Compression Type:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo de Compresión:</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="739"/>
+        <location filename="../dialogs/exportdialog.cpp" line="741"/>
         <source>Advanced</source>
-        <translation type="unfinished"></translation>
+        <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="746"/>
+        <location filename="../dialogs/exportdialog.cpp" line="748"/>
         <source>Audio</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="755"/>
+        <location filename="../dialogs/exportdialog.cpp" line="757"/>
         <source>Sampling Rate:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tasa de muestreo:</translation>
     </message>
     <message>
-        <location filename="../dialogs/exportdialog.cpp" line="761"/>
+        <location filename="../dialogs/exportdialog.cpp" line="763"/>
         <source>Bitrate (Kbps/CBR):</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad de bits (Kbps / CBR):</translation>
     </message>
 </context>
 <context>
     <name>ExportThread</name>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="79"/>
+        <location filename="../rendering/exportthread.cpp" line="77"/>
         <source>failed to send frame to encoder (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al enviar los fotogramas al codificador (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="90"/>
+        <location filename="../rendering/exportthread.cpp" line="88"/>
         <source>failed to receive packet from encoder (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al recibir el paquete del codificador (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="113"/>
+        <location filename="../rendering/exportthread.cpp" line="111"/>
         <source>could not video encoder for %1</source>
-        <translation type="unfinished"></translation>
+        <translation>No se ha podido codificar el vídeo para %1</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="122"/>
+        <location filename="../rendering/exportthread.cpp" line="120"/>
         <source>could not allocate video stream</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo asignar el flujo de video</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="131"/>
+        <location filename="../rendering/exportthread.cpp" line="129"/>
         <source>could not allocate video encoding context</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo asignar el flujo de video</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="180"/>
+        <location filename="../rendering/exportthread.cpp" line="179"/>
         <source>could not open output video encoder (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo abrir el codificador para el vídeo de salida (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="188"/>
+        <location filename="../rendering/exportthread.cpp" line="187"/>
         <source>could not copy video encoder parameters to output stream (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudieron copiar los parámetros del codificador de video para este flujo de salida (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="227"/>
+        <location filename="../rendering/exportthread.cpp" line="226"/>
         <source>could not audio encoder for %1</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo codificar el audio para %1</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="235"/>
+        <location filename="../rendering/exportthread.cpp" line="234"/>
         <source>could not allocate audio stream</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo asignar el flujo de audio</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="249"/>
+        <location filename="../rendering/exportthread.cpp" line="248"/>
         <source>could not allocate audio encoding context</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo asignar el contexto de codificación de audio</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="274"/>
+        <location filename="../rendering/exportthread.cpp" line="273"/>
         <source>could not open output audio encoder (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo abrir el codificador de audio de salida (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="282"/>
+        <location filename="../rendering/exportthread.cpp" line="281"/>
         <source>could not copy audio encoder parameters to output stream (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudieron copiar los parámetros del codificador de audio al flujo de salida (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="319"/>
+        <location filename="../rendering/exportthread.cpp" line="318"/>
         <source>could not allocate audio buffer (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo asignar el búfer de audio (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="350"/>
+        <location filename="../rendering/exportthread.cpp" line="349"/>
         <source>could not create output format context</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo crear el contexto del formato de salida</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="360"/>
+        <location filename="../rendering/exportthread.cpp" line="359"/>
         <source>could not open output file (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo abrir el archvo de salida (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="396"/>
+        <location filename="../rendering/exportthread.cpp" line="395"/>
         <source>could not write output file header (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo escribir la cabecera del archivo de salida (%1)</translation>
     </message>
     <message>
-        <location filename="../rendering/exportthread.cpp" line="600"/>
+        <location filename="../rendering/exportthread.cpp" line="598"/>
         <source>could not write output file trailer (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>no se pudo escribir el final del archivo de salida (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>FFmpegDecoder</name>
+    <message>
+        <location filename="../decoders/ffmpegdecoder.cpp" line="66"/>
+        <source>Failed to find appropriate decoder for this codec (%1 :: %2)</source>
+        <translation>No se pudo encontrar un decodificador adecuado para este códec (%1 :: %2)</translation>
+    </message>
+    <message>
+        <location filename="../decoders/ffmpegdecoder.cpp" line="74"/>
+        <source>Failed to allocate codec context (%1 :: %2)</source>
+        <translation>Error al asignar el contexto del códec (%1 :: %2)</translation>
+    </message>
+    <message>
+        <location filename="../decoders/ffmpegdecoder.cpp" line="133"/>
+        <source>Error decoding %1 - %2 %3</source>
+        <translation>Error al decodificar %1 - %2 %3</translation>
     </message>
 </context>
 <context>
     <name>FillLeftRightEffect</name>
     <message>
-        <location filename="../effects/internal/fillleftrighteffect.cpp" line="27"/>
-        <source>Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../effects/internal/fillleftrighteffect.cpp" line="29"/>
-        <source>Fill Left with Right</source>
-        <translation type="unfinished"></translation>
+        <source>Type</source>
+        <translation>Tipo</translation>
     </message>
     <message>
         <location filename="../effects/internal/fillleftrighteffect.cpp" line="30"/>
+        <source>Fill Left with Right</source>
+        <translation>Rellena a la izquierda con la derecha</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/fillleftrighteffect.cpp" line="31"/>
         <source>Fill Right with Left</source>
-        <translation type="unfinished"></translation>
+        <translation>Rellena a la derecha con la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/fillleftrighteffect.cpp" line="36"/>
+        <source>Fill Left/Right</source>
+        <translation>Rellenar Izquierda/Derecha</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/fillleftrighteffect.cpp" line="46"/>
+        <source>Replaces either the left or right channel with the other</source>
+        <translation>Reemplaza el canal izquierdo o derecho con el otro</translation>
     </message>
 </context>
 <context>
@@ -698,12 +727,12 @@
     <message>
         <location filename="../effects/internal/frei0reffect.cpp" line="55"/>
         <source>Failed to load Frei0r plugin &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Falló la carga del plugin Frei0r &quot;%1&quot;: %2</translation>
     </message>
     <message>
         <location filename="../effects/internal/frei0reffect.cpp" line="54"/>
         <source>Error loading Frei0r plugin</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al cargar el plugin Frei0r</translation>
     </message>
 </context>
 <context>
@@ -711,22 +740,22 @@
     <message>
         <location filename="../panels/grapheditor.cpp" line="140"/>
         <source>Graph Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Editor Gráfico</translation>
     </message>
     <message>
         <location filename="../panels/grapheditor.cpp" line="141"/>
         <source>Linear</source>
-        <translation type="unfinished"></translation>
+        <translation>Lineal</translation>
     </message>
     <message>
         <location filename="../panels/grapheditor.cpp" line="142"/>
         <source>Bezier</source>
-        <translation type="unfinished"></translation>
+        <translation>Bézier</translation>
     </message>
     <message>
         <location filename="../panels/grapheditor.cpp" line="143"/>
         <source>Hold</source>
-        <translation type="unfinished"></translation>
+        <translation>Mantener</translation>
     </message>
 </context>
 <context>
@@ -734,40 +763,40 @@
     <message>
         <location filename="../ui/graphview.cpp" line="80"/>
         <source>Zoom to Selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Ampliar a la selección</translation>
     </message>
     <message>
         <location filename="../ui/graphview.cpp" line="87"/>
         <source>Zoom to Show All</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar todo</translation>
     </message>
     <message>
         <location filename="../ui/graphview.cpp" line="96"/>
         <source>Reset View</source>
-        <translation type="unfinished"></translation>
+        <translation>Resetear vista</translation>
     </message>
 </context>
 <context>
     <name>InterlacingName</name>
     <message>
-        <location filename="../project/media.cpp" line="44"/>
+        <location filename="../project/footage.cpp" line="161"/>
         <source>None (Progressive)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ninguno (Progresivo)</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="45"/>
-        <source>Top Field First</source>
-        <translation type="unfinished"></translation>
+        <location filename="../project/footage.cpp" line="162"/>
+        <source>Upper Field First</source>
+        <translation>Campo superior primero</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="46"/>
-        <source>Bottom Field First</source>
-        <translation type="unfinished"></translation>
+        <location filename="../project/footage.cpp" line="163"/>
+        <source>Lower Field First</source>
+        <translation>Campo inferior primero</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="47"/>
+        <location filename="../project/footage.cpp" line="164"/>
         <source>Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation>No válido</translation>
     </message>
 </context>
 <context>
@@ -775,25 +804,25 @@
     <message>
         <location filename="../ui/keyframenavigator.cpp" line="77"/>
         <source>Enable Keyframes</source>
-        <translation type="unfinished"></translation>
+        <translation>Habilitar fotogramas clave</translation>
     </message>
 </context>
 <context>
     <name>KeyframeView</name>
     <message>
-        <location filename="../ui/keyframeview.cpp" line="74"/>
+        <location filename="../ui/keyframeview.cpp" line="75"/>
         <source>Linear</source>
-        <translation type="unfinished"></translation>
+        <translation>Lineal</translation>
     </message>
     <message>
-        <location filename="../ui/keyframeview.cpp" line="76"/>
+        <location filename="../ui/keyframeview.cpp" line="77"/>
         <source>Bezier</source>
-        <translation type="unfinished"></translation>
+        <translation>Bézier</translation>
     </message>
     <message>
-        <location filename="../ui/keyframeview.cpp" line="78"/>
+        <location filename="../ui/keyframeview.cpp" line="79"/>
         <source>Hold</source>
-        <translation type="unfinished"></translation>
+        <translation>Mantener</translation>
     </message>
 </context>
 <context>
@@ -801,24 +830,37 @@
     <message>
         <location filename="../ui/labelslider.cpp" line="271"/>
         <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
         <location filename="../ui/labelslider.cpp" line="275"/>
         <source>&amp;Reset to Default</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Restablecer a Predeterminados</translation>
     </message>
     <message>
         <location filename="../ui/labelslider.cpp" line="306"/>
         <location filename="../ui/labelslider.cpp" line="345"/>
         <source>Set Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer Valor</translation>
     </message>
     <message>
         <location filename="../ui/labelslider.cpp" line="307"/>
         <location filename="../ui/labelslider.cpp" line="346"/>
         <source>New value:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuevo Valor:</translation>
+    </message>
+</context>
+<context>
+    <name>LinearFadeTransition</name>
+    <message>
+        <location filename="../effects/internal/linearfadetransition.cpp" line="27"/>
+        <source>Linear Fade</source>
+        <translation>Fundido Lineal</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/linearfadetransition.cpp" line="37"/>
+        <source>An linear audio fade that fades evenly at a constant rate.</source>
+        <translation>Desvanecimiento lineal del audio a una velocidad constante.</translation>
     </message>
 </context>
 <context>
@@ -826,664 +868,687 @@
     <message>
         <location filename="../dialogs/loaddialog.cpp" line="37"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Cargando...</translation>
     </message>
     <message>
         <location filename="../dialogs/loaddialog.cpp" line="42"/>
         <source>Loading &apos;%1&apos;...</source>
-        <translation type="unfinished"></translation>
+        <translation>Cargando &apos;%1&apos;...</translation>
     </message>
     <message>
         <location filename="../dialogs/loaddialog.cpp" line="48"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
 </context>
 <context>
     <name>LoadThread</name>
     <message>
-        <location filename="../project/loadthread.cpp" line="246"/>
+        <location filename="../project/loadthread.cpp" line="256"/>
         <source>Version Mismatch</source>
-        <translation type="unfinished"></translation>
+        <translation>La versión no coincide</translation>
     </message>
     <message>
-        <location filename="../project/loadthread.cpp" line="247"/>
+        <location filename="../project/loadthread.cpp" line="257"/>
         <source>This project was saved in a different version of Olive and may not be fully compatible with this version. Would you like to attempt loading it anyway?</source>
-        <translation type="unfinished"></translation>
+        <translation>Este proyecto se guardó en una versión diferente de Olive y puede que no sea totalmente compatible con esta versión ¿Deseas intentar abrirlo de todos modos?</translation>
     </message>
     <message>
-        <location filename="../project/loadthread.cpp" line="570"/>
-        <source>Invalid Clip Link</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../project/loadthread.cpp" line="571"/>
-        <source>This project contains an invalid clip link. It may be corrupt. Would you like to continue loading it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../project/loadthread.cpp" line="694"/>
+        <location filename="../project/loadthread.cpp" line="709"/>
         <source>%1 - Line: %2 Col: %3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - Línea: %2 Col: %3</translation>
     </message>
     <message>
-        <location filename="../project/loadthread.cpp" line="721"/>
+        <location filename="../project/loadthread.cpp" line="736"/>
         <source>User aborted loading</source>
-        <translation type="unfinished"></translation>
+        <translation>Carga cancelada por el usuario</translation>
     </message>
     <message>
-        <location filename="../project/loadthread.cpp" line="752"/>
+        <location filename="../project/loadthread.cpp" line="767"/>
         <source>XML Parsing Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Error de análisis XML</translation>
     </message>
     <message>
-        <location filename="../project/loadthread.cpp" line="753"/>
+        <location filename="../project/loadthread.cpp" line="768"/>
         <source>Couldn&apos;t load &apos;%1&apos;. %2</source>
-        <translation type="unfinished"></translation>
+        <translation>No se pudo cargar &apos;%1&apos;. %2</translation>
     </message>
     <message>
-        <location filename="../project/loadthread.cpp" line="757"/>
+        <location filename="../project/loadthread.cpp" line="772"/>
         <source>Project Load Error</source>
-        <translation type="unfinished"></translation>
+        <translation>La carga del proyecto falló</translation>
     </message>
     <message>
-        <location filename="../project/loadthread.cpp" line="758"/>
+        <location filename="../project/loadthread.cpp" line="773"/>
         <source>Error loading project: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al cargar el proyecto: %1</translation>
+    </message>
+</context>
+<context>
+    <name>LogarithmicFadeTransition</name>
+    <message>
+        <location filename="../effects/internal/logarithmicfadetransition.cpp" line="32"/>
+        <source>Logarithmic Fade</source>
+        <translation>Desvanecimiento logarítmico</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/logarithmicfadetransition.cpp" line="42"/>
+        <source>An logarithmic audio fade that starts fast and ends slow.</source>
+        <translation>Un desvanecimiento de audio logarítmico que comienza rápido y termina lentamente.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="277"/>
+        <location filename="../ui/mainwindow.cpp" line="283"/>
         <source>Welcome to %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="820"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="821"/>
-        <source>&amp;New</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="822"/>
-        <source>&amp;Open Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="823"/>
-        <source>Clear Recent List</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="824"/>
-        <source>Open Recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="825"/>
-        <source>&amp;Save Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="826"/>
-        <source>Save Project &amp;As</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="827"/>
-        <source>&amp;Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="828"/>
-        <source>&amp;Export...</source>
-        <translation type="unfinished"></translation>
+        <translation>Bienvenido a %1</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="829"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;File</source>
+        <translation>&amp;Archivo</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="830"/>
+        <source>&amp;New</source>
+        <translation>&amp;Nuevo</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="831"/>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Open Project</source>
+        <translation>&amp;Abrir Proyecto</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="832"/>
-        <source>&amp;Undo</source>
-        <translation type="unfinished"></translation>
+        <source>Clear Recent List</source>
+        <translation>Limpiar lista de recientes</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="833"/>
-        <source>Redo</source>
-        <translation type="unfinished"></translation>
+        <source>Open Recent</source>
+        <translation>Abrir Recientes</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="834"/>
-        <source>Select &amp;All</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Save Project</source>
+        <translation>&amp;Guardar Proyecto</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="835"/>
-        <source>Deselect All</source>
-        <translation type="unfinished"></translation>
+        <source>Save Project &amp;As</source>
+        <translation>G&amp;uardar Proyecto Como</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="836"/>
-        <source>Ripple to In Point</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Import...</source>
+        <translation>&amp;Importar...</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="837"/>
-        <source>Ripple to Out Point</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Export...</source>
+        <translation>&amp;Exportar...</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="838"/>
-        <source>Edit to In Point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="839"/>
-        <source>Edit to Out Point</source>
-        <translation type="unfinished"></translation>
+        <source>E&amp;xit</source>
+        <translation>&amp;Cerrar la aplicación</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="840"/>
-        <source>Delete In/Out Point</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Edit</source>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="841"/>
-        <source>Ripple Delete In/Out Point</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Undo</source>
+        <translation>Deshacer Cambios (&amp;Undo)</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="842"/>
-        <source>Set/Edit Marker</source>
-        <translation type="unfinished"></translation>
+        <source>Redo</source>
+        <translation>Rehacer Cambios</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="843"/>
+        <source>Select &amp;All</source>
+        <translation>Seleccion&amp;ar Todo</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="844"/>
-        <source>&amp;View</source>
-        <translation type="unfinished"></translation>
+        <source>Deselect All</source>
+        <translation>Deseleccionar Todo</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="845"/>
-        <source>Zoom In</source>
-        <translation type="unfinished"></translation>
+        <source>Ripple to In Point</source>
+        <translation>Enrollar el clip desde el punto de entrada</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="846"/>
-        <source>Zoom Out</source>
-        <translation type="unfinished"></translation>
+        <source>Ripple to Out Point</source>
+        <translation>Enrollar el clip desde el punto de salida</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="847"/>
-        <source>Increase Track Height</source>
-        <translation type="unfinished"></translation>
+        <source>Edit to In Point</source>
+        <translation>Editar punto de entrada</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="848"/>
-        <source>Decrease Track Height</source>
-        <translation type="unfinished"></translation>
+        <source>Edit to Out Point</source>
+        <translation>Editar punto de salida</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="849"/>
-        <source>Toggle Show All</source>
-        <translation type="unfinished"></translation>
+        <source>Delete In/Out Point</source>
+        <translation>Sustraer lo comprendido entre los puntos de Entrada/Salida</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="850"/>
-        <source>Track Lines</source>
-        <translation type="unfinished"></translation>
+        <source>Ripple Delete In/Out Point</source>
+        <translation>Eliminar lo comprendido entre los puntos de Entrada/Salida</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="851"/>
-        <source>Rectified Waveforms</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="852"/>
-        <source>Frames</source>
-        <translation type="unfinished"></translation>
+        <source>Set/Edit Marker</source>
+        <translation>Establecer/Editar Marcador</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="853"/>
-        <source>Drop Frame</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;View</source>
+        <translation>&amp;Ver</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="854"/>
-        <source>Non-Drop Frame</source>
-        <translation type="unfinished"></translation>
+        <source>Zoom In</source>
+        <translation>Ampliar</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="855"/>
-        <source>Milliseconds</source>
-        <translation type="unfinished"></translation>
+        <source>Zoom Out</source>
+        <translation>Reducir</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="856"/>
+        <source>Increase Track Height</source>
+        <translation>Aumentar la altura de la pista</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="857"/>
-        <source>Title/Action Safe Area</source>
-        <translation type="unfinished"></translation>
+        <source>Decrease Track Height</source>
+        <translation>Disminuir la altura de la pista</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="858"/>
-        <source>Off</source>
-        <translation type="unfinished"></translation>
+        <source>Toggle Show All</source>
+        <translation>Alternar Mostrar Todo</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="271"/>
+        <source>OpenColorIO Config Error</source>
+        <translation>Error de configuración de OpenColorIO</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="272"/>
+        <source>Failed to set OpenColorIO configuration: %1</source>
+        <translation>Error al establecer la configuración de OpenColorIO: %1</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="859"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
+        <source>Rectified Waveforms</source>
+        <translation>Ondas de audio recortadas</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="860"/>
-        <source>4:3</source>
-        <translation type="unfinished"></translation>
+        <source>Frames</source>
+        <translation>Fotogramas</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="861"/>
-        <source>16:9</source>
-        <translation type="unfinished"></translation>
+        <source>Drop Frame</source>
+        <translation>Descartar fotograma (Drop Frame)</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="862"/>
-        <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <source>Non-Drop Frame</source>
+        <translation>No descartar fotograma (Non-Drop Frame)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="864"/>
-        <source>Full Screen</source>
-        <translation type="unfinished"></translation>
+        <location filename="../ui/mainwindow.cpp" line="863"/>
+        <source>Milliseconds</source>
+        <translation>Milisegundos</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="865"/>
-        <source>Full Screen Viewer</source>
-        <translation type="unfinished"></translation>
+        <source>Title/Action Safe Area</source>
+        <translation>Area segura para Titulos y Acción</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="866"/>
+        <source>Off</source>
+        <translation>Apagado</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="867"/>
-        <source>&amp;Playback</source>
-        <translation type="unfinished"></translation>
+        <source>Default</source>
+        <translation>Por defecto</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="868"/>
-        <source>Go to Start</source>
-        <translation type="unfinished"></translation>
+        <source>4:3</source>
+        <translation>4:3</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="869"/>
-        <source>Previous Frame</source>
-        <translation type="unfinished"></translation>
+        <source>16:9</source>
+        <translation>16:9</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="870"/>
-        <source>Play/Pause</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="871"/>
-        <source>Play In to Out</source>
-        <translation type="unfinished"></translation>
+        <source>Custom</source>
+        <translation>Personalizado</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="872"/>
-        <source>Next Frame</source>
-        <translation type="unfinished"></translation>
+        <source>Full Screen</source>
+        <translation>Pantalla completa</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="873"/>
-        <source>Go to End</source>
-        <translation type="unfinished"></translation>
+        <source>Full Screen Viewer</source>
+        <translation>Visor a pantalla completa</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="875"/>
-        <source>Go to Previous Cut</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Playback</source>
+        <translation>&amp;Reproducción</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="876"/>
-        <source>Go to Next Cut</source>
-        <translation type="unfinished"></translation>
+        <source>Go to Start</source>
+        <translation>Ir al inicio</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="877"/>
-        <source>Go to In Point</source>
-        <translation type="unfinished"></translation>
+        <source>Previous Frame</source>
+        <translation>Fotograma anterior</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="878"/>
-        <source>Go to Out Point</source>
-        <translation type="unfinished"></translation>
+        <source>Play/Pause</source>
+        <translation>Reproducir/Pausar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="879"/>
+        <source>Play In to Out</source>
+        <translation>Reproducir desde la marca de entrada a la marca de salida</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="880"/>
-        <source>Shuttle Left</source>
-        <translation type="unfinished"></translation>
+        <source>Next Frame</source>
+        <translation>Siguiente fotograma</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="881"/>
-        <source>Shuttle Stop</source>
-        <translation type="unfinished"></translation>
+        <source>Go to End</source>
+        <translation>Ir al final</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="882"/>
-        <source>Shuttle Right</source>
-        <translation type="unfinished"></translation>
+        <location filename="../ui/mainwindow.cpp" line="883"/>
+        <source>Go to Previous Cut</source>
+        <translation>Ir al corte anterior</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="884"/>
-        <source>Loop</source>
-        <translation type="unfinished"></translation>
+        <source>Go to Next Cut</source>
+        <translation>Ir al siguiente corte</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="885"/>
+        <source>Go to In Point</source>
+        <translation>Ir al punto de entrada</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="886"/>
-        <source>&amp;Window</source>
-        <translation type="unfinished"></translation>
+        <source>Go to Out Point</source>
+        <translation>Ir al punto de salida</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="888"/>
-        <source>Project</source>
-        <translation type="unfinished"></translation>
+        <source>Shuttle Left</source>
+        <translation>Reproducir hacia la Izquierda (Inversa)</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="889"/>
-        <source>Effect Controls</source>
-        <translation type="unfinished"></translation>
+        <source>Shuttle Stop</source>
+        <translation>Parar la Reproducción</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="890"/>
-        <source>Timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="891"/>
-        <source>Graph Editor</source>
-        <translation type="unfinished"></translation>
+        <source>Shuttle Right</source>
+        <translation>Reproducir hacia la Derecha (Normal)</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="892"/>
-        <source>Media Viewer</source>
-        <translation type="unfinished"></translation>
+        <source>Loop</source>
+        <translation>Bucle (Loop)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="893"/>
-        <source>Sequence Viewer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="895"/>
-        <source>Maximize Panel</source>
-        <translation type="unfinished"></translation>
+        <location filename="../ui/mainwindow.cpp" line="894"/>
+        <source>&amp;Window</source>
+        <translation>Ve&amp;ntana</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="896"/>
-        <source>Lock Panels</source>
-        <translation type="unfinished"></translation>
+        <source>Project</source>
+        <translation>Proyecto</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="897"/>
-        <source>Reset to Default Layout</source>
-        <translation type="unfinished"></translation>
+        <source>Effect Controls</source>
+        <translation>Controles de efectos</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="898"/>
+        <source>Timeline</source>
+        <translation>Línea de Tiempo</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="899"/>
-        <source>&amp;Tools</source>
-        <translation type="unfinished"></translation>
+        <source>Graph Editor</source>
+        <translation>Editor Gráfico</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="900"/>
+        <source>Node Editor</source>
+        <translation>Editor de Nodos</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="901"/>
-        <source>Pointer Tool</source>
-        <translation type="unfinished"></translation>
+        <source>Media Viewer</source>
+        <translation>Visor de Medios</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="902"/>
-        <source>Edit Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="903"/>
-        <source>Ripple Tool</source>
-        <translation type="unfinished"></translation>
+        <source>Sequence Viewer</source>
+        <translation>Visor de Secuencias</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="904"/>
-        <source>Razor Tool</source>
-        <translation type="unfinished"></translation>
+        <source>Maximize Panel</source>
+        <translation>Maximizar Panel</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="905"/>
-        <source>Slip Tool</source>
-        <translation type="unfinished"></translation>
+        <source>Lock Panels</source>
+        <translation>Bloquear Paneles</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="906"/>
-        <source>Slide Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="907"/>
-        <source>Hand Tool</source>
-        <translation type="unfinished"></translation>
+        <source>Reset to Default Layout</source>
+        <translation>Restaurar valores por defecto de la interfaz</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="908"/>
-        <source>Transition Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="909"/>
-        <source>Enable Snapping</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Tools</source>
+        <translation>&amp;Herramientas</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="910"/>
-        <source>Auto-Cut Silence</source>
-        <translation type="unfinished"></translation>
+        <source>Pointer Tool</source>
+        <translation>Puntero de Selección/Edición/Mover Clips</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="911"/>
+        <source>Edit Tool</source>
+        <translation>Herramienta de Selección</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="912"/>
-        <source>No Auto-Scroll</source>
-        <translation type="unfinished"></translation>
+        <source>Ripple Tool</source>
+        <translation>Herramienta para Enrrollar/Desenrrollar</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="913"/>
-        <source>Page Auto-Scroll</source>
-        <translation type="unfinished"></translation>
+        <source>Razor Tool</source>
+        <translation>Herramienta de Corte</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="914"/>
-        <source>Smooth Auto-Scroll</source>
-        <translation type="unfinished"></translation>
+        <source>Slip Tool</source>
+        <translation>Deslizar clip sin desplazar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="915"/>
+        <source>Slide Tool</source>
+        <translation>Desplazar clip afectando a los clips contiguos</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="916"/>
-        <source>Preferences</source>
-        <translation type="unfinished"></translation>
+        <source>Hand Tool</source>
+        <translation>Mano para ajustar la vista (No afecta a la edición)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="917"/>
+        <source>Transition Tool</source>
+        <translation>Herramienta para Inserción de Transiciones</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="918"/>
-        <source>Clear Undo</source>
-        <translation type="unfinished"></translation>
+        <source>Enable Snapping</source>
+        <translation>Habilitar Imán de Ajuste</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="919"/>
+        <source>Auto-Cut Silence</source>
+        <translation>Corte de Silencio Automático</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="921"/>
-        <source>&amp;Help</source>
-        <translation type="unfinished"></translation>
+        <source>No Auto-Scroll</source>
+        <translation>Sin desplazamiento automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="922"/>
+        <source>Page Auto-Scroll</source>
+        <translation>Desplazamiento automático de páginas</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="923"/>
-        <source>A&amp;ction Search</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="924"/>
-        <source>Debug Log</source>
-        <translation type="unfinished"></translation>
+        <source>Smooth Auto-Scroll</source>
+        <translation>Desplazamiento automático suave</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.cpp" line="925"/>
-        <source>&amp;About...</source>
-        <translation type="unfinished"></translation>
+        <source>Preferences</source>
+        <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="943"/>
+        <location filename="../ui/mainwindow.cpp" line="927"/>
+        <source>Clear Undo</source>
+        <translation>Limpiar historial de Deshacer</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="930"/>
+        <source>&amp;Help</source>
+        <translation>A&amp;yuda</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="932"/>
+        <source>A&amp;ction Search</source>
+        <translation>&amp;Buscar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="933"/>
+        <source>Debug Log</source>
+        <translation>Registro de depuración</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="934"/>
+        <source>&amp;About...</source>
+        <translation>&amp;Acerca de...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="952"/>
         <source>&lt;untitled&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;SinTítulo&gt;</translation>
     </message>
 </context>
 <context>
     <name>Marker</name>
     <message>
-        <location filename="../timeline/marker.cpp" line="64"/>
+        <location filename="../timeline/marker.cpp" line="68"/>
+        <location filename="../timeline/marker.cpp" line="114"/>
         <source>Set Marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer Marca</translation>
     </message>
     <message>
-        <location filename="../timeline/marker.cpp" line="66"/>
+        <location filename="../timeline/marker.cpp" line="69"/>
         <source>Set clip marker name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer el nombre del marcador de clip:</translation>
     </message>
     <message>
-        <location filename="../timeline/marker.cpp" line="67"/>
+        <location filename="../timeline/marker.cpp" line="115"/>
         <source>Set sequence marker name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer el nombre del marcador de secuencia:</translation>
     </message>
 </context>
 <context>
     <name>Media</name>
     <message>
-        <location filename="../project/media.cpp" line="94"/>
+        <location filename="../project/media.cpp" line="90"/>
         <source>New Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Nueva Carpeta</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="119"/>
+        <location filename="../project/media.cpp" line="115"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre:</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="115"/>
+        <source>Filename:</source>
+        <translation>Nombre de Archivo:</translation>
     </message>
     <message>
         <location filename="../project/media.cpp" line="119"/>
-        <source>Filename:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../project/media.cpp" line="123"/>
         <source>Video Dimensions:</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensiones de Vídeo:</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="133"/>
+        <location filename="../project/media.cpp" line="129"/>
         <source>Frame Rate:</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotogramas por Segundo:</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="143"/>
+        <location filename="../project/media.cpp" line="139"/>
         <source>%1 field(s) (%2 frame(s))</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Campo(s) (%2 Fotograma(s))</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="152"/>
+        <location filename="../project/media.cpp" line="148"/>
         <source>Interlacing:</source>
-        <translation type="unfinished"></translation>
+        <translation>Entrelazado:</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="164"/>
+        <location filename="../project/media.cpp" line="160"/>
         <source>Audio Frequency:</source>
-        <translation type="unfinished"></translation>
+        <translation>Frecuencia del Audio:</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="173"/>
+        <location filename="../project/media.cpp" line="169"/>
         <source>Audio Channels:</source>
-        <translation type="unfinished"></translation>
+        <translation>Canales de Audio:</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="191"/>
+        <location filename="../project/media.cpp" line="187"/>
         <source>Name: %1
 Video Dimensions: %2x%3
 Frame Rate: %4
 Audio Frequency: %5
 Audio Layout: %6</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../project/media.cpp" line="322"/>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre: %1
+Dimensiones del Vídeo: %2x%3
+Fotogramas por Segundo: %4
+Frecuencia del Audio: %5
+Audio: %6</translation>
     </message>
     <message>
         <location filename="../project/media.cpp" line="324"/>
-        <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <source>Name</source>
+        <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../project/media.cpp" line="328"/>
+        <location filename="../project/media.cpp" line="326"/>
+        <source>Duration</source>
+        <translation>Duración</translation>
+    </message>
+    <message>
+        <location filename="../project/media.cpp" line="330"/>
         <source>Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad</translation>
     </message>
 </context>
 <context>
     <name>MediaPropertiesDialog</name>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="44"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="46"/>
         <source>&quot;%1&quot; Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;%1&quot; Propiedades</translation>
     </message>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="53"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="55"/>
         <source>Tracks:</source>
-        <translation type="unfinished"></translation>
+        <translation>Pistas:</translation>
     </message>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="61"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="63"/>
         <source>Video %1: %2x%3 %4FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>Vídeo %1: %2x%3 %4FPS</translation>
     </message>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="77"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="79"/>
         <source>Audio %1: %2Hz %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio %1: %2Hz %3</translation>
     </message>
     <message numerus="yes">
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="80"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="82"/>
         <source>%n channel(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n canal</numerusform>
+            <numerusform>%n canales</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="95"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="97"/>
         <source>Conform to Frame Rate:</source>
-        <translation type="unfinished"></translation>
+        <translation>Conforme a la velocidad de fotogramas:</translation>
     </message>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="105"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="107"/>
         <source>Alpha is Premultiplied</source>
-        <translation type="unfinished"></translation>
+        <translation>Canal Alfa Premultiplicado</translation>
     </message>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="114"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="116"/>
         <source>Auto (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Automático (%1)</translation>
     </message>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="127"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="129"/>
         <source>Interlacing:</source>
-        <translation type="unfinished"></translation>
+        <translation>Entrelazado:</translation>
     </message>
     <message>
-        <location filename="../dialogs/mediapropertiesdialog.cpp" line="134"/>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="150"/>
+        <source>Color Space:</source>
+        <translation>Espacio de color:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/mediapropertiesdialog.cpp" line="158"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre:</translation>
     </message>
 </context>
 <context>
@@ -1491,887 +1556,1165 @@ Audio Layout: %6</source>
     <message>
         <location filename="../ui/menuhelper.cpp" line="161"/>
         <source>&amp;Project</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Proyecto</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="162"/>
         <source>&amp;Sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Sequencia</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="163"/>
         <source>&amp;Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Carpeta</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="164"/>
         <source>Set In Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer punto de entrada</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="165"/>
         <source>Set Out Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer punto de salida</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="166"/>
         <source>Reset In Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Resetear punto de entrada</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="167"/>
         <source>Reset Out Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Resetear punto de salida</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="168"/>
         <source>Clear In/Out Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Limpiar puntos de Entrada/Salida</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="169"/>
         <source>Add Default Transition</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir Transición predeterminada</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="170"/>
         <source>Link/Unlink</source>
-        <translation type="unfinished"></translation>
+        <translation>Unir/Separar clips seleccionados </translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="171"/>
         <source>Enable/Disable</source>
-        <translation type="unfinished"></translation>
+        <translation>Habilitar/Deshabilitar clips seleccionados</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="172"/>
         <source>Nest</source>
-        <translation type="unfinished"></translation>
+        <translation>Anidar</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="173"/>
         <source>Cu&amp;t</source>
-        <translation type="unfinished"></translation>
+        <translation>Cortar (&amp;x)</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="174"/>
         <source>Cop&amp;y</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Copiar</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="175"/>
         <location filename="../ui/menuhelper.cpp" line="270"/>
         <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Pegar</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="176"/>
         <source>Paste Insert</source>
-        <translation type="unfinished"></translation>
+        <translation>Insertar (Pegar)</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="177"/>
         <source>Duplicate</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplicar</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="178"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar clip(s) seleccionado(s) Sin eliminar el hueco</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="179"/>
         <source>Ripple Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar clip(s) seleccionado(s) Eliminando el hueco</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="180"/>
         <source>Split</source>
-        <translation type="unfinished"></translation>
+        <translation>Dividir clips en la posición de cursor</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="223"/>
         <source>Invalid aspect ratio</source>
-        <translation type="unfinished"></translation>
+        <translation>Relación de aspecto no válida</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="223"/>
         <source>The aspect ratio &apos;%1&apos; is invalid. Please try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>La relación de aspecto &apos;%1&apos; no es válida. Inténtalo de nuevo.</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="226"/>
         <source>Enter custom aspect ratio</source>
-        <translation type="unfinished"></translation>
+        <translation>Introduzca una relación de aspecto personalizada</translation>
     </message>
     <message>
         <location filename="../ui/menuhelper.cpp" line="226"/>
         <source>Enter the aspect ratio to use for the title/action safe area (e.g. 16:9):</source>
-        <translation type="unfinished"></translation>
+        <translation>Ingrese la relación de aspecto a usar para el área segura de título/acción (por ejemplo, 16:9):</translation>
     </message>
 </context>
 <context>
     <name>NewSequenceDialog</name>
     <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="62"/>
+        <location filename="../dialogs/newsequencedialog.cpp" line="66"/>
         <source>Editing &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Edición &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="82"/>
+        <location filename="../dialogs/newsequencedialog.cpp" line="86"/>
         <source>New Sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Nueva Secuencia</translation>
     </message>
     <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="209"/>
+        <location filename="../dialogs/newsequencedialog.cpp" line="211"/>
         <source>Preset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="213"/>
-        <source>Film 4K</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="214"/>
-        <source>TV 4K (Ultra HD/2160p)</source>
-        <translation type="unfinished"></translation>
+        <translation>Preestablecidos:</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="215"/>
-        <source>1080p</source>
-        <translation type="unfinished"></translation>
+        <source>Film 4K</source>
+        <translation>Película 4K</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="216"/>
-        <source>720p</source>
-        <translation type="unfinished"></translation>
+        <source>TV 4K (Ultra HD/2160p)</source>
+        <translation>TV 4K (Ultra HD/2160p)</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="217"/>
-        <source>480p</source>
-        <translation type="unfinished"></translation>
+        <source>1080p</source>
+        <translation>1080p</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="218"/>
-        <source>360p</source>
-        <translation type="unfinished"></translation>
+        <source>720p</source>
+        <translation>720p</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="219"/>
-        <source>240p</source>
-        <translation type="unfinished"></translation>
+        <source>480p</source>
+        <translation>480p</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="220"/>
-        <source>144p</source>
-        <translation type="unfinished"></translation>
+        <source>360p</source>
+        <translation>360p</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="221"/>
-        <source>NTSC (480i)</source>
-        <translation type="unfinished"></translation>
+        <source>240p</source>
+        <translation>240p</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="222"/>
-        <source>PAL (576i)</source>
-        <translation type="unfinished"></translation>
+        <source>144p</source>
+        <translation>144p</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="223"/>
+        <source>NTSC (480i)</source>
+        <translation>NTSC (480i)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="224"/>
+        <source>PAL (576i)</source>
+        <translation>PAL (576i)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="225"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Personalizado</translation>
     </message>
     <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="231"/>
+        <location filename="../dialogs/newsequencedialog.cpp" line="233"/>
         <source>Video</source>
-        <translation type="unfinished"></translation>
+        <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="235"/>
+        <location filename="../dialogs/newsequencedialog.cpp" line="237"/>
         <source>Width:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ancho:</translation>
     </message>
     <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="241"/>
+        <location filename="../dialogs/newsequencedialog.cpp" line="243"/>
         <source>Height:</source>
-        <translation type="unfinished"></translation>
+        <translation>Alto:</translation>
     </message>
     <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="247"/>
+        <location filename="../dialogs/newsequencedialog.cpp" line="249"/>
         <source>Frame Rate:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="267"/>
-        <source>Pixel Aspect Ratio:</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad de Fotogramas (FPS):</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="269"/>
-        <source>Square Pixels (1.0)</source>
-        <translation type="unfinished"></translation>
+        <source>Pixel Aspect Ratio:</source>
+        <translation>Relación de aspecto de píxeles:</translation>
     </message>
     <message>
-        <location filename="../dialogs/newsequencedialog.cpp" line="272"/>
-        <source>Interlacing:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/newsequencedialog.cpp" line="271"/>
+        <source>Square Pixels (1.0)</source>
+        <translation>Píxeles cuadrados (1.0)</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="274"/>
+        <source>Interlacing:</source>
+        <translation>Entrelazado:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/newsequencedialog.cpp" line="276"/>
         <source>None (Progressive)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ninguno (Progresivo)</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="282"/>
         <source>Audio</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="286"/>
         <source>Sample Rate: </source>
-        <translation type="unfinished"></translation>
+        <translation>Frecuencia de muestreo:</translation>
     </message>
     <message>
         <location filename="../dialogs/newsequencedialog.cpp" line="304"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Name:</translation>
+    </message>
+</context>
+<context>
+    <name>Node</name>
+    <message>
+        <location filename="../nodes/node.cpp" line="12"/>
+        <source>Node</source>
+        <translation>Nodo</translation>
+    </message>
+</context>
+<context>
+    <name>NodeBlock</name>
+    <message>
+        <location filename="../nodes/nodes/nodeblock.cpp" line="6"/>
+        <source>Previous</source>
+        <translation>Anterior</translation>
+    </message>
+    <message>
+        <location filename="../nodes/nodes/nodeblock.cpp" line="11"/>
+        <source>Next</source>
+        <translation>Siguiente</translation>
+    </message>
+    <message>
+        <location filename="../nodes/nodes/nodeblock.cpp" line="46"/>
+        <source>Block</source>
+        <translation>Bloquear</translation>
+    </message>
+</context>
+<context>
+    <name>NodeEditor</name>
+    <message>
+        <location filename="../panels/nodeeditor.cpp" line="16"/>
+        <source>Node Editor</source>
+        <translation>Editor de Nodos</translation>
+    </message>
+</context>
+<context>
+    <name>NodeIO</name>
+    <message>
+        <location filename="../nodes/nodeio.cpp" line="235"/>
+        <source>Disable Keyframes</source>
+        <translation>Desconectar Fotogramas Clave</translation>
+    </message>
+    <message>
+        <location filename="../nodes/nodeio.cpp" line="236"/>
+        <source>Disabling keyframes will delete all current keyframes. Are you sure you want to do this?</source>
+        <translation>¡Al desactivar los fotogramas clave se eliminarán todos los fotogramas clave actuales! ¿Seguro que quieres hacer esto?</translation>
+    </message>
+</context>
+<context>
+    <name>NodeMedia</name>
+    <message>
+        <location filename="../nodes/nodes/nodemedia.cpp" line="18"/>
+        <source>Matrix</source>
+        <translation>Matriz</translation>
+    </message>
+    <message>
+        <location filename="../nodes/nodes/nodemedia.cpp" line="21"/>
+        <source>Texture</source>
+        <translation>Textura</translation>
+    </message>
+    <message>
+        <location filename="../nodes/nodes/nodemedia.cpp" line="27"/>
+        <source>Media</source>
+        <translation>Medios</translation>
+    </message>
+</context>
+<context>
+    <name>NodeTexturePassthru</name>
+    <message>
+        <location filename="../nodes/nodes/nodetexturepassthru.cpp" line="6"/>
+        <location filename="../nodes/nodes/nodetexturepassthru.cpp" line="9"/>
+        <source>Texture</source>
+        <translation>Textura</translation>
+    </message>
+    <message>
+        <location filename="../nodes/nodes/nodetexturepassthru.cpp" line="15"/>
+        <source>Image Output</source>
+        <translation>Salida de imagen</translation>
+    </message>
+</context>
+<context>
+    <name>NodeVideoClip</name>
+    <message>
+        <location filename="../nodes/nodes/nodevideoclip.cpp" line="6"/>
+        <location filename="../nodes/nodes/nodevideoclip.cpp" line="9"/>
+        <source>Texture</source>
+        <translation>Textura</translation>
+    </message>
+</context>
+<context>
+    <name>NodeView</name>
+    <message>
+        <location filename="../ui/nodeview.cpp" line="15"/>
+        <source>Node Editor</source>
+        <translation>Editor de Nodos</translation>
+    </message>
+</context>
+<context>
+    <name>OldEffectNode</name>
+    <message>
+        <location filename="../nodes/oldeffectnode.cpp" line="204"/>
+        <source>Save Effect Settings</source>
+        <translation>Guardar Ajustes del Efecto</translation>
+    </message>
+    <message>
+        <location filename="../nodes/oldeffectnode.cpp" line="206"/>
+        <location filename="../nodes/oldeffectnode.cpp" line="236"/>
+        <source>Effect XML Settings %1</source>
+        <translation>Configuración de efectos XML %1</translation>
+    </message>
+    <message>
+        <location filename="../nodes/oldeffectnode.cpp" line="224"/>
+        <source>Save Settings Failed</source>
+        <translation>El guardado de los ajustes a fallado</translation>
+    </message>
+    <message>
+        <location filename="../nodes/oldeffectnode.cpp" line="225"/>
+        <source>Failed to open &quot;%1&quot; for writing.</source>
+        <translation>Error al abrir &quot;%1&quot; para escribir.</translation>
+    </message>
+    <message>
+        <location filename="../nodes/oldeffectnode.cpp" line="234"/>
+        <source>Load Effect Settings</source>
+        <translation>Cargar Ajustes del Efecto</translation>
+    </message>
+    <message>
+        <location filename="../nodes/oldeffectnode.cpp" line="250"/>
+        <location filename="../nodes/oldeffectnode.cpp" line="452"/>
+        <source>Load Settings Failed</source>
+        <translation>La carga de los ajustes ha fallado</translation>
+    </message>
+    <message>
+        <location filename="../nodes/oldeffectnode.cpp" line="251"/>
+        <source>Failed to open &quot;%1&quot; for reading.</source>
+        <translation>Error al abrir &quot;%1&quot; para leer.</translation>
+    </message>
+    <message>
+        <location filename="../nodes/oldeffectnode.cpp" line="453"/>
+        <source>This settings file doesn&apos;t match this effect.</source>
+        <translation>Este archivo de configuración no es valido para este efecto.</translation>
     </message>
 </context>
 <context>
     <name>OliveGlobal</name>
     <message>
-        <location filename="../global/global.cpp" line="68"/>
+        <location filename="../global/global.cpp" line="75"/>
         <source>Olive Project %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Proyecto de Olive %1</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="96"/>
+        <location filename="../global/global.cpp" line="103"/>
         <source>Auto-recovery</source>
-        <translation type="unfinished"></translation>
+        <translation>Recuperación Automática</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="97"/>
+        <location filename="../global/global.cpp" line="104"/>
         <source>Olive didn&apos;t close properly and an autorecovery file was detected. Would you like to open it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Olive no se cerró correctamente y se generó un archivo de recuperación automática. ¿Deseas abrirlo?</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="239"/>
+        <location filename="../global/global.cpp" line="416"/>
+        <source>Effect already exists</source>
+        <translation>Effect already exists</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="417"/>
+        <source>Clip &apos;%1&apos; already contains a &apos;%2&apos; effect. Would you like to replace it with the pasted one or add it as a separate effect?</source>
+        <translation>El clip &apos;%1&apos; ya contiene un efecto &apos;%2&apos;. ¿Desea reemplazarlo con el que está pegando o agregarlo como un efecto separado?</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="422"/>
+        <source>Add</source>
+        <translation>Añadir</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="423"/>
+        <source>Replace</source>
+        <translation>Reemplazar</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="424"/>
+        <source>Skip</source>
+        <translation>Omitir</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="426"/>
+        <source>Do this for all conflicts found</source>
+        <translation>Haga esto para todos los conflictos encontrados</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="509"/>
         <source>Open Project...</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir Preyecto...</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="250"/>
+        <location filename="../global/global.cpp" line="520"/>
         <source>Missing recent project</source>
-        <translation type="unfinished"></translation>
+        <translation>No se encuentra este proyecto reciente, si lo ha movido de su ubicación desde que lo guardo por última vez deberá abrirlo manualmente</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="251"/>
+        <location filename="../global/global.cpp" line="521"/>
         <source>The project &apos;%1&apos; no longer exists. Would you like to remove it from the recent projects list?</source>
-        <translation type="unfinished"></translation>
+        <translation>El proyecto &apos;%1&apos; ya no existe. ¿Deseas eliminarlo de la lista de proyectos recientes?</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="262"/>
+        <location filename="../global/global.cpp" line="532"/>
         <source>Save Project As...</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar Proyecto Como...</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="287"/>
+        <location filename="../global/global.cpp" line="557"/>
         <source>Unsaved Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Proyecto no guardado</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="288"/>
+        <location filename="../global/global.cpp" line="558"/>
         <source>This project has changed since it was last saved. Would you like to save it before closing?</source>
-        <translation type="unfinished"></translation>
+        <translation>¡ADVERTENCIA! Se han realizado cambios desde la última vez que se guardó. ¿Deseas guardar éstos antes de cerrar?</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="382"/>
+        <location filename="../global/global.cpp" line="583"/>
+        <source>Import media...</source>
+        <translation>Importar Medios...</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="583"/>
+        <source>All Files</source>
+        <translation>Todos los Archivos</translation>
+    </message>
+    <message>
+        <location filename="../global/global.cpp" line="680"/>
         <source>No active sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Ninguna Secuaencia Activa</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="383"/>
+        <location filename="../global/global.cpp" line="681"/>
         <source>Please open the sequence to perform this action.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, abra la secuencia para realizar esta acción.</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="448"/>
+        <location filename="../global/global.cpp" line="813"/>
         <source>No clips selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Ningún Clip Seleccionado</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="449"/>
+        <location filename="../global/global.cpp" line="814"/>
         <source>Select the clips you wish to auto-cut</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccione los clips que desea cortar automáticamente</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="319"/>
+        <location filename="../global/global.cpp" line="616"/>
         <source>Missing Project File</source>
-        <translation type="unfinished"></translation>
+        <translation>No se encuentra el archivo de proyecto</translation>
     </message>
     <message>
-        <location filename="../global/global.cpp" line="320"/>
+        <location filename="../global/global.cpp" line="617"/>
         <source>Specified project &apos;%1&apos; does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation>El proyecto especificado &apos;%1&apos; no existe.</translation>
     </message>
 </context>
 <context>
     <name>PanEffect</name>
     <message>
         <location filename="../effects/internal/paneffect.cpp" line="32"/>
+        <location filename="../effects/internal/paneffect.cpp" line="40"/>
         <source>Pan</source>
-        <translation type="unfinished"></translation>
+        <translation>Panorámica</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/paneffect.cpp" line="50"/>
+        <source>Modifying the panning on a stereo audio clip.</source>
+        <translation>Modificar la panorámica en un clip de audio estéreo.</translation>
     </message>
 </context>
 <context>
     <name>PreferencesDialog</name>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="84"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="85"/>
         <source>Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="91"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="92"/>
         <source>Default Sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Secuencia Predeterminada</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="196"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="326"/>
         <source>Invalid CSS File</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivo CSS NO válido</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="197"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="327"/>
         <source>CSS file &apos;%1&apos; does not exist.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="363"/>
-        <source>Confirm Reset All Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="364"/>
-        <source>Are you sure you wish to reset all keyboard shortcuts to their defaults?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="414"/>
-        <source>Import Keyboard Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="438"/>
-        <location filename="../dialogs/preferencesdialog.cpp" line="462"/>
-        <source>Error saving shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="439"/>
-        <source>Failed to open file for reading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="446"/>
-        <source>Export Keyboard Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="460"/>
-        <source>Export Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="460"/>
-        <source>Shortcuts exported successfully</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="462"/>
-        <source>Failed to open file for writing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="468"/>
-        <source>Browse for CSS file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="476"/>
-        <source>Delete All Previews</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="477"/>
-        <source>Are you sure you want to delete all previews?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="481"/>
-        <source>Previews Deleted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="482"/>
-        <source>All previews deleted succesfully. You may have to re-open your current project for changes to take effect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="506"/>
-        <source>Language:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="583"/>
-        <source>Default Sequence Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="595"/>
-        <source>Add Default Effects to New Clips</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="599"/>
-        <source>Automatically Seek to the Beginning When Playing at the End of a Sequence</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="603"/>
-        <source>Selecting Also Seeks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="607"/>
-        <source>Edit Tool Also Seeks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="611"/>
-        <source>Edit Tool Selects Links</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="615"/>
-        <source>Seek Also Selects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="619"/>
-        <source>Seek to the End of Pastes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="623"/>
-        <source>Scroll Wheel Zooms</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="624"/>
-        <source>Hold CTRL to toggle this setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="628"/>
-        <source>Invert Timeline Scroll Axes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="632"/>
-        <source>Enable Drag Files to Timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="636"/>
-        <source>Auto-Scale By Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="640"/>
-        <source>Auto-Seek to Imported Clips</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="644"/>
-        <source>Audio Scrubbing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="648"/>
-        <source>Drop Files on Media to Replace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="652"/>
-        <source>Enable Hover Focus</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="656"/>
-        <source>Ask For Name When Setting Marker</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="662"/>
-        <source>Appearance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="669"/>
-        <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="672"/>
-        <source>Olive Dark (Default)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="673"/>
-        <source>Olive Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="674"/>
-        <source>Native</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="675"/>
-        <source>Native (Light Icons)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="684"/>
-        <source>Use Native Menu Styling</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="692"/>
-        <source>Custom CSS:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="698"/>
-        <source>Browse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="543"/>
-        <source>Image sequence formats:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="815"/>
-        <source>Audio Recording:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="818"/>
-        <source>Mono</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="819"/>
-        <source>Stereo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="705"/>
-        <source>Effect Textbox Lines:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="553"/>
-        <source>Thumbnail Resolution:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="561"/>
-        <source>Waveform Resolution:</source>
-        <translation type="unfinished"></translation>
+        <translation>El archivo CSS &apos;%1&apos; NO existe.</translation>
     </message>
     <message>
         <location filename="../dialogs/preferencesdialog.cpp" line="569"/>
-        <source>Delete Previews</source>
-        <translation type="unfinished"></translation>
+        <source>Confirm Reset All Shortcuts</source>
+        <translation>Confirmar restablecer todos los accesos directos</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="576"/>
-        <source>Use Software Fallbacks When Possible</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="570"/>
+        <source>Are you sure you wish to reset all keyboard shortcuts to their defaults?</source>
+        <translation>¿Está seguro de que desea restablecer todos los métodos abreviados de teclado a sus valores predeterminados?</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="587"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="620"/>
+        <source>Import Keyboard Shortcuts</source>
+        <translation>Importar Accesos Rápidos de Teclado</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="591"/>
-        <source>Behavior</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="644"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="668"/>
+        <source>Error saving shortcuts</source>
+        <translation>Error al guardar los Accesos Rápidos</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="720"/>
-        <source>Memory Usage</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="645"/>
+        <source>Failed to open file for reading</source>
+        <translation>Error al abrir el archivo de lectura</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="722"/>
-        <source>Upcoming Frame Queue:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="652"/>
+        <source>Export Keyboard Shortcuts</source>
+        <translation>Exportar los Accesos Rápidos de Teclado</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="666"/>
+        <source>Export Shortcuts</source>
+        <translation>Exportar Accesos Rápidos</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="666"/>
+        <source>Shortcuts exported successfully</source>
+        <translation>Atajos exportados exitosamente</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="668"/>
+        <source>Failed to open file for writing</source>
+        <translation>Error al abrir el archivo para escribir</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="674"/>
+        <source>Browse for CSS file</source>
+        <translation>Buscar el archivo CSS</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="696"/>
+        <source>Delete All Previews</source>
+        <translation>Eliminar todas las vistas previas</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="697"/>
+        <source>Are you sure you want to delete all previews?</source>
+        <translation>¿Estás seguro de que deseas eliminar todas las vistas previas?</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="701"/>
+        <source>Previews Deleted</source>
+        <translation>Vistas previas eliminadas</translation>
     </message>
     <message>
         <location filename="../dialogs/preferencesdialog.cpp" line="727"/>
-        <location filename="../dialogs/preferencesdialog.cpp" line="736"/>
-        <source>frames</source>
-        <translation type="unfinished"></translation>
+        <source>Language:</source>
+        <translation>Idioma:</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="728"/>
-        <location filename="../dialogs/preferencesdialog.cpp" line="737"/>
-        <source>seconds</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="731"/>
-        <source>Previous Frame Queue:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="742"/>
-        <source>Playback</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="753"/>
-        <source>Output Device:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="756"/>
-        <location filename="../dialogs/preferencesdialog.cpp" line="779"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="776"/>
-        <source>Input Device:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="799"/>
-        <source>Sample Rate:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="809"/>
+        <source>Default Sequence Settings</source>
+        <translation>Configuración predeterminada
+de las secuencias</translation>
     </message>
     <message>
         <location filename="../dialogs/preferencesdialog.cpp" line="825"/>
-        <source>Audio</source>
-        <translation type="unfinished"></translation>
+        <source>Add Default Effects to New Clips</source>
+        <translation>Añadir efectos predeterminados a los nuevos clips</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="829"/>
+        <source>Automatically Seek to the Beginning When Playing at the End of a Sequence</source>
+        <translation>Ir al principio cuando iniciamos la reproducción
+con el cursor al final de la secuencia</translation>
     </message>
     <message>
         <location filename="../dialogs/preferencesdialog.cpp" line="833"/>
-        <source>Search for action or shortcut</source>
-        <translation type="unfinished"></translation>
+        <source>Selecting Also Seeks</source>
+        <translation>Al seleccionar un clip
+poner el cursor en su inico</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="840"/>
-        <source>Action</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="837"/>
+        <source>Edit Tool Also Seeks</source>
+        <translation>Poner el cursor de reproducción
+al inicio de la selección</translation>
     </message>
     <message>
         <location filename="../dialogs/preferencesdialog.cpp" line="841"/>
-        <source>Shortcut</source>
-        <translation type="unfinished"></translation>
+        <source>Edit Tool Selects Links</source>
+        <translation>La selección incluye
+los clips vinculados</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="846"/>
-        <source>Import</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="845"/>
+        <source>Seek Also Selects</source>
+        <translation>El cursor de reproducción
+selecciona los clips que cruza</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="850"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="849"/>
+        <source>Seek to the End of Pastes</source>
+        <translation>Desplazar el cursor al final de lo pegado</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="856"/>
-        <source>Reset Selected</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="853"/>
+        <source>Scroll Wheel Zooms</source>
+        <translation>Usar rueda del ratón para hacer zoom</translation>
     </message>
     <message>
-        <location filename="../dialogs/preferencesdialog.cpp" line="860"/>
-        <source>Reset All</source>
-        <translation type="unfinished"></translation>
+        <location filename="../dialogs/preferencesdialog.cpp" line="854"/>
+        <source>Hold CTRL to toggle this setting</source>
+        <translation>Mantenga presionada la tecla CTRL para cambiar esta configuración</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="858"/>
+        <source>Invert Timeline Scroll Axes</source>
+        <translation>Rueda del ratón desplaza la línea de tiempo</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="862"/>
+        <source>Enable Drag Files to Timeline</source>
+        <translation>Habilitar poder arrastrar archivos a la línea de tiempo</translation>
     </message>
     <message>
         <location filename="../dialogs/preferencesdialog.cpp" line="866"/>
+        <source>Auto-Scale By Default</source>
+        <translation>Escala automática por defecto</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="870"/>
+        <source>Auto-Seek to Imported Clips</source>
+        <translation>Búsqueda automática de clips importados</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="874"/>
+        <source>Audio Scrubbing</source>
+        <translation>Limpiar o depurar Audio</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="878"/>
+        <source>Drop Files on Media to Replace</source>
+        <translation>Colocar archivos de medios para reemplazar</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="882"/>
+        <source>Enable Hover Focus</source>
+        <translation>Habilitar Enfoque flotante</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="886"/>
+        <source>Ask For Name When Setting Marker</source>
+        <translation>Preguntar por el nombre al insertar un marcador</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="892"/>
+        <source>Appearance</source>
+        <translation>Apariencia</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="899"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="902"/>
+        <source>Olive Dark (Default)</source>
+        <translation>Olive Oscuro (Por defecto)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="903"/>
+        <source>Olive Light</source>
+        <translation>Olive Claro</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="904"/>
+        <source>Native</source>
+        <translation>Nativo del sistema</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="905"/>
+        <source>Native (Light Icons)</source>
+        <translation>Nativo con Iconos Claros</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="914"/>
+        <source>Use Native Menu Styling</source>
+        <translation>Usar el estilo de menú nativo</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="922"/>
+        <source>Custom CSS:</source>
+        <translation>CSS Personalizado:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="928"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1085"/>
+        <source>Browse</source>
+        <translation>Buscar</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="764"/>
+        <source>Image sequence formats:</source>
+        <translation>Secuencia de imágenes.
+Formatos:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1045"/>
+        <source>Audio Recording:</source>
+        <translation>Grabación de audio en:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1048"/>
+        <source>Mono</source>
+        <translation>Monoaural (1 canal)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1049"/>
+        <source>Stereo</source>
+        <translation>Estéreo (2 canales)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="935"/>
+        <source>Effect Textbox Lines:</source>
+        <translation>Efectos de inserción de Texto.
+Líneas de los Cuadros de Texto:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="216"/>
+        <source>(None)</source>
+        <translation>(Nada)</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="238"/>
+        <source>OpenColorIO Config Error</source>
+        <translation>Error de configuración de OpenColorIO</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="239"/>
+        <source>Failed to set OpenColorIO configuration: %1</source>
+        <translation>Error al establecer la configuración de OpenColorIO: %1</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="338"/>
+        <source>Invalid OpenColorIO Configuration File</source>
+        <translation>Archivo de configuración de OpenColorIO no válido</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="342"/>
+        <source>You must specify an OpenColorIO configuration file if color management is enabled.</source>
+        <translation>Debe especificar un archivo de configuración de OpenColorIO si la administración de color está habilitada.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="344"/>
+        <source>OpenColorIO configuration file &apos;%1&apos; does not exist.</source>
+        <translation>El archivo de configuración de OpenColorIO &apos;%1&apos; no existe.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="682"/>
+        <source>Browse for OpenColorIO configuration</source>
+        <translation>Buscar la configuración OpenColorIO</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="702"/>
+        <source>All previews deleted successfully. You may have to re-open your current project for changes to take effect.</source>
+        <translation>Todas las vistas previas eliminadas con éxito. Es posible que tenga que volver a abrir su proyecto actual para que los cambios surtan efecto.</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="773"/>
+        <source>Thumbnail Resolution:</source>
+        <translation>Resolución miniaturas:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="781"/>
+        <source>Waveform Resolution:</source>
+        <translation>Resolución Onda de Audio:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="789"/>
+        <source>Delete Previews</source>
+        <translation>Eliminar vistas previas</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="798"/>
+        <source>Use Software Fallbacks When Possible</source>
+        <translation>Use los recursos de software cuando sea posible</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="803"/>
+        <source>Don&apos;t Use Proxies When Exporting</source>
+        <translation>No use proxies al exportar</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="804"/>
+        <source>Use originals instead of proxies when exporting</source>
+        <translation>Use originales en lugar de proxies al exportar</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="817"/>
+        <source>General</source>
+        <translation>General</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="821"/>
+        <source>Behavior</source>
+        <translation>Comportamiento</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="950"/>
+        <source>Memory Usage</source>
+        <translation>Uso de Memoria</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="952"/>
+        <source>Upcoming Frame Queue:</source>
+        <translation>Cargar cola de fotogramas en:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="957"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="966"/>
+        <source>frames</source>
+        <translation>Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="958"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="967"/>
+        <source>seconds</source>
+        <translation>segundos</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="961"/>
+        <source>Previous Frame Queue:</source>
+        <translation>Cola de fotogramas anteriores en:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="972"/>
+        <source>Playback</source>
+        <translation>Reproducir</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="983"/>
+        <source>Output Device:</source>
+        <translation>Dispositivo de Salida:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="986"/>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1009"/>
+        <source>Default</source>
+        <translation>Por defecto</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1006"/>
+        <source>Input Device:</source>
+        <translation>Dispositivo de Entrada:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1029"/>
+        <source>Sample Rate:</source>
+        <translation>Frecuencia de muestreo:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1055"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1068"/>
+        <source>Enable Color Management</source>
+        <translation>Habilitar la gestión del color</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1078"/>
+        <source>OpenColorIO Config File:</source>
+        <translation>Archivo de configuración de OpenColorIO:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1091"/>
+        <source>Default Input Color Space:</source>
+        <translation>Espacio de color de entrada predeterminado:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1097"/>
+        <source>Display:</source>
+        <translation>Monitor:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1102"/>
+        <source>View:</source>
+        <translation>Ver:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1107"/>
+        <source>Look:</source>
+        <translation>Mira:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1115"/>
+        <source>Bit Depth</source>
+        <translation>Profundidad de bits</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1124"/>
+        <source>Playback (Offline):</source>
+        <translation>Reproducción (sin conexión):</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1133"/>
+        <source>Export (Online):</source>
+        <translation>Exportar (sin conexión):</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1144"/>
+        <source>Color Management</source>
+        <translation>Manejo del color</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1152"/>
+        <source>Search for action or shortcut</source>
+        <translation>Buscar acción o atajo</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1159"/>
+        <source>Action</source>
+        <translation>Acción</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1160"/>
+        <source>Shortcut</source>
+        <translation>Atajo</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1165"/>
+        <source>Import</source>
+        <translation>Importar</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1169"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1175"/>
+        <source>Reset Selected</source>
+        <translation>Restablecer lo Seleccionado</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1179"/>
+        <source>Reset All</source>
+        <translation>Restablecer Todo</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/preferencesdialog.cpp" line="1185"/>
         <source>Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Atajos de Teclado</translation>
     </message>
 </context>
 <context>
     <name>PreviewGenerator</name>
     <message>
-        <location filename="../project/previewgenerator.cpp" line="203"/>
+        <location filename="../project/previewgenerator.cpp" line="202"/>
         <source>Failed to find any valid video/audio streams</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al encontrar cualquier transmisión de video/audio válida</translation>
     </message>
     <message>
-        <location filename="../project/previewgenerator.cpp" line="559"/>
+        <location filename="../project/previewgenerator.cpp" line="561"/>
         <source>Could not open file - %1</source>
-        <translation type="unfinished"></translation>
+        <translation>No se pudo abrir el archivo -%1</translation>
     </message>
     <message>
-        <location filename="../project/previewgenerator.cpp" line="566"/>
+        <location filename="../project/previewgenerator.cpp" line="568"/>
         <source>Could not find stream information - %1</source>
-        <translation type="unfinished"></translation>
+        <translation>No se pudo encontrar la información de la secuencia -%1</translation>
     </message>
 </context>
 <context>
     <name>Project</name>
     <message>
-        <location filename="../panels/project.cpp" line="99"/>
+        <location filename="../panels/project.cpp" line="95"/>
         <source>New</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="105"/>
+        <location filename="../panels/project.cpp" line="101"/>
         <source>Open Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir Proyecto</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="111"/>
+        <location filename="../panels/project.cpp" line="107"/>
         <source>Save Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar Proyecto</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="117"/>
+        <location filename="../panels/project.cpp" line="113"/>
         <source>Undo</source>
-        <translation type="unfinished"></translation>
+        <translation>Deshacer los cambiós</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="123"/>
+        <location filename="../panels/project.cpp" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"></translation>
+        <translation>Reacer los cambios</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="134"/>
+        <location filename="../panels/project.cpp" line="130"/>
         <source>Tree View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ver en árbol</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="140"/>
+        <location filename="../panels/project.cpp" line="136"/>
         <source>Icon View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ver como iconos</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="146"/>
+        <location filename="../panels/project.cpp" line="142"/>
         <source>List View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ver en modo lista</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="224"/>
+        <location filename="../panels/project.cpp" line="220"/>
         <source>Search media, markers, etc.</source>
-        <translation type="unfinished"></translation>
+        <translation>Buscar archivos multimedia, marcas, etc.</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="225"/>
+        <location filename="../panels/project.cpp" line="221"/>
         <source>Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Proyecto</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="229"/>
-        <source>Sequence</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/project.cpp" line="351"/>
-        <source>Replace &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/project.cpp" line="353"/>
-        <location filename="../panels/project.cpp" line="1002"/>
-        <source>All Files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/project.cpp" line="364"/>
-        <location filename="../panels/project.cpp" line="1014"/>
+        <location filename="../panels/project.cpp" line="257"/>
+        <location filename="../panels/project.cpp" line="571"/>
         <source>No active sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Sin secuencia activa</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="365"/>
+        <location filename="../panels/project.cpp" line="258"/>
         <source>No sequence is active, please open the sequence you want to replace clips from.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ninguna secuencia está activa, abra la secuencia desde la que desea reemplazar los clips.</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="373"/>
+        <location filename="../panels/project.cpp" line="266"/>
         <source>Active sequence selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Secuencia activa seleccionada</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="374"/>
+        <location filename="../panels/project.cpp" line="267"/>
         <source>You cannot insert a sequence into itself, so no clips of this media would be in this sequence.</source>
-        <translation type="unfinished"></translation>
+        <translation>No puede insertar una secuencia en sí misma, por lo que no habrá clips de este medio en esta secuencia.</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="405"/>
+        <location filename="../panels/project.cpp" line="298"/>
         <source>Rename &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Renombrar &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="406"/>
+        <location filename="../panels/project.cpp" line="299"/>
         <source>Enter new name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Introduzca un nuevo nombre:</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="576"/>
+        <location filename="../panels/project.cpp" line="393"/>
         <source>Delete media in use?</source>
-        <translation type="unfinished"></translation>
+        <translation>¿Realmente quieres borrar este archivo que está en uso?</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="577"/>
+        <location filename="../panels/project.cpp" line="394"/>
         <source>The media &apos;%1&apos; is currently used in &apos;%2&apos;. Deleting it will remove all instances in the sequence. Are you sure you want to do this?</source>
-        <translation type="unfinished"></translation>
+        <translation>El medio &apos;%1&apos; se usa actualmente en &apos;%2&apos;. Al eliminarlo se eliminarán todas las instancias en la secuencia. ¿Seguro que quieres hacer esto?</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="580"/>
+        <location filename="../panels/project.cpp" line="397"/>
         <source>Skip</source>
-        <translation type="unfinished"></translation>
+        <translation>Saltar/Omitir</translation>
     </message>
     <message>
-        <location filename="../panels/project.cpp" line="743"/>
-        <source>Import a Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/project.cpp" line="744"/>
-        <source>&quot;%1&quot; is an Olive project file. It will merge with this project. Do you wish to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/project.cpp" line="847"/>
-        <source>Image sequence detected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/project.cpp" line="848"/>
-        <source>The file &apos;%1&apos; appears to be part of an image sequence. Would you like to import it as such?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/project.cpp" line="1002"/>
-        <source>Import media...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/project.cpp" line="1015"/>
+        <location filename="../panels/project.cpp" line="572"/>
         <source>No sequence is active, please open the sequence you want to delete clips from.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ninguna secuencia está activa, abra la secuencia de la que desea eliminar los clips.</translation>
+    </message>
+</context>
+<context>
+    <name>ProjectModel</name>
+    <message>
+        <location filename="../project/projectmodel.cpp" line="275"/>
+        <source>Sequence %1</source>
+        <translation>Secuencia %1</translation>
+    </message>
+    <message>
+        <location filename="../project/projectmodel.cpp" line="459"/>
+        <source>Import a Project</source>
+        <translation>Importar un proyecto</translation>
+    </message>
+    <message>
+        <location filename="../project/projectmodel.cpp" line="460"/>
+        <source>&quot;%1&quot; is an Olive project file. It will merge with this project. Do you wish to continue?</source>
+        <translation>&quot;%1&quot; es un archivo de proyecto de Olive. Se fusionará con este proyecto. ¿Desea continuar?</translation>
+    </message>
+    <message>
+        <location filename="../project/projectmodel.cpp" line="563"/>
+        <source>Image sequence detected</source>
+        <translation>Secuencia de Imágenes Detectada</translation>
+    </message>
+    <message>
+        <location filename="../project/projectmodel.cpp" line="564"/>
+        <source>The file &apos;%1&apos; appears to be part of an image sequence. Would you like to import it as such?</source>
+        <translation>El archivo &apos;%1&apos; parece ser parte de una secuencia de imágenes. ¿Te gustaría importarlo como tal?</translation>
     </message>
 </context>
 <context>
@@ -2379,85 +2722,85 @@ Audio Layout: %6</source>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="41"/>
         <source>Create Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>Crear Proxy</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="44"/>
         <source>Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>Proxy</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="50"/>
         <source>Dimensions:</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensiones:</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="53"/>
         <source>Same Size as Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Mismo tamaño que la fuente</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="54"/>
         <source>Half Resolution (1/2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Resolución a la mitad (1/2)</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="55"/>
         <source>Quarter Resolution (1/4)</source>
-        <translation type="unfinished"></translation>
+        <translation>Resolución a un cuarto (1/4)</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="56"/>
         <source>Eighth Resolution (1/8)</source>
-        <translation type="unfinished"></translation>
+        <translation>Resolución a un octavo (1/8)</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="57"/>
         <source>Sixteenth Resolution (1/16)</source>
-        <translation type="unfinished"></translation>
+        <translation>Resolución a un dieciseisavo (1/16)</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="61"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Formato:</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="64"/>
         <source>ProRes HQ</source>
-        <translation type="unfinished"></translation>
+        <translation>ProRes HQ</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="72"/>
         <source>Location:</source>
-        <translation type="unfinished"></translation>
+        <translation>Localización:</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="75"/>
         <source>Same as Source (in &quot;%1&quot; folder)</source>
-        <translation type="unfinished"></translation>
+        <translation>Igual que la fuente (en la carpeta &quot;%1&quot;)</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="128"/>
         <source>Proxy file exists</source>
-        <translation type="unfinished"></translation>
+        <translation>El archivo proxy existe</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="129"/>
         <source>The file &quot;%1&quot; already exists. Do you wish to replace it?</source>
-        <translation type="unfinished"></translation>
+        <translation>El archivo &quot;%1&quot; ya existe. ¿Desea reemplazarlo?</translation>
     </message>
     <message>
         <location filename="../dialogs/proxydialog.cpp" line="182"/>
         <source>Custom Location</source>
-        <translation type="unfinished"></translation>
+        <translation>Ubicación Personalizada</translation>
     </message>
 </context>
 <context>
     <name>ProxyGenerator</name>
     <message>
-        <location filename="../project/proxygenerator.cpp" line="332"/>
+        <location filename="../project/proxygenerator.cpp" line="333"/>
         <source>Finished generating proxy for &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Terminado de generar el proxy para &quot;%1&quot;</translation>
     </message>
 </context>
 <context>
@@ -2465,173 +2808,188 @@ Audio Layout: %6</source>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="37"/>
         <source>Replace clips using &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Reemplazar clips usando &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="43"/>
         <source>Select which media you want to replace this media&apos;s clips with:</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccione el medio con el que desea reemplazar los clips de este medio por:</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="49"/>
         <source>Keep the same media in-points</source>
-        <translation type="unfinished"></translation>
+        <translation>Mantener los mismos puntos de entrada de medios</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="57"/>
         <source>Replace</source>
-        <translation type="unfinished"></translation>
+        <translation>Reemplazar</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="61"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="77"/>
         <source>No media selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Ningún medio seleccionado</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="78"/>
         <source>Please select a media to replace with or click &apos;Cancel&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccione un medio para reemplazar o haga clic en &quot;Cancelar&quot;.</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="86"/>
         <source>Same media selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Mismo medio seleccionado</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="87"/>
         <source>You selected the same media that you&apos;re replacing. Please select a different one or click &apos;Cancel&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionó el mismo medio que está reemplazando. Por favor, seleccione uno diferente o haga clic en &apos;Cancelar&apos;.</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="93"/>
         <source>Folder selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Carpeta Seleccionada</translation>
     </message>
     <message>
         <location filename="../dialogs/replaceclipmediadialog.cpp" line="94"/>
         <source>You cannot replace footage with a folder.</source>
-        <translation type="unfinished"></translation>
+        <translation>No puedes reemplazar las imágenes con una carpeta.</translation>
     </message>
     <message>
-        <location filename="../dialogs/replaceclipmediadialog.cpp" line="101"/>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="104"/>
         <source>Active sequence selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Secuencia activa seleccionada</translation>
     </message>
     <message>
-        <location filename="../dialogs/replaceclipmediadialog.cpp" line="102"/>
+        <location filename="../dialogs/replaceclipmediadialog.cpp" line="105"/>
         <source>You cannot insert a sequence into itself.</source>
-        <translation type="unfinished"></translation>
+        <translation>No puedes insertar una secuencia en sí misma.</translation>
     </message>
 </context>
 <context>
     <name>RichTextEffect</name>
     <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="22"/>
-        <source>Text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="26"/>
-        <source>Padding</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="30"/>
-        <source>Position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="34"/>
-        <source>Vertical Align:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="36"/>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="37"/>
-        <source>Center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="38"/>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="42"/>
-        <source>Auto-Scroll</source>
-        <translation type="unfinished"></translation>
+        <source>Text</source>
+        <translation>Texto</translation>
     </message>
     <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="44"/>
-        <source>Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="45"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
+        <source>Padding</source>
+        <translation>Relleno</translation>
     </message>
     <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="46"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="47"/>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
+        <source>Position</source>
+        <translation>Posición</translation>
     </message>
     <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="48"/>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
+        <source>Vertical Align:</source>
+        <translation>Alineación Vertical:</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="49"/>
+        <source>Top</source>
+        <translation>Arriba</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="50"/>
+        <source>Center</source>
+        <translation>Centro</translation>
     </message>
     <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="51"/>
-        <source>Shadow</source>
-        <translation type="unfinished"></translation>
+        <source>Bottom</source>
+        <translation>Abajo</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="54"/>
+        <source>Auto-Scroll</source>
+        <translation>Desplazamiento automático</translation>
     </message>
     <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="55"/>
-        <source>Shadow Color</source>
-        <translation type="unfinished"></translation>
+        <source>Off</source>
+        <translation>Apagado</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="56"/>
+        <source>Up</source>
+        <translation>Arriba</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="57"/>
+        <source>Down</source>
+        <translation>Abajo</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="58"/>
+        <source>Left</source>
+        <translation>Izquierda</translation>
     </message>
     <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="59"/>
-        <source>Shadow Angle</source>
-        <translation type="unfinished"></translation>
+        <source>Right</source>
+        <translation>Derecha</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="61"/>
+        <source>Shadow</source>
+        <translation>Sombra</translation>
     </message>
     <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="63"/>
-        <source>Shadow Distance</source>
-        <translation type="unfinished"></translation>
+        <source>Shadow Color</source>
+        <translation>Color de la Sombra</translation>
     </message>
     <message>
-        <location filename="../effects/internal/richtexteffect.cpp" line="68"/>
+        <location filename="../effects/internal/richtexteffect.cpp" line="65"/>
+        <source>Shadow Angle</source>
+        <translation>Angulo de la Sombra</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="67"/>
+        <source>Shadow Distance</source>
+        <translation>Distancia de la Sombra</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="70"/>
         <source>Shadow Softness</source>
-        <translation type="unfinished"></translation>
+        <translation>Suavizado de la Sombra</translation>
     </message>
     <message>
         <location filename="../effects/internal/richtexteffect.cpp" line="73"/>
         <source>Shadow Opacity</source>
-        <translation type="unfinished"></translation>
+        <translation>Opacidad de la Sombra</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="87"/>
+        <source>Rich Text</source>
+        <translation>Texto enriquecido</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="97"/>
+        <source>Render</source>
+        <translation>Renderizar (Calcular)</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/richtexteffect.cpp" line="102"/>
+        <source>Render formatted rich text over a clip.</source>
+        <translation>Renderizar texto enriquecido formateado sobre un clip.</translation>
     </message>
 </context>
 <context>
     <name>Sequence</name>
     <message>
-        <location filename="../timeline/sequence.cpp" line="41"/>
+        <location filename="../timeline/sequence.cpp" line="47"/>
         <source>%1 (copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (copiar)</translation>
     </message>
 </context>
 <context>
@@ -2639,17 +2997,32 @@ Audio Layout: %6</source>
     <message>
         <location filename="../effects/internal/shakeeffect.cpp" line="38"/>
         <source>Intensity</source>
-        <translation type="unfinished"></translation>
+        <translation>Intensidad</translation>
     </message>
     <message>
-        <location filename="../effects/internal/shakeeffect.cpp" line="43"/>
+        <location filename="../effects/internal/shakeeffect.cpp" line="42"/>
         <source>Rotation</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotación</translation>
     </message>
     <message>
-        <location filename="../effects/internal/shakeeffect.cpp" line="48"/>
+        <location filename="../effects/internal/shakeeffect.cpp" line="46"/>
         <source>Frequency</source>
-        <translation type="unfinished"></translation>
+        <translation>Frecuencia</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/shakeeffect.cpp" line="85"/>
+        <source>Shake</source>
+        <translation>Temblor/Movimiento</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/shakeeffect.cpp" line="95"/>
+        <source>Distort</source>
+        <translation>Distorsionar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/shakeeffect.cpp" line="100"/>
+        <source>Simulate a camera shake movement.</source>
+        <translation>Simular movimiento de la cámara.</translation>
     </message>
 </context>
 <context>
@@ -2657,180 +3030,205 @@ Audio Layout: %6</source>
     <message>
         <location filename="../effects/internal/solideffect.cpp" line="43"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="44"/>
+        <source>Solid Color</source>
+        <translation>Color Sólido</translation>
     </message>
     <message>
         <location filename="../effects/internal/solideffect.cpp" line="45"/>
-        <source>Solid Color</source>
-        <translation type="unfinished"></translation>
+        <source>SMPTE Bars</source>
+        <translation>Barras SMPTE</translation>
     </message>
     <message>
         <location filename="../effects/internal/solideffect.cpp" line="46"/>
-        <source>SMPTE Bars</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/solideffect.cpp" line="47"/>
         <source>Checkerboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Tablero de damas</translation>
     </message>
     <message>
-        <location filename="../effects/internal/solideffect.cpp" line="49"/>
+        <location filename="../effects/internal/solideffect.cpp" line="48"/>
         <source>Opacity</source>
-        <translation type="unfinished"></translation>
+        <translation>Opacidad</translation>
     </message>
     <message>
-        <location filename="../effects/internal/solideffect.cpp" line="55"/>
+        <location filename="../effects/internal/solideffect.cpp" line="53"/>
         <source>Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Color</translation>
     </message>
     <message>
-        <location filename="../effects/internal/solideffect.cpp" line="59"/>
+        <location filename="../effects/internal/solideffect.cpp" line="56"/>
         <source>Checkerboard Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamaño de los cuadros</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="74"/>
+        <source>Solid</source>
+        <translation>Sólido</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="84"/>
+        <source>Render</source>
+        <translation>Renderizar/Calcular</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/solideffect.cpp" line="89"/>
+        <source>Render a solid color over this clip.</source>
+        <translation>Renderiza un color sólido sobre este clip.</translation>
     </message>
 </context>
 <context>
     <name>SourcesCommon</name>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="83"/>
+        <location filename="../project/sourcescommon.cpp" line="84"/>
         <source>Import...</source>
-        <translation type="unfinished"></translation>
+        <translation>Impotar...</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="86"/>
+        <location filename="../project/sourcescommon.cpp" line="87"/>
         <source>New</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="90"/>
+        <location filename="../project/sourcescommon.cpp" line="91"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="93"/>
+        <location filename="../project/sourcescommon.cpp" line="94"/>
         <source>Tree View</source>
-        <translation type="unfinished"></translation>
+        <translation>Vista en árbol</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="96"/>
+        <location filename="../project/sourcescommon.cpp" line="97"/>
         <source>Icon View</source>
-        <translation type="unfinished"></translation>
+        <translation>Vista de Icono</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="99"/>
+        <location filename="../project/sourcescommon.cpp" line="100"/>
         <source>Show Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar la barra de herramientas</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="104"/>
+        <location filename="../project/sourcescommon.cpp" line="105"/>
         <source>Show Sequences</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar Secuencias</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="116"/>
+        <location filename="../project/sourcescommon.cpp" line="117"/>
         <source>Replace/Relink Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Reemplazar/Revincular Medios</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="120"/>
+        <location filename="../project/sourcescommon.cpp" line="121"/>
         <source>Reveal in Explorer</source>
-        <translation type="unfinished"></translation>
+        <translation>Revelar en el explorador</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="122"/>
+        <location filename="../project/sourcescommon.cpp" line="123"/>
         <source>Reveal in Finder</source>
-        <translation type="unfinished"></translation>
+        <translation>Revelar en el buscador</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="124"/>
+        <location filename="../project/sourcescommon.cpp" line="125"/>
         <source>Reveal in File Manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Revelar en el administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="129"/>
+        <location filename="../project/sourcescommon.cpp" line="130"/>
         <source>Replace Clips Using This Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Reemplazar clips utilizando este medio</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="152"/>
+        <location filename="../project/sourcescommon.cpp" line="153"/>
         <source>Create Sequence With This Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Crear secuencia con este medio</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="158"/>
+        <location filename="../project/sourcescommon.cpp" line="159"/>
         <source>Duplicate</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="164"/>
+        <location filename="../project/sourcescommon.cpp" line="165"/>
         <source>Delete All Clips Using This Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar todos los clips que utilizan este medio</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="167"/>
+        <location filename="../project/sourcescommon.cpp" line="168"/>
         <source>Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>Trabajar con Proxy</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="174"/>
+        <location filename="../project/sourcescommon.cpp" line="175"/>
         <source>Generating proxy: %1% complete</source>
-        <translation type="unfinished"></translation>
+        <translation>Generando proxy: %1% completado</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="198"/>
+        <location filename="../project/sourcescommon.cpp" line="199"/>
         <source>Create/Modify Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>Crear/Modificar Proxy</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="201"/>
+        <location filename="../project/sourcescommon.cpp" line="202"/>
         <source>Create Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>Crear Proxy</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="212"/>
+        <location filename="../project/sourcescommon.cpp" line="213"/>
         <source>Modify Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>Modificar Proxy</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="215"/>
+        <location filename="../project/sourcescommon.cpp" line="216"/>
         <source>Restore Original</source>
-        <translation type="unfinished"></translation>
+        <translation>Restaurar Original</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="221"/>
+        <location filename="../project/sourcescommon.cpp" line="222"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="228"/>
+        <location filename="../project/sourcescommon.cpp" line="229"/>
         <source>Preview in Media Viewer</source>
-        <translation type="unfinished"></translation>
+        <translation>Previsualizar en el visor de medios</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="234"/>
+        <location filename="../project/sourcescommon.cpp" line="235"/>
         <source>Properties...</source>
-        <translation type="unfinished"></translation>
+        <translation>Propiedades...</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="291"/>
+        <location filename="../project/sourcescommon.cpp" line="248"/>
+        <source>Replace &apos;%1&apos;</source>
+        <translation>Reemplazar &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="250"/>
+        <source>All Files</source>
+        <translation>Todos los archivos</translation>
+    </message>
+    <message>
+        <location filename="../project/sourcescommon.cpp" line="307"/>
         <source>Replace Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Reemplazar medios</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="292"/>
+        <location filename="../project/sourcescommon.cpp" line="308"/>
         <source>You dropped a file onto &apos;%1&apos;. Would you like to replace it with the dropped file?</source>
-        <translation type="unfinished"></translation>
+        <translation>Has colocado un archivo en &apos;%1&apos;. ¿Te gustaría reemplazarlo con el archivo caído?</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="421"/>
+        <location filename="../project/sourcescommon.cpp" line="437"/>
         <source>Delete proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar Proxy</translation>
     </message>
     <message>
-        <location filename="../project/sourcescommon.cpp" line="422"/>
+        <location filename="../project/sourcescommon.cpp" line="438"/>
         <source>Would you like to delete the proxy file &quot;%1&quot; as well?</source>
-        <translation type="unfinished"></translation>
+        <translation>¿Desea eliminar el archivo proxy &quot;%1&quot; también?</translation>
     </message>
 </context>
 <context>
@@ -2838,37 +3236,38 @@ Audio Layout: %6</source>
     <message>
         <location filename="../dialogs/speeddialog.cpp" line="40"/>
         <source>Speed/Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad/Duración</translation>
     </message>
     <message>
         <location filename="../dialogs/speeddialog.cpp" line="49"/>
         <source>Speed:</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad:</translation>
     </message>
     <message>
         <location filename="../dialogs/speeddialog.cpp" line="56"/>
         <source>Frame Rate:</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad
+Fotogramas:</translation>
     </message>
     <message>
         <location filename="../dialogs/speeddialog.cpp" line="61"/>
         <source>Duration:</source>
-        <translation type="unfinished"></translation>
+        <translation>Duración:</translation>
     </message>
     <message>
         <location filename="../dialogs/speeddialog.cpp" line="69"/>
         <source>Reverse</source>
-        <translation type="unfinished"></translation>
+        <translation>Invertir Dirección</translation>
     </message>
     <message>
         <location filename="../dialogs/speeddialog.cpp" line="70"/>
         <source>Maintain Audio Pitch</source>
-        <translation type="unfinished"></translation>
+        <translation>Mantener el Tono del Audio</translation>
     </message>
     <message>
         <location filename="../dialogs/speeddialog.cpp" line="71"/>
         <source>Ripple Changes</source>
-        <translation type="unfinished"></translation>
+        <translation>Desplazar clips contiguos</translation>
     </message>
 </context>
 <context>
@@ -2876,390 +3275,397 @@ Audio Layout: %6</source>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="35"/>
         <source>Edit Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Editar texto</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="68"/>
         <source>Thin</source>
-        <translation type="unfinished"></translation>
+        <translation>Fino</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="69"/>
         <source>Extra Light</source>
-        <translation type="unfinished"></translation>
+        <translation>Extra Fino</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="70"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation>Suave</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="71"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation>Normal</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="72"/>
         <source>Medium</source>
-        <translation type="unfinished"></translation>
+        <translation>Medio</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="73"/>
         <source>Demi Bold</source>
-        <translation type="unfinished"></translation>
+        <translation>Semi Negrita</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="74"/>
         <source>Bold</source>
-        <translation type="unfinished"></translation>
+        <translation>Negrita</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="75"/>
         <source>Extra Bold</source>
-        <translation type="unfinished"></translation>
+        <translation>Extra Negrita</translation>
     </message>
     <message>
         <location filename="../dialogs/texteditdialog.cpp" line="76"/>
         <source>Black</source>
-        <translation type="unfinished"></translation>
+        <translation>Grueso</translation>
     </message>
 </context>
 <context>
     <name>TextEditEx</name>
     <message>
-        <location filename="../ui/texteditex.cpp" line="40"/>
+        <location filename="../ui/texteditex.cpp" line="46"/>
         <source>Edit Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Editar Texto</translation>
     </message>
     <message>
-        <location filename="../ui/texteditex.cpp" line="88"/>
+        <location filename="../ui/texteditex.cpp" line="94"/>
         <source>&amp;Edit Text</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Editar Texto</translation>
     </message>
 </context>
 <context>
     <name>TextEffect</name>
     <message>
-        <location filename="../effects/internal/texteffect.cpp" line="51"/>
+        <location filename="../effects/internal/texteffect.cpp" line="50"/>
+        <location filename="../effects/internal/texteffect.cpp" line="126"/>
         <source>Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../effects/internal/texteffect.cpp" line="55"/>
+        <location filename="../effects/internal/texteffect.cpp" line="52"/>
         <source>Font</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuente</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="54"/>
+        <source>Size</source>
+        <translation>Tamaño</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="57"/>
+        <source>Color</source>
+        <translation>Color</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="59"/>
-        <source>Size</source>
-        <translation type="unfinished"></translation>
+        <source>Horizontal Alignment</source>
+        <translation>Alineación Horizontal</translation>
     </message>
     <message>
-        <location filename="../effects/internal/texteffect.cpp" line="64"/>
-        <source>Color</source>
-        <translation type="unfinished"></translation>
+        <location filename="../effects/internal/texteffect.cpp" line="60"/>
+        <source>Left</source>
+        <translation>Izquierda</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="61"/>
+        <location filename="../effects/internal/texteffect.cpp" line="67"/>
+        <source>Center</source>
+        <translation>Centrado</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="62"/>
+        <source>Right</source>
+        <translation>Derecha</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="63"/>
+        <source>Justify</source>
+        <translation>Justificado</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="65"/>
+        <source>Vertical Alignment</source>
+        <translation>Alineación Vertical</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="66"/>
+        <source>Top</source>
+        <translation>Arriba</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="68"/>
-        <source>Alignment</source>
-        <translation type="unfinished"></translation>
+        <source>Bottom</source>
+        <translation>Abajo</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="70"/>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/texteffect.cpp" line="71"/>
-        <location filename="../effects/internal/texteffect.cpp" line="77"/>
-        <source>Center</source>
-        <translation type="unfinished"></translation>
+        <source>Word Wrap</source>
+        <translation>Ajuste de línea</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="72"/>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
+        <source>Padding</source>
+        <translation>Margen</translation>
     </message>
     <message>
-        <location filename="../effects/internal/texteffect.cpp" line="73"/>
-        <source>Justify</source>
-        <translation type="unfinished"></translation>
+        <location filename="../effects/internal/texteffect.cpp" line="74"/>
+        <source>Position</source>
+        <translation>Posición</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="76"/>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
+        <source>Outline</source>
+        <translation>Contorno</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="78"/>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
+        <source>Outline Color</source>
+        <translation>Color Contorno</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="80"/>
-        <source>Word Wrap</source>
-        <translation type="unfinished"></translation>
+        <source>Outline Width</source>
+        <translation>Ancho del Contorno</translation>
     </message>
     <message>
-        <location filename="../effects/internal/texteffect.cpp" line="84"/>
-        <source>Padding</source>
-        <translation type="unfinished"></translation>
+        <location filename="../effects/internal/texteffect.cpp" line="83"/>
+        <source>Shadow</source>
+        <translation>Sombra</translation>
     </message>
     <message>
-        <location filename="../effects/internal/texteffect.cpp" line="88"/>
-        <source>Position</source>
-        <translation type="unfinished"></translation>
+        <location filename="../effects/internal/texteffect.cpp" line="85"/>
+        <source>Shadow Color</source>
+        <translation>Color Sombra</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="87"/>
+        <source>Shadow Angle</source>
+        <translation>Ángulo Sombra</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="89"/>
+        <source>Shadow Distance</source>
+        <translation>Distancia Sombra</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="92"/>
-        <source>Outline</source>
-        <translation type="unfinished"></translation>
+        <source>Shadow Softness</source>
+        <translation>Suavidad Sombra</translation>
     </message>
     <message>
-        <location filename="../effects/internal/texteffect.cpp" line="96"/>
-        <source>Outline Color</source>
-        <translation type="unfinished"></translation>
+        <location filename="../effects/internal/texteffect.cpp" line="95"/>
+        <source>Shadow Opacity</source>
+        <translation>Opacidad Sombra</translation>
     </message>
     <message>
         <location filename="../effects/internal/texteffect.cpp" line="100"/>
-        <source>Outline Width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/texteffect.cpp" line="105"/>
-        <source>Shadow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/texteffect.cpp" line="109"/>
-        <source>Shadow Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/texteffect.cpp" line="113"/>
-        <source>Shadow Angle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/texteffect.cpp" line="117"/>
-        <source>Shadow Distance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/texteffect.cpp" line="122"/>
-        <source>Shadow Softness</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/texteffect.cpp" line="127"/>
-        <source>Shadow Opacity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/texteffect.cpp" line="134"/>
         <source>Sample Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Texto de ejemplo</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="136"/>
+        <source>Render</source>
+        <translation>Renderizar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/texteffect.cpp" line="141"/>
+        <source>Generate simple text over this clip</source>
+        <translation>Generar texto simple sobre este clip</translation>
     </message>
 </context>
 <context>
     <name>TimecodeEffect</name>
     <message>
-        <location filename="../effects/internal/timecodeeffect.cpp" line="51"/>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="50"/>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="79"/>
         <source>Timecode</source>
-        <translation type="unfinished"></translation>
+        <translation>Código de Tiempo</translation>
     </message>
     <message>
-        <location filename="../effects/internal/timecodeeffect.cpp" line="53"/>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="51"/>
         <source>Sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Secuencia</translation>
     </message>
     <message>
-        <location filename="../effects/internal/timecodeeffect.cpp" line="54"/>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="52"/>
         <source>Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Clip</translation>
     </message>
     <message>
-        <location filename="../effects/internal/timecodeeffect.cpp" line="57"/>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="55"/>
         <source>Scale</source>
-        <translation type="unfinished"></translation>
+        <translation>Escala</translation>
     </message>
     <message>
-        <location filename="../effects/internal/timecodeeffect.cpp" line="64"/>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="60"/>
         <source>Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Color</translation>
     </message>
     <message>
-        <location filename="../effects/internal/timecodeeffect.cpp" line="69"/>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="63"/>
         <source>Background Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Color del Fondo</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="66"/>
+        <source>Background Opacity</source>
+        <translation>Opacidad del Fondo</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="71"/>
+        <source>Offset</source>
+        <translation>Compensar x-y</translation>
     </message>
     <message>
         <location filename="../effects/internal/timecodeeffect.cpp" line="74"/>
-        <source>Background Opacity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/timecodeeffect.cpp" line="81"/>
-        <source>Offset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/timecodeeffect.cpp" line="85"/>
         <source>Prepend</source>
-        <translation type="unfinished"></translation>
+        <translation>Anteponer</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="89"/>
+        <source>Render</source>
+        <translation>Renderizar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/timecodeeffect.cpp" line="94"/>
+        <source>Render the media or sequence timecode on this clip.</source>
+        <translation>Renderice el código de tiempo de los medios, o la secuencia, en este clip.</translation>
     </message>
 </context>
 <context>
     <name>Timeline</name>
     <message>
-        <location filename="../panels/timeline.cpp" line="1939"/>
-        <source>Timeline: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/timeline.cpp" line="487"/>
+        <location filename="../panels/timeline.cpp" line="338"/>
         <source>Nested Sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Secuencia Anidada</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1353"/>
-        <source>Effect already exists</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/timeline.cpp" line="1354"/>
-        <source>Clip &apos;%1&apos; already contains a &apos;%2&apos; effect. Would you like to replace it with the pasted one or add it as a separate effect?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/timeline.cpp" line="1359"/>
-        <source>Add</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/timeline.cpp" line="1360"/>
-        <source>Replace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/timeline.cpp" line="1361"/>
-        <source>Skip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/timeline.cpp" line="1363"/>
-        <source>Do this for all conflicts found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/timeline.cpp" line="1826"/>
+        <location filename="../panels/timeline.cpp" line="824"/>
         <source>Title...</source>
-        <translation type="unfinished"></translation>
+        <translation>Título...</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1831"/>
+        <location filename="../panels/timeline.cpp" line="829"/>
         <source>Solid Color...</source>
-        <translation type="unfinished"></translation>
+        <translation>Color Sólido...</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1836"/>
+        <location filename="../panels/timeline.cpp" line="834"/>
         <source>Bars...</source>
-        <translation type="unfinished"></translation>
+        <translation>Barras...</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1843"/>
+        <location filename="../panels/timeline.cpp" line="841"/>
         <source>Tone...</source>
-        <translation type="unfinished"></translation>
+        <translation>Tono...</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1848"/>
+        <location filename="../panels/timeline.cpp" line="846"/>
         <source>Noise...</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruido...</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1871"/>
+        <location filename="../panels/timeline.cpp" line="869"/>
         <source>Unsaved Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Proyecto sin guardar</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1872"/>
+        <location filename="../panels/timeline.cpp" line="870"/>
         <source>You must save this project before you can record audio in it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Debe guardar este proyecto antes de poder grabar audio en él.</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1878"/>
+        <location filename="../panels/timeline.cpp" line="876"/>
         <source>Click on the timeline where you want to start recording (drag to limit the recording to a certain timeframe)</source>
-        <translation type="unfinished"></translation>
+        <translation>Haga clic en la línea de tiempo donde desea iniciar la grabación (arrastre para limitar la grabación a un determinado período de tiempo)</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="1941"/>
+        <location filename="../panels/timeline.cpp" line="886"/>
+        <source>Video Transitions</source>
+        <translation>Transiciones de Vídeo</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="898"/>
+        <source>Audio Transitions</source>
+        <translation>Transiciones de Audio</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="932"/>
+        <source>Timeline: %1</source>
+        <translation>Linea de Tiempo: %1</translation>
+    </message>
+    <message>
+        <location filename="../panels/timeline.cpp" line="933"/>
         <source>(none)</source>
-        <translation type="unfinished"></translation>
+        <translation>(Ninguno)</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="124"/>
+        <location filename="../panels/timeline.cpp" line="243"/>
         <source>Pointer Tool</source>
-        <translation type="unfinished"></translation>
+        <translation>Puntero de Selección/Edición/Mover Clips</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="125"/>
+        <location filename="../panels/timeline.cpp" line="244"/>
         <source>Edit Tool</source>
-        <translation type="unfinished"></translation>
+        <translation>Herramienta de Selección</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="126"/>
+        <location filename="../panels/timeline.cpp" line="245"/>
         <source>Ripple Tool</source>
-        <translation type="unfinished"></translation>
+        <translation>Herramienta para Enrrollar/Desenrrollar</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="127"/>
+        <location filename="../panels/timeline.cpp" line="246"/>
         <source>Razor Tool</source>
-        <translation type="unfinished"></translation>
+        <translation>Herramienta de corte</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="128"/>
+        <location filename="../panels/timeline.cpp" line="247"/>
         <source>Slip Tool</source>
-        <translation type="unfinished"></translation>
+        <translation>Deslizar clip sin desplazar</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="129"/>
+        <location filename="../panels/timeline.cpp" line="248"/>
         <source>Slide Tool</source>
-        <translation type="unfinished"></translation>
+        <translation>Desplazar clip afectando a los clips contiguos</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="130"/>
+        <location filename="../panels/timeline.cpp" line="249"/>
         <source>Hand Tool</source>
-        <translation type="unfinished"></translation>
+        <translation>Herramienta de Mano</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="131"/>
+        <location filename="../panels/timeline.cpp" line="250"/>
         <source>Transition Tool</source>
-        <translation type="unfinished"></translation>
+        <translation>Herramienta para Inserción de Transiciones</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="132"/>
+        <location filename="../panels/timeline.cpp" line="251"/>
         <source>Snapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Imantar</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="133"/>
+        <location filename="../panels/timeline.cpp" line="252"/>
         <source>Zoom In</source>
-        <translation type="unfinished"></translation>
+        <translation>Acercar (Zoom)</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="134"/>
+        <location filename="../panels/timeline.cpp" line="253"/>
         <source>Zoom Out</source>
-        <translation type="unfinished"></translation>
+        <translation>Alejar (Zoom)</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="135"/>
+        <location filename="../panels/timeline.cpp" line="254"/>
         <source>Record audio</source>
-        <translation type="unfinished"></translation>
+        <translation>Grabar Audio</translation>
     </message>
     <message>
-        <location filename="../panels/timeline.cpp" line="136"/>
+        <location filename="../panels/timeline.cpp" line="255"/>
         <source>Add title, solid, bars, etc.</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir clip de:.</translation>
     </message>
 </context>
 <context>
@@ -3267,7 +3673,119 @@ Audio Layout: %6</source>
     <message>
         <location filename="../ui/timelineheader.cpp" line="486"/>
         <source>Center Timecodes</source>
-        <translation type="unfinished"></translation>
+        <translation>Centrar Código de Tiempo</translation>
+    </message>
+</context>
+<context>
+    <name>TimelineLabel</name>
+    <message>
+        <location filename="../ui/timelinelabel.cpp" line="97"/>
+        <source>Rename Track</source>
+        <translation>Renombrar Pista</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelinelabel.cpp" line="98"/>
+        <source>Enter the new name for this track</source>
+        <translation>Introduzca el nuevo nombre para esta pista</translation>
+    </message>
+</context>
+<context>
+    <name>TimelineView</name>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="112"/>
+        <source>&amp;Undo</source>
+        <translation>&amp;Deshacer</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="113"/>
+        <source>&amp;Redo</source>
+        <translation>&amp;Rehacer</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="135"/>
+        <source>R&amp;ipple Delete Empty Space</source>
+        <translation>&amp;Eliminar espacio vacío</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="139"/>
+        <source>Sequence Settings</source>
+        <translation>Ajustes de la Secuencia</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="158"/>
+        <source>&amp;Speed/Duration</source>
+        <translation>Cambiar &amp;Velocidad/Duración</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="161"/>
+        <source>Auto-Cut Silence</source>
+        <translation>Corte de Silencio Automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="164"/>
+        <source>Auto-S&amp;cale</source>
+        <translation>Escala Aut&amp;omática</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="182"/>
+        <source>&amp;Reveal in Project</source>
+        <translation>&amp;Revelar en Proyecto</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="186"/>
+        <source>Properties</source>
+        <translation>Propiedades</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="211"/>
+        <source>%1
+Start: %2
+End: %3
+Duration: %4</source>
+        <translation>%1
+Inicio: %2
+Final: %3
+Duración: %4</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="233"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="233"/>
+        <source>Couldn&apos;t locate media wrapper for sequence.</source>
+        <translation>No se pudo localizar el contenedor de medios para la secuencia.</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="1039"/>
+        <source>Title</source>
+        <translation>Título</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="1043"/>
+        <source>Solid Color</source>
+        <translation>Color Sólido</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="1048"/>
+        <source>Bars</source>
+        <translation>Barras</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="1059"/>
+        <source>Tone</source>
+        <translation>Tono</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="1063"/>
+        <source>Noise</source>
+        <translation>Ruido</translation>
+    </message>
+    <message>
+        <location filename="../ui/timelineview.cpp" line="2006"/>
+        <source>Duration:</source>
+        <translation>Duración:</translation>
     </message>
 </context>
 <context>
@@ -3275,27 +3793,27 @@ Audio Layout: %6</source>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="90"/>
         <source>&amp;Undo</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Deshacer</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="91"/>
         <source>&amp;Redo</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Rehacer</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="115"/>
         <source>Sequence Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajustes de la Secuencia</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="134"/>
         <source>&amp;Speed/Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Cambiar &amp;Velocidad/Duración</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="175"/>
         <source>&amp;Reveal in Project</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Revelar en Proyecto</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="207"/>
@@ -3303,67 +3821,70 @@ Audio Layout: %6</source>
 Start: %2
 End: %3
 Duration: %4</source>
-        <translation type="unfinished"></translation>
+        <translation>%1
+Inicio: %2
+Final: %3
+Duración: %4</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="111"/>
         <source>R&amp;ipple Delete Empty Space</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Eliminar espacio vacío</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="137"/>
         <source>Auto-Cut Silence</source>
-        <translation type="unfinished"></translation>
+        <translation>Corte de Silencio Automático</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="140"/>
         <source>Auto-S&amp;cale</source>
-        <translation type="unfinished"></translation>
+        <translation>Escala Aut&amp;omática</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="179"/>
         <source>Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Propiedades</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="233"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="233"/>
         <source>Couldn&apos;t locate media wrapper for sequence.</source>
-        <translation type="unfinished"></translation>
+        <translation>No se pudo localizar el contenedor de medios para la secuencia.</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="1041"/>
         <source>Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Título</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="1045"/>
         <source>Solid Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Color Sólido</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="1050"/>
         <source>Bars</source>
-        <translation type="unfinished"></translation>
+        <translation>Barras</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="1061"/>
         <source>Tone</source>
-        <translation type="unfinished"></translation>
+        <translation>Tono</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="1065"/>
         <source>Noise</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruido</translation>
     </message>
     <message>
         <location filename="../ui/timelinewidget.cpp" line="1994"/>
         <source>Duration:</source>
-        <translation type="unfinished"></translation>
+        <translation>Duración:</translation>
     </message>
 </context>
 <context>
@@ -3371,27 +3892,60 @@ Duration: %4</source>
     <message>
         <location filename="../effects/internal/toneeffect.cpp" line="31"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../effects/internal/toneeffect.cpp" line="33"/>
+        <location filename="../effects/internal/toneeffect.cpp" line="32"/>
         <source>Sine</source>
-        <translation type="unfinished"></translation>
+        <translation>Sinusoidal</translation>
     </message>
     <message>
-        <location filename="../effects/internal/toneeffect.cpp" line="35"/>
+        <location filename="../effects/internal/toneeffect.cpp" line="34"/>
         <source>Frequency</source>
-        <translation type="unfinished"></translation>
+        <translation>Frecuencia</translation>
     </message>
     <message>
-        <location filename="../effects/internal/toneeffect.cpp" line="41"/>
+        <location filename="../effects/internal/toneeffect.cpp" line="39"/>
         <source>Amount</source>
-        <translation type="unfinished"></translation>
+        <translation>Cantidad</translation>
     </message>
     <message>
-        <location filename="../effects/internal/toneeffect.cpp" line="47"/>
+        <location filename="../effects/internal/toneeffect.cpp" line="44"/>
         <source>Mix</source>
-        <translation type="unfinished"></translation>
+        <translation>Mezclar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/toneeffect.cpp" line="50"/>
+        <source>Tone</source>
+        <translation>Tono</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/toneeffect.cpp" line="60"/>
+        <source>Generate a sine wave tone to mix into this clip&apos;s audio.</source>
+        <translation>Genera un tono de onda sinusoidal para mezclarlo con el audio de este clip.</translation>
+    </message>
+</context>
+<context>
+    <name>Track</name>
+    <message>
+        <location filename="../timeline/track.cpp" line="78"/>
+        <source>Video %1</source>
+        <translation>Vídeo %1</translation>
+    </message>
+    <message>
+        <location filename="../timeline/track.cpp" line="80"/>
+        <source>Audio %1</source>
+        <translation>Audio %1</translation>
+    </message>
+    <message>
+        <location filename="../timeline/track.cpp" line="82"/>
+        <source>Subtitle %1</source>
+        <translation>Subtítulo %1</translation>
+    </message>
+    <message>
+        <location filename="../timeline/track.cpp" line="84"/>
+        <source>Unknown %1</source>
+        <translation>Desconocido %1</translation>
     </message>
 </context>
 <context>
@@ -3399,235 +3953,281 @@ Duration: %4</source>
     <message>
         <location filename="../effects/internal/transformeffect.cpp" line="49"/>
         <source>Position</source>
-        <translation type="unfinished"></translation>
+        <translation>Posición</translation>
     </message>
     <message>
-        <location filename="../effects/internal/transformeffect.cpp" line="54"/>
+        <location filename="../effects/internal/transformeffect.cpp" line="51"/>
         <source>Scale</source>
-        <translation type="unfinished"></translation>
+        <translation>Escala</translation>
     </message>
     <message>
-        <location filename="../effects/internal/transformeffect.cpp" line="64"/>
+        <location filename="../effects/internal/transformeffect.cpp" line="55"/>
         <source>Uniform Scale</source>
-        <translation type="unfinished"></translation>
+        <translation>Escala Uniforme</translation>
     </message>
     <message>
-        <location filename="../effects/internal/transformeffect.cpp" line="68"/>
+        <location filename="../effects/internal/transformeffect.cpp" line="59"/>
         <source>Rotation</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotación</translation>
     </message>
     <message>
-        <location filename="../effects/internal/transformeffect.cpp" line="72"/>
+        <location filename="../effects/internal/transformeffect.cpp" line="61"/>
         <source>Anchor Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Punto de Ancla</translation>
     </message>
     <message>
-        <location filename="../effects/internal/transformeffect.cpp" line="77"/>
+        <location filename="../effects/internal/transformeffect.cpp" line="65"/>
         <source>Opacity</source>
-        <translation type="unfinished"></translation>
+        <translation>Opacidad</translation>
     </message>
     <message>
-        <location filename="../effects/internal/transformeffect.cpp" line="84"/>
-        <source>Blend Mode</source>
-        <translation type="unfinished"></translation>
+        <location filename="../effects/internal/transformeffect.cpp" line="130"/>
+        <source>Transform</source>
+        <translation>Transformación</translation>
     </message>
     <message>
-        <location filename="../effects/internal/transformeffect.cpp" line="89"/>
-        <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <location filename="../effects/internal/transformeffect.cpp" line="140"/>
+        <source>Distort</source>
+        <translation>Distorsionar</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/transformeffect.cpp" line="145"/>
+        <source>Transform the position, scale, and rotation of this clip.</source>
+        <translation>Transformar la posición, escala y rotación de este clip.</translation>
     </message>
 </context>
 <context>
     <name>Transition</name>
     <message>
-        <location filename="../effects/transition.cpp" line="48"/>
+        <location filename="../effects/transition.cpp" line="47"/>
         <source>Length</source>
-        <translation type="unfinished"></translation>
+        <translation>Longitud</translation>
     </message>
 </context>
 <context>
     <name>UpdateNotification</name>
     <message>
-        <location filename="../ui/updatenotification.cpp" line="35"/>
+        <location filename="../ui/updatenotification.cpp" line="55"/>
         <source>An update is available from the Olive website. Visit www.olivevideoeditor.org to download it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Una actualización está disponible en el sitio web de Olive. Visita www.olivevideoeditor.org para descargarla.</translation>
     </message>
 </context>
 <context>
     <name>VSTHost</name>
     <message>
-        <location filename="../effects/internal/vsthost.cpp" line="130"/>
-        <location filename="../effects/internal/vsthost.cpp" line="146"/>
+        <location filename="../effects/internal/vsthost.cpp" line="129"/>
+        <location filename="../effects/internal/vsthost.cpp" line="145"/>
         <source>Error loading VST plugin</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al cargar el Plugin VST</translation>
     </message>
     <message>
-        <location filename="../effects/internal/vsthost.cpp" line="131"/>
+        <location filename="../effects/internal/vsthost.cpp" line="130"/>
         <source>Failed to load VST plugin &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Falló la carga del complemento VST &quot;%1&quot;:%2</translation>
     </message>
     <message>
-        <location filename="../effects/internal/vsthost.cpp" line="147"/>
+        <location filename="../effects/internal/vsthost.cpp" line="146"/>
         <source>Failed to locate entry point for dynamic library.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al localizar el punto de entrada para la librería dinámica.</translation>
     </message>
     <message>
-        <location filename="../effects/internal/vsthost.cpp" line="172"/>
+        <location filename="../effects/internal/vsthost.cpp" line="171"/>
         <source>VST Error</source>
-        <translation type="unfinished"></translation>
+        <translation>VST Error</translation>
     </message>
     <message>
-        <location filename="../effects/internal/vsthost.cpp" line="172"/>
+        <location filename="../effects/internal/vsthost.cpp" line="171"/>
         <source>Plugin&apos;s magic number is invalid</source>
-        <translation type="unfinished"></translation>
+        <translation>El número mágico de Plugin no es válido</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="239"/>
+        <source>Plugin</source>
+        <translation>Plugin</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="242"/>
+        <source>Interface</source>
+        <translation>Interface</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/vsthost.cpp" line="242"/>
+        <source>Show</source>
+        <translation>Mostrar</translation>
     </message>
     <message>
         <location filename="../effects/internal/vsthost.cpp" line="254"/>
-        <source>Plugin</source>
-        <translation type="unfinished"></translation>
+        <source>VST Plugin 2.x</source>
+        <translation>VST Plugin 2.x</translation>
     </message>
     <message>
-        <location filename="../effects/internal/vsthost.cpp" line="258"/>
-        <source>Interface</source>
-        <translation type="unfinished"></translation>
+        <location filename="../effects/internal/vsthost.cpp" line="264"/>
+        <source>Use a VST 2.x plugin on this clip&apos;s audio.</source>
+        <translation>Utilice un Plugin VST 2.x en el audio de este clip.</translation>
     </message>
     <message>
-        <location filename="../effects/internal/vsthost.cpp" line="260"/>
-        <source>Show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../effects/internal/vsthost.cpp" line="228"/>
+        <location filename="../effects/internal/vsthost.cpp" line="218"/>
         <source>VST Plugin</source>
-        <translation type="unfinished"></translation>
+        <translation>Plugin VST</translation>
     </message>
 </context>
 <context>
     <name>Viewer</name>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="927"/>
-        <source>Sequence Viewer</source>
-        <translation type="unfinished"></translation>
+        <location filename="../panels/viewer.cpp" line="71"/>
+        <source>Viewer: %1</source>
+        <translation>Visionar: %1</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="928"/>
-        <source>Media Viewer</source>
-        <translation type="unfinished"></translation>
+        <location filename="../panels/viewer.cpp" line="351"/>
+        <source>Failed to import recorded file</source>
+        <translation>No se pudo importar el archivo grabado</translation>
     </message>
     <message>
-        <location filename="../panels/viewer.cpp" line="601"/>
+        <location filename="../panels/viewer.cpp" line="352"/>
+        <source>An error occurred trying to import the recorded audio</source>
+        <translation>Se ha producido un error al intentar importar el audio grabado</translation>
+    </message>
+    <message>
+        <location filename="../panels/viewer.cpp" line="550"/>
         <source>(none)</source>
-        <translation type="unfinished"></translation>
+        <translation>(ninguno)</translation>
     </message>
     <message>
-        <location filename="../panels/viewer.cpp" line="737"/>
+        <location filename="../panels/viewer.cpp" line="682"/>
         <source>Drag video only</source>
-        <translation type="unfinished"></translation>
+        <translation>Sólo arrastrar Vídeo</translation>
     </message>
     <message>
-        <location filename="../panels/viewer.cpp" line="744"/>
+        <location filename="../panels/viewer.cpp" line="689"/>
         <source>Drag audio only</source>
-        <translation type="unfinished"></translation>
+        <translation>Sólo arrastrar Audio</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="936"/>
+        <source>Sequence Viewer: %1</source>
+        <translation>Visor de secuencia:%1</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="937"/>
+        <source>Media Viewer: %1</source>
+        <translation>Visor de Medios: %1</translation>
     </message>
 </context>
 <context>
     <name>ViewerWidget</name>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="113"/>
+        <location filename="../ui/viewerwidget.cpp" line="117"/>
         <source>Save Frame as Image...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/viewerwidget.cpp" line="116"/>
-        <source>Show Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar fotograma como imagen...</translation>
     </message>
     <message>
         <location filename="../ui/viewerwidget.cpp" line="120"/>
+        <source>Show Fullscreen</source>
+        <translation>Pantalla Completa</translation>
+    </message>
+    <message>
+        <location filename="../ui/viewerwidget.cpp" line="124"/>
         <source>Disable</source>
-        <translation type="unfinished"></translation>
+        <translation>Desconectar</translation>
     </message>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="123"/>
+        <location filename="../ui/viewerwidget.cpp" line="127"/>
         <source>Screen %1: %2x%3</source>
-        <translation type="unfinished"></translation>
+        <translation>Pantalla %1: %2x%3</translation>
     </message>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="131"/>
+        <location filename="../ui/viewerwidget.cpp" line="135"/>
         <source>Zoom</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="132"/>
+        <location filename="../ui/viewerwidget.cpp" line="136"/>
         <source>Fit</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajuste Automático</translation>
     </message>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="142"/>
+        <location filename="../ui/viewerwidget.cpp" line="146"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Personalizado</translation>
     </message>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="148"/>
+        <location filename="../ui/viewerwidget.cpp" line="152"/>
         <source>Close Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Cerrar Medios</translation>
     </message>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="158"/>
+        <location filename="../ui/viewerwidget.cpp" line="162"/>
         <source>Save Frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar Fotograma</translation>
     </message>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="192"/>
+        <location filename="../ui/viewerwidget.cpp" line="196"/>
         <source>Viewer Zoom</source>
-        <translation type="unfinished"></translation>
+        <translation>Visor de Zoom</translation>
     </message>
     <message>
-        <location filename="../ui/viewerwidget.cpp" line="193"/>
+        <location filename="../ui/viewerwidget.cpp" line="197"/>
         <source>Set Custom Zoom Value:</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer valor de zoom personalizado:</translation>
     </message>
 </context>
 <context>
     <name>ViewerWindow</name>
     <message>
-        <location filename="../ui/viewerwindow.cpp" line="170"/>
+        <location filename="../ui/viewerwindow.cpp" line="165"/>
         <source>Exit Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Salir de la Pantalla Completa</translation>
     </message>
 </context>
 <context>
     <name>VoidEffect</name>
     <message>
-        <location filename="../effects/internal/voideffect.cpp" line="33"/>
+        <location filename="../effects/internal/voideffect.cpp" line="36"/>
         <source>(unknown)</source>
-        <translation type="unfinished"></translation>
+        <translation>(Desconocido)</translation>
     </message>
     <message>
-        <location filename="../effects/internal/voideffect.cpp" line="37"/>
+        <location filename="../effects/internal/voideffect.cpp" line="39"/>
         <source>Missing Effect</source>
-        <translation type="unfinished"></translation>
+        <translation>Efecto faltante</translation>
     </message>
 </context>
 <context>
     <name>VolumeEffect</name>
     <message>
         <location filename="../effects/internal/volumeeffect.cpp" line="32"/>
+        <location filename="../effects/internal/volumeeffect.cpp" line="41"/>
         <source>Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Volumen</translation>
+    </message>
+    <message>
+        <location filename="../effects/internal/volumeeffect.cpp" line="51"/>
+        <source>Adjust the volume of this clip&apos;s audio</source>
+        <translation>Ajusta el volumen de los clips de audio</translation>
     </message>
 </context>
 <context>
-    <name>transition</name>
+    <name>bitdepths</name>
     <message>
-        <location filename="../effects/transition.cpp" line="117"/>
-        <source>Invalid transition</source>
-        <translation type="unfinished"></translation>
+        <location filename="../rendering/pixelformats.cpp" line="33"/>
+        <source>8-bit</source>
+        <translation>8-bit</translation>
     </message>
     <message>
-        <location filename="../effects/transition.cpp" line="118"/>
-        <source>No candidate for transition &apos;%1&apos;. This transition may be corrupt. Try reinstalling it or Olive.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../rendering/pixelformats.cpp" line="39"/>
+        <source>16-bit Integer</source>
+        <translation>16-bit Entero</translation>
+    </message>
+    <message>
+        <location filename="../rendering/pixelformats.cpp" line="45"/>
+        <source>Half-Float (16-bit)</source>
+        <translation>Medio-Coma-Flotante (16-bit)</translation>
+    </message>
+    <message>
+        <location filename="../rendering/pixelformats.cpp" line="51"/>
+        <source>Full-Float (32-bit)</source>
+        <translation>Máximo-Coma-Flotante (32-bit)</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
I have completed version 2.1, this version is 100% translated (Spelling errors have also been reviewed)
This translation is for all Spanish-speaking countries, so I've used the generic code "es" instead of "es_ES" which only refers to Spain.
A pleasure to collaborate in what I can, but I am an audiovisual technician, my programming skills are low.
[olive_es.ts-files.zip](https://github.com/olive-editor/olive/files/3342961/olive_es.ts-files.zip)