### PR TITLE
common/rational general refactoring

### DIFF
--- a/app/common/rational.cpp
+++ b/app/common/rational.cpp
@@ -45,6 +45,10 @@ void rational::fixSigns()
 void rational::reduce()
 {
     intType d = gcd(std::abs(numer), denom);
+    if (d == 0)
+    {
+        return;
+    }
     numer /= d;
     denom /= d;
 }

--- a/app/common/rational.cpp
+++ b/app/common/rational.cpp
@@ -3,9 +3,25 @@
 
 #include "rational.h"
 
+#include <cmath>
+
+using namespace std;
+
+rational::rational(const intType& num)
+    : numer(num)
+      , denom(1)
+{}
+
+rational::rational(const intType& num, const intType& den)
+    : numer(num)
+      , denom(den)
+{
+    fixSigns();
+    reduce();
+}
 rational::rational(const AVRational &r) :
-  numer(r.num),
-  denom(r.den)
+    numer(r.num),
+    denom(r.den)
 {
 }
 
@@ -13,413 +29,288 @@ rational::rational(const AVRational &r) :
 
 void rational::print(ostream &out) const
 {
-  out << this->numer << "/" << this->denom;
+    out << this->numer << "/" << this->denom;
 }
 
 //Function: ensures denom >= 0
 
 void rational::fixSigns()
 {
-  if(denom < 0)
-    {
-      denom = -denom;
-      numer = -numer;
-    }
-  if(numer == intType(0) || denom == intType(0))
-    {
-      numer = intType(0);
-      denom = intType(0);
-    }
+    numer *= 1 - 2 * std::signbit(denom);
+    denom = std::abs(denom);
 }
 
 //Function: ensures lowest form
 
 void rational::reduce()
 {
-  // Euclidean often fails if numbers are negative, we abs it and re-neg it later if necessary
-  bool neg = numer < 0;
-
-  numer = qAbs(numer);
-
-  intType d = 1;
-
-  if(denom != 0 && numer !=0)
-    d = gcd(numer, denom);
-
-  if(d > 1)
-    {
-      numer /= d;
-      denom /= d;
-    }
-
-  if (neg) {
-    numer = -numer;
-  }
+    intType d = gcd(std::abs(numer), denom);
+    numer /= d;
+    denom /= d;
 }
 
 //Function: finds greatest common denominator
 
-intType rational::gcd(intType &x, intType &y)
+intType rational::gcd(const intType &x, const intType &y)
 {
-  if(y == 0)
-    return x;
-  else
-    {
-      intType tmp = x % y;
-
-      return gcd(y, tmp);
-    }
+    return y == 0 ? x : gcd(y, x % y);
 }
 
 //Function: convert to double
 
 double rational::toDouble() const
 {
-  if(denom != 0)
-    return static_cast<double>(numer) / static_cast<double>(denom);
-  else
-    return static_cast<double>(0);
+    if(denom != 0)
+        return static_cast<double>(numer) / static_cast<double>(denom);
+    else
+        return std::nan("");
 }
 
 AVRational rational::toAVRational() const
 {
-  AVRational r;
+    AVRational r;
 
-  r.num = static_cast<int>(numer);
-  r.den = static_cast<int>(denom);
+    r.num = static_cast<int>(numer);
+    r.den = static_cast<int>(denom);
 
-  return r;
+    return r;
 }
 
 rational rational::flipped() const
 {
-  return rational(denom, numer);
+    return rational(denom, numer);
 }
 
 bool rational::isNull() const
 {
-  return denominator() == 0;
+    return denominator() == 0;
 }
 
 const intType &rational::numerator() const
 {
-  return numer;
+    return numer;
 }
 
 const intType &rational::denominator() const
 {
-  return denom;
+    return denom;
 }
 
 //Assignment Operators
 
-const rational& rational::operator=(const rational &rhs)
+rational& rational::operator=(const rational &rhs)
 {
-  if(this != &rhs)
+    if(this != &rhs)
     {
-      numer = rhs.numer;
-      denom = rhs.denom;
+        numer = rhs.numer;
+        denom = rhs.denom;
     }
-  return *this;
+    return *this;
 }
 
