### PR TITLE
Fix linkage error

### DIFF
--- a/app/project/item/footage/imagestream.cpp
+++ b/app/project/item/footage/imagestream.cpp
@@ -84,3 +84,8 @@ void ImageStream::ColorConfigChangedSlot()
   // FIXME: Update colorspace correctly
   colorspace_.clear();
 }
+
+void ImageStream::ColorSpaceChanged()
+{
+
+}


### PR DESCRIPTION
Linkage error without empty definition.

```
[100%] Linking CXX executable olive-editor
/usr/bin/ld: CMakeFiles/olive-editor.dir/project/item/footage/imagestream.cpp.o: in function `ImageStream::set_colorspace(QString const&)':
imagestream.cpp:(.text+0x31b): undefined reference to `ImageStream::ColorSpaceChanged()'
collect2: error: ld returned 1 exit status
```