### PR TITLE
Code Cleanup: common: removing default constructors

### DIFF
--- a/app/common/rational.h
+++ b/app/common/rational.h
@@ -51,10 +51,7 @@ public:
       numer = intType(0);
   }
 
-  rational(const rational &rhs)
-    :numer(rhs.numer), denom(rhs.denom)
-  {
-  }
+  rational(const rational &rhs) = default;
 
   rational(const AVRational& r);
 

--- a/app/common/threadedobject.cpp
+++ b/app/common/threadedobject.cpp
@@ -1,9 +1,5 @@
 #include "threadedobject.h"
 
-ThreadedObject::ThreadedObject()
-{
-}
-
 void ThreadedObject::LockDeletes()
 {
   threadobj_delete_lock_++;

--- a/app/common/threadedobject.h
+++ b/app/common/threadedobject.h
@@ -6,7 +6,6 @@
 class ThreadedObject
 {
 public:
-  ThreadedObject();
 
   void LockMutex();
   void UnlockMutex();

--- a/app/common/timerange.cpp
+++ b/app/common/timerange.cpp
@@ -1,9 +1,5 @@
 #include "timerange.h"
 
-TimeRange::TimeRange()
-{
-}
-
 TimeRange::TimeRange(const rational &in, const rational &out) :
   in_(in),
   out_(out)

--- a/app/common/timerange.h
+++ b/app/common/timerange.h
@@ -5,7 +5,7 @@
 
 class TimeRange {
 public:
-  TimeRange();
+  TimeRange() = default;
   TimeRange(const rational& in, const rational& out);
 
   const rational& in() const;


### PR DESCRIPTION
As C++11 is the adopted standard, trivial constructors are not needed,
compiler can generate it for us.