-const rational& rational::operator+=(const rational &rhs)
+rational& rational::operator+=(const rational &rhs)
 {
-  if(numer * denom == intType(0) && rhs.numer * rhs.denom == intType(0))
-    {
-      numer = intType(0);
-      denom = intType(0);
-    }
-  else
-    if(numer * denom != intType(0) && rhs.numer * rhs.denom == intType(0))
-      {
-
-      }
-    else
-      if(numer * denom == intType(0) && rhs.numer * rhs.denom != intType(0))
-        {
-          numer = rhs.numer;
-          denom = rhs.denom;
-        }
-      else
-        {
-          numer = (numer * rhs.denom) + (rhs.numer * denom);
-          denom = denom * rhs.denom;
-          fixSigns();
-          reduce();
-        }
-  return *this;
+    intType dn = denom * rhs.denom;
+    intType nn = numer * rhs.denom + rhs.numer * denom;
+    numer = nn;
+    denom = dn;
+    reduce();
+    return *this;
 }
 
-const rational& rational::operator-=(const rational &rhs)
+rational& rational::operator-=(const rational &rhs)
 {
-  if(numer * denom == intType(0) && rhs.numer * rhs.denom == intType(0))
-    {
-      numer = intType(0);
-      denom = intType(0);
-    }
-  else
-    if(numer * denom != intType(0) && rhs.numer * rhs.denom == intType(0))
-      {
-
-      }
-    else
-      if(numer * denom == intType(0) && rhs.numer * rhs.denom != intType(0))
-        {
-          numer = -(rhs.numer);
-          denom = rhs.denom;
-        }
-      else
-        {
-          numer = (numer * rhs.denom) - (rhs.numer * denom);
-          denom = denom * rhs.denom;
-          fixSigns();
-          reduce();
-        }
-  return *this;
+    intType dn = denom * rhs.denom;
+    intType nn = numer * rhs.denom - rhs.numer * denom;
+    numer = nn;
+    denom = dn;
+    reduce();
+    return *this;
 }
 
-const rational& rational::operator/=(const rational &rhs)
+rational& rational::operator/=(const rational &rhs)
 {
-  numer = numer * rhs.denom;
-  denom = denom * rhs.numer;
-  fixSigns();
-  reduce();
-  return *this;
+    numer = numer * rhs.denom;
+    denom = denom * rhs.numer;
+    fixSigns();
+    reduce();
+    return *this;
 }
 
