### PR TITLE
Initializes the "msg_type" variable in the debug.cpp file.

### DIFF
--- a/app/common/debug.cpp
+++ b/app/common/debug.cpp
@@ -5,7 +5,7 @@ void DebugHandler(QtMsgType type, const QMessageLogContext &context, const QStri
 {
   QByteArray localMsg = msg.toLocal8Bit();
 
-  const char* msg_type;
+  const char* msg_type = NULL;
   switch (type) {
   case QtDebugMsg:
     msg_type = "DEBUG";


### PR DESCRIPTION
Olive's build on Arch Linux ends in error because of an uninitialized variable in the "app/common/debug.cpp" file:
```
[  6%] Building CXX object app/CMakeFiles/olive-editor.dir/common/debug.cpp.o
(...)/src/olive/app/common/debug.cpp: In function ‘void DebugHandler(QtMsgType, const QMessageLogContext&, const QString&)’:
(...)/src/olive/app/common/debug.cpp:27:10: error: ‘msg_type’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   27 |   fprintf(stderr, "[%s] %s (%s:%u)\n", msg_type, localMsg.constData(), context.function, context.line);
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [app/CMakeFiles/olive-editor.dir/build.make:541: app/CMakeFiles/olive-editor.dir/common/debug.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:139: app/CMakeFiles/olive-editor.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```
The full error log is at the link [https://pastebin.com/daU5w6g6](url)

This pull request initializes the "msg_type" variable in the "debug.cpp" file at the time of declaration, thus solving the problem.