### PR TITLE
Inroduce Node Styles

### DIFF
--- a/app/ui/style/olive-dark/style.css
+++ b/app/ui/style/olive-dark/style.css
@@ -23,14 +23,49 @@ QPushButton:checked {
   background: #191919;
 }
 
-/* Node styling */
-NodeViewItemWidget {
-  qproperty-titlebarColor: #4040a0;
-  qproperty-borderColor: #000000;
+/* Node styling - Follow Directory Convetion */
+NodeDefaultStyleWidget {
+  qproperty-titlebarColor: rgb(25%, 25%, 65%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeBlockClipStyle {
+  qproperty-titlebarColor: rgb(60%, 60%, 85%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeDistortTransformStyle {
+  qproperty-titlebarColor: rgb(75%, 75%, 45%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeInputMediaVideoStyle {
+  qproperty-titlebarColor: rgb(60%, 60%, 25%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeInputMediaAudioStyle {
+  qproperty-titlebarColor: rgb(25%, 50%, 25%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeAudioVolumeStyle {
+  qproperty-titlebarColor: rgb(25%, 65%, 25%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeOutputTrackStyle {
+  qproperty-titlebarColor: rgb(35%, 35%, 35%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeOutputViewerStyle {
+  qproperty-titlebarColor: rgb(45%, 45%, 45%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
 }
 
 /* Timeline playhead styling */
 TimelinePlayhead {
-  qproperty-playheadColor: #ff0000;
-  qproperty-playheadHighlightColor: rgba(255, 255, 255, 0.2);
+  qproperty-playheadColor: rgb(100%, 0%, 0%);
+  qproperty-playheadHighlightColor: rgba(100%, 100%, 100%, 20%);
 }

--- a/app/ui/style/olive-dark/style.css
+++ b/app/ui/style/olive-dark/style.css
@@ -64,6 +64,41 @@ NodeOutputViewerStyle {
   qproperty-borderColor: rgb(0%, 0%, 0%);
 }
 
+NodeMathMathStyle {
+  qproperty-titlebarColor: rgb(70%, 30%, 70%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeMathTrigonometryStyle {
+  qproperty-titlebarColor: rgb(55%, 30%, 55%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeBlockGapStyle {
+  qproperty-titlebarColor: rgb(50%, 50%, 70%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeAudioPanStyle {
+  qproperty-titlebarColor: rgb(35%, 65%, 35%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeGeneratorSolidStyle {
+  qproperty-titlebarColor: rgb(85%, 65%, 40%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeManipulationMergeStyle {
+  qproperty-titlebarColor: rgb(75%, 55%, 35%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeConvolutionBlurStyle {
+  qproperty-titlebarColor: rgb(70%, 50%, 25%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
 /* Timeline playhead styling */
 TimelinePlayhead {
   qproperty-playheadColor: rgb(100%, 0%, 0%);

--- a/app/ui/style/olive-light/style.css
+++ b/app/ui/style/olive-light/style.css
@@ -62,6 +62,41 @@ NodeOutputViewerStyle {
   qproperty-borderColor: rgb(0%, 0%, 0%);
 }
 
+NodeMathMathStyle {
+  qproperty-titlebarColor: rgb(80%, 40%, 80%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeMathTrigonometryStyle {
+  qproperty-titlebarColor: rgb(65%, 40%, 65%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeBlockGapStyle {
+  qproperty-titlebarColor: rgb(60%, 60%, 80%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeAudioPanStyle {
+  qproperty-titlebarColor: rgb(45%, 75%, 45%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeGeneratorSolidStyle {
+  qproperty-titlebarColor: rgb(90%, 70%, 45%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeManipulationMergeStyle {
+  qproperty-titlebarColor: rgb(80%, 60%, 40%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeConvolutionBlurStyle {
+  qproperty-titlebarColor: rgb(75%, 55%, 30%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
 /* Playhead styling */
 TimelinePlayhead {
   qproperty-playheadColor: rgb(100%, 0%, 0%);

--- a/app/ui/style/olive-light/style.css
+++ b/app/ui/style/olive-light/style.css
@@ -22,13 +22,48 @@
 
 
 /* Node styling */
-NodeViewItemWidget {
-  qproperty-titlebarColor: #a0a0ff;
-  qproperty-borderColor: #000000;
+NodeDefaultStyleWidget {
+  qproperty-titlebarColor: rgb(35%, 35%, 75%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
 }
 
-/* Timeline playhead styling */
+NodeBlockClipStyle {
+  qproperty-titlebarColor: rgb(60%, 60%, 85%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeDistortTransformStyle {
+  qproperty-titlebarColor: rgb(85%, 85%, 55%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeInputMediaVideoStyle {
+  qproperty-titlebarColor: rgb(70%, 70%, 35%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeInputMediaAudioStyle {
+  qproperty-titlebarColor: rgb(35%, 60%, 35%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeAudioVolumeStyle {
+  qproperty-titlebarColor: rgb(35%, 75%, 35%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeOutputTrackStyle {
+  qproperty-titlebarColor: rgb(45%, 45%, 45%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+NodeOutputViewerStyle {
+  qproperty-titlebarColor: rgb(55%, 55%, 55%);
+  qproperty-borderColor: rgb(0%, 0%, 0%);
+}
+
+/* Playhead styling */
 TimelinePlayhead {
-  qproperty-playheadColor: #ff0000;
-  qproperty-playheadHighlightColor: rgba(0, 0, 0, 0.25);
+  qproperty-playheadColor: rgb(100%, 0%, 0%);
+  qproperty-playheadHighlightColor: rgba(0%, 0%, 0%, 25%);
 }

--- a/app/widget/nodeview/nodeviewitem.cpp
+++ b/app/widget/nodeview/nodeviewitem.cpp
@@ -40,6 +40,7 @@ OLIVE_NAMESPACE_ENTER
 NodeViewItem::NodeViewItem(QGraphicsItem *parent) :
   QGraphicsRectItem(parent),
   node_(nullptr),
+  css_proxy_(nullptr),
   dragging_edge_(nullptr),
   cached_drop_item_(nullptr),
   cached_drop_item_expanded_(false),
@@ -69,6 +70,9 @@ NodeViewItem::NodeViewItem(QGraphicsItem *parent) :
   // Not particularly great way of using text scaling to set the width (DPI-awareness, etc.)
   int widget_width = QFontMetricsWidth(font_metrics, "HHHHHHHHHHHHHH");
 
+  // Set the css_proxy_ to the non-null default style
+  css_proxy_ = NodeStylesRegistry::GetRegistry()->GetStyle(0);
+
   // Use the current default font height to size this widget
   // Set default "collapsed" size
   int widget_height = font_metrics.height() + node_text_padding * 2;
@@ -85,6 +89,8 @@ void NodeViewItem::SetNode(Node *n)
 
   if (node_) {
     node_->Retranslate();
+
+    css_proxy_ = NodeStylesRegistry::GetRegistry()->GetStyle(node_->id());
 
     foreach (NodeParam* p, node_->parameters()) {
       if (p->type() == NodeParam::kInput) {
@@ -152,13 +158,13 @@ void NodeViewItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
     if (option->state & QStyle::State_Selected) {
       border_pen.setColor(app_pal.color(QPalette::Highlight));
     } else {
-      border_pen.setColor(css_proxy_.BorderColor());
+      border_pen.setColor(css_proxy_->BorderColor());
     }
 
     if (IsExpanded()) {
       bkg_color = app_pal.color(QPalette::Window);
     } else {
-      bkg_color = css_proxy_.TitleBarColor();
+      bkg_color = css_proxy_->TitleBarColor();
     }
 
     painter->setPen(border_pen);

--- a/app/widget/nodeview/nodeviewitem.cpp
+++ b/app/widget/nodeview/nodeviewitem.cpp
@@ -158,13 +158,15 @@ void NodeViewItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
     if (option->state & QStyle::State_Selected) {
       border_pen.setColor(app_pal.color(QPalette::Highlight));
     } else {
-      border_pen.setColor(css_proxy_->BorderColor());
+      if (css_proxy_)
+        border_pen.setColor(css_proxy_->BorderColor());
     }
 
     if (IsExpanded()) {
       bkg_color = app_pal.color(QPalette::Window);
     } else {
-      bkg_color = css_proxy_->TitleBarColor();
+      if (css_proxy_)
+        bkg_color = css_proxy_->TitleBarColor();
     }
 
     painter->setPen(border_pen);

--- a/app/widget/nodeview/nodeviewitem.h
+++ b/app/widget/nodeview/nodeviewitem.h
@@ -26,6 +26,7 @@
 #include <QLinearGradient>
 #include <QUndoCommand>
 #include <QWidget>
+#include <QPointer>
 
 #include "node/node.h"
 #include "nodeviewedge.h"
@@ -111,7 +112,7 @@ private:
    *
    * \see NodeViewItemWidget
    */
-  NodeDefaultStyleWidget* css_proxy_;
+  QPointer<NodeDefaultStyleWidget> css_proxy_;
 
   /**
    * @brief Rectangle of the Node's title bar (equal to rect() when collapsed)

--- a/app/widget/nodeview/nodeviewitem.h
+++ b/app/widget/nodeview/nodeviewitem.h
@@ -111,7 +111,7 @@ private:
    *
    * \see NodeViewItemWidget
    */
-  NodeViewItemWidget css_proxy_;
+  NodeDefaultStyleWidget* css_proxy_;
 
   /**
    * @brief Rectangle of the Node's title bar (equal to rect() when collapsed)

--- a/app/widget/nodeview/nodeviewitemwidgetproxy.cpp
+++ b/app/widget/nodeview/nodeviewitemwidgetproxy.cpp
@@ -19,23 +19,76 @@
 ***/
 
 #include "nodeviewitemwidgetproxy.h"
+#include <QDebug>
 
-QColor NodeViewItemWidget::TitleBarColor()
+// NodeDefaultStyleWidget::NodeDefaultStyleWidget(QWidget* parent) :
+//   QWidget(parent)
+// {
+// }
+
+QColor NodeDefaultStyleWidget::TitleBarColor()
 {
   return title_bar_color_;
 }
 
-void NodeViewItemWidget::SetTitleBarColor(QColor color)
+void NodeDefaultStyleWidget::SetTitleBarColor(QColor color)
 {
   title_bar_color_ = color;
 }
 
-QColor NodeViewItemWidget::BorderColor()
+QColor NodeDefaultStyleWidget::BorderColor()
 {
   return border_color_;
 }
 
-void NodeViewItemWidget::SetBorderColor(QColor color)
+void NodeDefaultStyleWidget::SetBorderColor(QColor color)
 {
   border_color_ = color;
+}
+
+Q_GLOBAL_STATIC(NodeStylesRegistry, global_style_registry_)
+NodeStylesRegistry* NodeStylesRegistry::GetRegistry(void)
+{
+  return (NodeStylesRegistry*)global_style_registry_;
+}
+
+NodeStylesRegistry::NodeStylesRegistry(QWidget* parent)
+{
+  registry_.insert(
+    0,
+    &default_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.audioinput",
+    &input_media_audio_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.volume",
+    &audio_volume_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.track",
+    &output_track_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.vieweroutput",
+    &output_viewer_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.clip",
+    &block_clip_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.videoinput",
+    &input_media_video_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.transform",
+    &distort_transform_style_
+  );
+}
+
+NodeDefaultStyleWidget* NodeStylesRegistry::GetStyle(QString id)
+{
+  return registry_.value(id, &default_style_);
 }

--- a/app/widget/nodeview/nodeviewitemwidgetproxy.cpp
+++ b/app/widget/nodeview/nodeviewitemwidgetproxy.cpp
@@ -86,6 +86,34 @@ NodeStylesRegistry::NodeStylesRegistry(QWidget* parent)
     "org.olivevideoeditor.Olive.transform",
     &distort_transform_style_
   );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.pan",
+    &audio_pan_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.gap",
+    &block_gap_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.math",
+    &math_math_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.trigonometry",
+    &math_trigonometry_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.solidgenerator",
+    &generator_solid_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.alphaoverblend",
+    &manipulation_merge_style_
+  );
+  registry_.insert(
+    "org.olivevideoeditor.Olive.blur",
+    &convolution_blur_style_
+  );
 }
 
 NodeDefaultStyleWidget* NodeStylesRegistry::GetStyle(QString id)

--- a/app/widget/nodeview/nodeviewitemwidgetproxy.h
+++ b/app/widget/nodeview/nodeviewitemwidgetproxy.h
@@ -51,7 +51,35 @@ private:
   QColor border_color_;
 };
 
-// Follow directory structure, prefix with Node.
+/*
+ * Node Styles
+ *
+ * To add a style for a given node, it involves several steps.
+ *
+ * 1. Introduce a Node Style class. This must inherit from the
+ *    NodeDefaultStyleWidget class.
+ * 2. Name the Node such that it matches the layout of the
+ *    Olive directory structure in which it is found. That is,
+ *    it should be Node[SubDirectory][Subdirectory][Etc]Style.
+ *    For example, if the node directory is node - block - gap,
+ *    the class should be NodeBlockGapStyle.
+ * 3. Copy the relevant stanzas that follow, and hook up any
+ *    relevant Q_PROPERTY values to their respective functions.
+ * 4. In the NodeStylesRegistry class that follows, add a single
+ *    instance of the relevant newly created class. It should follow
+ *    the Olive naming convention of underscores and lowercase,
+ *    and match the class definition without the Node prefix. For
+ *    example, NodeInputMediaVideoStyle becomes input_media_video_style_.
+ *    Note the trailing underscore convention.
+ * 5. Register the key and value pair in nodeviewitemwidgetproxy.cpp.
+ *    The string must be identical to the Node class identifier given
+ *    in the relevant source code file.
+ * 6. Add the relevant stylings to the Olive light and dark themes
+ *    located in style.css for each. The name must match the node
+ *    style class, such as NodeInputMediaVideoStyle class.
+ *
+ */
+
 class NodeInputMediaAudioStyle : public NodeDefaultStyleWidget {
   Q_OBJECT
   Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
@@ -65,6 +93,12 @@ class NodeInputMediaVideoStyle : public NodeDefaultStyleWidget {
 };
 
 class NodeAudioVolumeStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeAudioPanStyle : public NodeDefaultStyleWidget {
   Q_OBJECT
   Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
   Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
@@ -94,6 +128,42 @@ class NodeBlockClipStyle : public NodeDefaultStyleWidget {
   Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
 };
 
+class NodeBlockGapStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeMathMathStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeMathTrigonometryStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeGeneratorSolidStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeManipulationMergeStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeConvolutionBlurStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
 class NodeStylesRegistry : public QWidget {
 public:
   NodeStylesRegistry(QWidget* parent = nullptr);
@@ -108,7 +178,14 @@ private:
   NodeOutputTrackStyle output_track_style_;
   NodeOutputViewerStyle output_viewer_style_;
   NodeAudioVolumeStyle audio_volume_style_;
+  NodeAudioPanStyle audio_pan_style_;
   NodeBlockClipStyle block_clip_style_;
+  NodeBlockGapStyle block_gap_style_;
+  NodeMathMathStyle math_math_style_;
+  NodeMathTrigonometryStyle math_trigonometry_style_;
+  NodeGeneratorSolidStyle generator_solid_style_;
+  NodeManipulationMergeStyle manipulation_merge_style_;
+  NodeConvolutionBlurStyle convolution_blur_style_;
 
   QMap<QString, NodeDefaultStyleWidget*> registry_;
 };

--- a/app/widget/nodeview/nodeviewitemwidgetproxy.h
+++ b/app/widget/nodeview/nodeviewitemwidgetproxy.h
@@ -22,6 +22,9 @@
 #define NODEVIEWITEMWIDGETPROXY_H
 
 #include <QWidget>
+#include <QMap>
+
+class NodeStylesRegistry;
 
 /**
  * @brief A proxy object to allow NodeViewItem access to CSS functions
@@ -29,21 +32,85 @@
  * QGraphicsItems can't take Q_PROPERTYs for CSS stylesheet input, but QWidgets can. This is a hack to allow CSS
  * properties to be set from CSS and then read by NodeViewItem.
  */
-class NodeViewItemWidget : public QWidget {
+class NodeDefaultStyleWidget : public QWidget {
   Q_OBJECT
   Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
   Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
 public:
-  NodeViewItemWidget() = default;
+  // NodeDefaultStyleWidget(QWidget* parent = nullptr);
+  NodeDefaultStyleWidget() = default;
 
   QColor TitleBarColor();
   void SetTitleBarColor(QColor color);
 
   QColor BorderColor();
   void SetBorderColor(QColor color);
+
 private:
   QColor title_bar_color_;
   QColor border_color_;
+};
+
+// Follow directory structure, prefix with Node.
+class NodeInputMediaAudioStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeInputMediaVideoStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeAudioVolumeStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeDistortTransformStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeOutputTrackStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeOutputViewerStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeBlockClipStyle : public NodeDefaultStyleWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor titlebarColor READ TitleBarColor WRITE SetTitleBarColor DESIGNABLE true)
+  Q_PROPERTY(QColor borderColor READ BorderColor WRITE SetBorderColor DESIGNABLE true)
+};
+
+class NodeStylesRegistry : public QWidget {
+public:
+  NodeStylesRegistry(QWidget* parent = nullptr);
+
+  static NodeStylesRegistry* GetRegistry(void);
+  NodeDefaultStyleWidget* GetStyle(QString id);
+private:
+  NodeDefaultStyleWidget default_style_;
+  NodeDistortTransformStyle distort_transform_style_;
+  NodeInputMediaAudioStyle input_media_audio_style_;
+  NodeInputMediaVideoStyle input_media_video_style_;
+  NodeOutputTrackStyle output_track_style_;
+  NodeOutputViewerStyle output_viewer_style_;
+  NodeAudioVolumeStyle audio_volume_style_;
+  NodeBlockClipStyle block_clip_style_;
+
+  QMap<QString, NodeDefaultStyleWidget*> registry_;
 };
 
 #endif // NODEVIEWITEMWIDGETPROXY_H


### PR DESCRIPTION
Short term solution to adding granularity
on node colouring and styles. Due to the
nature of QGraphics, the standard CSS
stylesheets are not available. This branch
adds in a cloned factory to introduce a
single object instance of each node style
that is reused amongst the nodes. It
uses Qt's STATIC_GLOBAL macro, so
should be thread safe.