-const rational& rational::operator*=(const rational &rhs)
+rational& rational::operator*=(const rational &rhs)
 {
-  numer = numer * rhs.numer;
-  denom = denom * rhs.denom;
-  fixSigns();
-  reduce();
-  return *this;
+    numer = numer * rhs.numer;
+    denom = denom * rhs.denom;
+    fixSigns();
+    reduce();
+    return *this;
 }
 
 //Binary math operators
 
 rational rational::operator+(const rational &rhs) const
 {
- rational answer(*this);
- answer += rhs;
- return answer;
+    rational answer(*this);
+    answer += rhs;
+    return answer;
 }
 
 rational rational::operator-(const rational &rhs) const
 {
-  rational answer(*this);
-  answer -= rhs;
-  return answer;
+    rational answer(*this);
+    answer -= rhs;
+    return answer;
 }
 
 rational rational::operator/(const rational &rhs) const
 {
-  rational answer(*this);
-  answer /= rhs;
-  return answer;
+    rational answer(*this);
+    answer /= rhs;
+    return answer;
 }
 
 rational rational::operator*(const rational &rhs) const
 {
-  rational answer(*this);
-  answer *= rhs;
-  return answer;
+    rational answer(*this);
+    answer *= rhs;
+    return answer;
 }
 
 //Relational and equality operators
 
 bool rational::operator<(const rational &rhs) const
 {
-  if(numer * denom == intType(0) && rhs.numer * rhs.denom == intType(0))
-    return false;
-  else
-    if(numer * denom != intType(0) && rhs.numer * rhs.denom == intType(0))
-      {
-        if(numer * denom < intType(0))
-          return true;
-        else
-          return false;
-      }
-    else
-      if(numer * denom == intType(0) && rhs.numer * rhs.denom != intType(0))
-        {
-          if(rhs.numer * rhs.denom < intType(0))
-            return false;
-          else
-            return true;
-        }
-      else
-        return ((numer * rhs.denom) < (denom * rhs.numer));
+    if (this->isNull() or rhs.isNull())
+    {
+        return false;
+    }
+    return numer * rhs.denom < denom * rhs.numer;
 }
 
 bool rational::operator<=(const rational &rhs) const
 {
-  if(numer * denom == intType(0) && rhs.numer * rhs.denom == intType(0))
-    return true;
-  else
-    if(numer * denom != intType(0) && rhs.numer * rhs.denom == intType(0))
-      {
-        if(numer * denom < intType(0))
-          return true;
-        else
-          return false;
-      }
-    else
-      if(numer * denom == intType(0) && rhs.numer * rhs.denom != intType(0))
-        {
-          if(rhs.numer * rhs.denom < intType(0))
-            return false;
-          else
-            return true;
-        }
-      else
-        return ((numer * rhs.denom) <= (denom * rhs.numer));
+    if (this->isNull() or rhs.isNull())
+    {
+        return false;
+    }
+    return *this < rhs || *this == rhs;
 }
 
 bool rational::operator>(const rational &rhs) const
 {
-  if(numer * denom == intType(0) && rhs.numer * rhs.denom == intType(0))
-    return false;
-  else
-    if(numer * denom != intType(0) && rhs.numer * rhs.denom == intType(0))
-      {
-        if(numer * denom > intType(0))
-          return true;
-        else
-          return false;
-      }
-    else
-      if(numer * denom == intType(0) && rhs.numer * rhs.denom != intType(0))
-        {
-          if(rhs.numer * rhs.denom > intType(0))
-            return false;
-          else
-            return true;
-        }
-      else
-        return ((numer * rhs.denom) > (denom * rhs.numer));
+    if (this->isNull() or rhs.isNull())
+    {
+        return false;
+    }
+    return rhs < *this;
 }
 
 bool rational::operator>=(const rational &rhs) const
 {
-  if(numer * denom == intType(0) && rhs.numer * rhs.denom == intType(0))
-    return true;
-  else
-    if(numer * denom != intType(0) && rhs.numer * rhs.denom == intType(0))
-      {
-        if(numer * denom > intType(0))
-          return true;
-        else
-          return false;
-      }
-    else
-      if(numer * denom == intType(0) && rhs.numer * rhs.denom != intType(0))
-        {
-          if(rhs.numer * rhs.denom > intType(0))
-            return false;
-          else
-            return true;
-        }
-      else
-
-  return ((numer * rhs.denom) >= (denom * rhs.numer));
+    if (this->isNull() or rhs.isNull())
+    {
+        return false;
+    }
+    return *this == rhs || rhs < *this;
 }
 
 bool rational::operator==(const rational &rhs) const
 {
-  return (numer == rhs.numer && denom == rhs.denom);
+    if (this->isNull() or rhs.isNull())
+    {
+        return false;
+    }
+    return (numer == rhs.numer && denom == rhs.denom);
 }
 
 bool rational::operator!=(const rational &rhs) const
 {
-  return (numer != rhs.numer) || (denom != rhs.denom);
-
+    return !(*this == rhs);
 }
 
 //Unary operators
 
 const rational& rational::operator++()
 {
-  numer += denom;
-  return *this;
+    numer += denom;
+    return *this;
 }
 
 rational rational::operator++(int)
 {
-  rational tmp = *this;
-  numer += denom;
-  return tmp;
+    rational tmp = *this;
+    numer += denom;
+    return tmp;
 }
 
 const rational& rational::operator--()
 {
-  numer -= denom;
-  return *this;
+    numer -= denom;
+    return *this;
 
 }
 
 rational rational::operator--(int)
 {
-  rational tmp;
-  numer -= denom;
-  return tmp;
+    rational tmp;
+    numer -= denom;
+    return tmp;
 }
 
 const rational& rational::operator+() const
 {
-  return *this;
+    return *this;
 }
 
 rational rational::operator-() const
 {
-  return rational(numer, -denom);
+    return rational(numer, -denom);
 }
 
 bool rational::operator!() const
 {
-  return !numer;
+    return !numer;
 }
 
 //IO
 
 ostream& operator<<(ostream &out, const rational &value)
 {
-  out << value.numer;
-  if(value.denom != 1)
+    out << value.numer;
+    if(value.denom != 1)
     {
-      out << '/' << value.denom;
-      return out;
+        out << '/' << value.denom;
+        return out;
     }
-  return out;
+    return out;
 }
 
 istream& operator>>(istream &in, rational &value)
 {
-  in >> value.numer;
-  value.denom = 1;
+    in >> value.numer;
+    value.denom = 1;
 
-  char ch;
-  in.get(ch);
+    char ch;
+    in.get(ch);
 
-  if(!in.eof())
+    if(!in.eof())
     {
-      if(ch == '/')
+        if(ch == '/')
         {
-          in >> value.denom;
-          value.fixSigns();
-          value.reduce();
+            in >> value.denom;
+            value.fixSigns();
+            value.reduce();
         }
-      else
-        in.putback(ch);
+        else
+            in.putback(ch);
     }
-  return in;
+    return in;
 }
 
 QDebug operator<<(QDebug debug, const rational &r)
 {
-  debug.nospace() << r.numerator() << "/" << r.denominator();
-  return debug.space();
+    debug.nospace() << r.numerator() << "/" << r.denominator();
+    return debug.space();
 }
 
 uint qHash(const rational &r, uint seed)

