### PR TITLE
Don't use GNU grep for OpenBSD package builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
   endif()
-elseif(UNIX AND NOT APPLE)
+elseif(UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
   # Fallback for Ubuntu/Launchpad (extracts Git hash from debian/changelog rather than Git repo)
   # (see https://answers.launchpad.net/launchpad/+question/678556)
   execute_process(COMMAND sh -c "grep -Po '(?<=-)(([a-z0-9])\\w+)(?=\\+)' -m 1 changelog"


### PR DESCRIPTION
Hi --

The -P flag is only available on GNU grep, not BSD grep. This causes package builds on OpenBSD to needlessly fail when running cmake.

We will only ever package tagged versions of Olive, so we'll all know what version of Olive we're using. If a user wants to build from the tip of the tree, then they'll have a .git directory and the fallback won't even happen.

Other than that, Olive works beautifully on OpenBSD, thanks!