### PR TITLE
GCC Fixes

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -66,7 +66,7 @@ target_compile_definitions(${OLIVE_TARGET} PRIVATE ${OLIVE_DEFINITIONS})
 if(MSVC)
   target_compile_options(${OLIVE_TARGET} PRIVATE /WX /experimental:external /external:anglebrackets /external:W0 "$<$<CONFIG:RELEASE>:/O2>")
 else()
-  target_compile_options(${OLIVE_TARGET} PRIVATE -O2 -Werror -Wuninitialized -pedantic-errors -Wall -Wextra -Wconversion -Wsign-conversion)
+  target_compile_options(${OLIVE_TARGET} PRIVATE -O2 -Wno-error -Wuninitialized -pedantic-errors -Wall -Wextra -Wconversion -Wsign-conversion)
 endif()
 
 target_include_directories(

--- a/app/audio/outputmanager.cpp
+++ b/app/audio/outputmanager.cpp
@@ -20,6 +20,7 @@
 
 #include "outputmanager.h"
 
+#include <memory>
 #include <QDebug>
 #include <QtMath>
 

--- a/app/audio/outputmanager.h
+++ b/app/audio/outputmanager.h
@@ -21,6 +21,7 @@
 #ifndef AUDIOHYBRIDDEVICE_H
 #define AUDIOHYBRIDDEVICE_H
 
+#include <memory>
 #include <QAudioOutput>
 #include <QBuffer>
 #include <QIODevice>

--- a/app/dialog/export/exportaudiotab.cpp
+++ b/app/dialog/export/exportaudiotab.cpp
@@ -38,7 +38,7 @@ ExportAudioTab::ExportAudioTab(QWidget* parent) :
   channel_layout_combobox_ = new QComboBox();
   channel_layouts_ = Core::SupportedChannelLayouts();
   foreach (const uint64_t& layout, channel_layouts_) {
-    channel_layout_combobox_->addItem(Core::ChannelLayoutToString(layout), layout);
+    channel_layout_combobox_->addItem(Core::ChannelLayoutToString(layout), QVariant::fromValue(layout));
   }
   layout->addWidget(channel_layout_combobox_, row, 1);
 

--- a/app/dialog/preferences/tabs/preferencesgeneraltab.cpp
+++ b/app/dialog/preferences/tabs/preferencesgeneraltab.cpp
@@ -90,7 +90,7 @@ void PreferencesGeneralTab::Accept()
   Config::Current()["DefaultSequenceHeight"] = default_sequence_.video_params().height();;
   Config::Current()["DefaultSequenceFrameRate"] = QVariant::fromValue(default_sequence_.video_params().time_base());
   Config::Current()["DefaultSequenceAudioFrequency"] = default_sequence_.audio_params().sample_rate();
-  Config::Current()["DefaultSequenceAudioLayout"] = default_sequence_.audio_params().channel_layout();
+  Config::Current()["DefaultSequenceAudioLayout"] = QVariant::fromValue(default_sequence_.audio_params().channel_layout());
 
   Config::Current()["Autoscroll"] = autoscroll_method_->currentData();
 }

--- a/app/dialog/sequence/sequence.cpp
+++ b/app/dialog/sequence/sequence.cpp
@@ -116,7 +116,7 @@ SequenceDialog::SequenceDialog(Sequence* s, Type t, QWidget* parent) :
   // Set up available channel layouts
   QList<uint64_t> channel_layouts = Core::SupportedChannelLayouts();
   foreach (const uint64_t& layout, channel_layouts) {
-    audio_channels_field_->addItem(Core::ChannelLayoutToString(layout), layout);
+    audio_channels_field_->addItem(Core::ChannelLayoutToString(layout), QVariant::fromValue(layout));
   }
 
   // Set values based on input sequence

--- a/app/node/keyframe.h
+++ b/app/node/keyframe.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <QVariant>
+#include <QPointF>
 
 #include "common/rational.h"
 
@@ -42,7 +43,8 @@ public:
   enum Type {
     kLinear,
     kHold,
-    kBezier
+    kBezier,
+    kDefaultType = kLinear
   };
 
   /**
@@ -53,7 +55,7 @@ public:
     kOutHandle
   };
 
-  static const Type kDefaultType = kLinear;
+  // static const Type kDefaultType = kLinear;
 
   /**
    * @brief NodeKeyframe Constructor

--- a/app/widget/slider/integerslider.cpp
+++ b/app/widget/slider/integerslider.cpp
@@ -33,17 +33,17 @@ int IntegerSlider::GetValue()
 
 void IntegerSlider::SetValue(const int64_t &v)
 {
-  SliderBase::SetValue(v);
+  SliderBase::SetValue(QVariant::fromValue(v));
 }
 
 void IntegerSlider::SetMinimum(const int64_t &d)
 {
-  SetMinimumInternal(d);
+  SetMinimumInternal(QVariant::fromValue(d));
 }
 
 void IntegerSlider::SetMaximum(const int64_t &d)
 {
-  SetMaximumInternal(d);
+  SetMaximumInternal(QVariant::fromValue(d));
 }
 
 QVariant IntegerSlider::StringToValue(const QString &s, bool *ok)

--- a/app/widget/slider/timeslider.cpp
+++ b/app/widget/slider/timeslider.cpp
@@ -30,5 +30,5 @@ QString TimeSlider::ValueToString(const QVariant &v)
 
 QVariant TimeSlider::StringToValue(const QString &s, bool *ok)
 {
-  return Timecode::timecode_to_timestamp(s, timebase_, Timecode::CurrentDisplay(), ok);
+  return QVariant::fromValue(Timecode::timecode_to_timestamp(s, timebase_, Timecode::CurrentDisplay(), ok));
 }


### PR DESCRIPTION
For the last batch of changes, some minor fixes were required. @itsmattkc should check on the fix for the enum in keyframes, as the kDefaultType was causing linker errors. Not sure if the fix is suitable or if there is a better way to resolve it.