--- a/app/common/rational.h
+++ b/app/common/rational.h
@@ -14,8 +14,6 @@ extern "C" {
 #include <libavformat/avformat.h>
 }
 
-using namespace std;
-
 typedef int64_t intType;
 /*
  * Zero Handling
@@ -27,6 +25,7 @@ class rational
 {
 public:
   //constructors
+<<<<<<< HEAD
   rational(const intType &numerator = 0)
     :numer(numerator), denom(1)
   {
@@ -53,14 +52,20 @@ public:
 
   rational(const rational &rhs) = default;
 
+=======
+  rational() = default;
+  rational(const intType &numerator);
+  rational(const intType &numerator, const intType &denominator);
+  rational(const rational &rhs) = default;
+>>>>>>> common/rational general refactoring
   rational(const AVRational& r);
 
   //Assignment Operators
-  const rational& operator=(const rational &rhs);
-  const rational& operator+=(const rational &rhs);
-  const rational& operator-=(const rational &rhs);
-  const rational& operator/=(const rational &rhs);
-  const rational& operator*=(const rational &rhs);
+  rational& operator=(const rational &rhs);
+  rational& operator+=(const rational &rhs);
+  rational& operator-=(const rational &rhs);
+  rational& operator/=(const rational &rhs);
+  rational& operator*=(const rational &rhs);
 
   //Binary math operators
   rational operator+(const rational &rhs) const;
@@ -97,26 +102,26 @@ public:
   bool isNull() const;
 
   //Function: print number to cout
-  void print(ostream &out = cout) const;
+  void print(std::ostream &out = std::cout) const;
 
   //IO
-  friend ostream& operator<<(ostream &out, const rational &value);
-  friend istream& operator>>(istream &in, rational &value);
+  friend std::ostream& operator<<(std::ostream &out, const rational &value);
+  friend std::istream& operator>>(std::istream &in, rational &value);
 
   const intType& numerator() const;
   const intType& denominator() const;
 
 private:
   //numerator and denominator
-  intType numer;
-  intType denom;
+  intType numer = 0;
+  intType denom = 0;
 
   //Function: ensures denom >= 0
   void fixSigns();
   //Function: ensures lowest form
   void reduce();
   //Function: finds greatest common denominator
-  intType gcd(intType &x, intType &y);
+  static intType gcd(const intType &x, const intType &y);
 };
 
 QDebug operator<<(QDebug debug, const rational& r);


### PR DESCRIPTION
Let's make rational shorter, cleaner and faster.

Quick refactoring of rational class, this commit changes the way
rational numbers behave:
- rational::rational(x) = x / 1
- NaN is indicated by denom == 0
- NaN spreads to everything it touches ( NaN + x = Nan, ...)
- default constructor builds a NaN
- comparison against a NaN behaves like c++ NaN for floating point
numbers :
   * NaN [<,<=,>,>=,==] [x,NaN] == false
   * NaN != [x,NaN] == true