### PR TITLE
Upgrade shaders from GLSL 110 to 150 (OpenGL 3.2)

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
   QSurfaceFormat format;
   format.setVersion(3, 2);
   format.setDepthBufferSize(24);
-  format.setProfile(QSurfaceFormat::CompatibilityProfile);
+  format.setProfile(QSurfaceFormat::CoreProfile);
   QSurfaceFormat::setDefaultFormat(format);
 
   // Try to share OpenGL contexts

--- a/app/node/math/math/math.cpp
+++ b/app/node/math/math/math.cpp
@@ -133,7 +133,7 @@ QString MathNode::ShaderFragmentCode(const NodeValueDatabase &input) const
     NodeParam* tex_in = (type_a == NodeParam::kTexture) ? param_a_in_ : param_b_in_;
     NodeParam* mat_in = (type_a == NodeParam::kTexture) ? param_b_in_ : param_a_in_;
 
-    operation = QStringLiteral("texture2D(%1, (vec4(ove_texcoord, 0.0, 1.0) * %2).xy)").arg(tex_in->id(), mat_in->id());
+    operation = QStringLiteral("texture(%1, (vec4(ove_texcoord, 0.0, 1.0) * %2).xy)").arg(tex_in->id(), mat_in->id());
 
   } else {
     switch (GetOperation()) {
@@ -158,15 +158,17 @@ QString MathNode::ShaderFragmentCode(const NodeValueDatabase &input) const
                               GetShaderVariableCall(param_b_in_->id(), type_b));
   }
 
-  return QStringLiteral("#version 110\n"
-                        "\n"
-                        "varying vec2 ove_texcoord;\n"
+  return QStringLiteral("#version 150\n"
                         "\n"
                         "uniform %1 %3;\n"
                         "uniform %2 %4;\n"
                         "\n"
+                        "in vec2 ove_texcoord;\n"
+                        "\n"
+                        "out vec4 fragColor;\n"
+                        "\n"
                         "void main(void) {\n"
-                        "  gl_FragColor = %5;\n"
+                        "    fragColor = %5;\n"
                         "}\n").arg(GetShaderUniformType(type_a),
                                    GetShaderUniformType(type_b),
                                    param_a_in_->id(),
@@ -397,7 +399,7 @@ QString MathNode::GetShaderUniformType(const NodeParam::DataType &type)
 QString MathNode::GetShaderVariableCall(const QString &input_id, const NodeParam::DataType &type, const QString& coord_op)
 {
   if (type == NodeParam::kTexture) {
-    return QStringLiteral("texture2D(%1, ove_texcoord%2)").arg(input_id, coord_op);
+    return QStringLiteral("texture(%1, ove_texcoord%2)").arg(input_id, coord_op);
   }
 
   return input_id;

--- a/app/render/backend/opengl/openglshader.cpp
+++ b/app/render/backend/opengl/openglshader.cpp
@@ -152,7 +152,7 @@ OpenGLShaderPtr OpenGLShader::CreateOCIO(QOpenGLContext* ctx,
 
 QString OpenGLShader::CodeDefaultFragment(const QString &function_name, const QString &shader_code)
 {
-  QString frag_code = QStringLiteral("#version 110\n"
+  QString frag_code = QStringLiteral("#version 150\n"
                                      "\n"
                                      "#ifdef GL_ES\n"
                                      "precision highp int;\n"
@@ -162,7 +162,10 @@ QString OpenGLShader::CodeDefaultFragment(const QString &function_name, const QS
                                      "uniform sampler2D ove_maintex;\n"
                                      "uniform bool color_only;\n"
                                      "uniform vec4 color_only_color;\n"
-                                     "varying vec2 ove_texcoord;\n"
+                                     "\n"
+                                     "in vec2 ove_texcoord;\n"
+                                     "\n"
+                                     "out vec4 fragColor;\n"
                                      "\n");
 
   // Finish the function with the main function
@@ -174,12 +177,12 @@ QString OpenGLShader::CodeDefaultFragment(const QString &function_name, const QS
 
     frag_code.append(QStringLiteral("\n"
                                     "void main() {\n"
-                                    "  if (color_only) {\n"
-                                    "    gl_FragColor = color_only_color;"
-                                    "  } else {\n"
-                                    "    vec4 color = texture2D(ove_maintex, ove_texcoord);\n"
-                                    "    gl_FragColor = color;\n"
-                                    "  }\n"
+                                    "    if (color_only) {\n"
+                                    "        fragColor = color_only_color;"
+                                    "    } else {\n"
+                                    "        vec4 color = texture(ove_maintex, ove_texcoord);\n"
+                                    "        fragColor = color;\n"
+                                    "    }\n"
                                     "}\n"));
 
   } else {
@@ -193,8 +196,8 @@ QString OpenGLShader::CodeDefaultFragment(const QString &function_name, const QS
 
     frag_code.append(QStringLiteral("\n"
                                     "void main() {\n"
-                                    "  vec4 color = %1(texture2D(ove_maintex, ove_texcoord));\n"
-                                    "  gl_FragColor = color;\n"
+                                    "    vec4 color = %1(texture(ove_maintex, ove_texcoord));\n"
+                                    "    fragColor = color;\n"
                                     "}\n").arg(function_name));
 
   }
@@ -205,7 +208,7 @@ QString OpenGLShader::CodeDefaultFragment(const QString &function_name, const QS
 QString OpenGLShader::CodeDefaultVertex()
 {
   // Generate vertex shader
-  return QStringLiteral("#version 110\n"
+  return QStringLiteral("#version 150\n"
                         "\n"
                         "#ifdef GL_ES\n"
                         "precision highp int;\n"
@@ -214,41 +217,41 @@ QString OpenGLShader::CodeDefaultVertex()
                         "\n"
                         "uniform mat4 ove_mvpmat;\n"
                         "\n"
-                        "attribute vec4 a_position;\n"
-                        "attribute vec2 a_texcoord;\n"
+                        "in vec4 a_position;\n"
+                        "in vec2 a_texcoord;\n"
                         "\n"
-                        "varying vec2 ove_texcoord;\n"
+                        "out vec2 ove_texcoord;\n"
                         "\n"
                         "void main() {\n"
-                        "  gl_Position = ove_mvpmat * a_position;\n"
-                        "  ove_texcoord = a_texcoord;\n"
+                        "    gl_Position = ove_mvpmat * a_position;\n"
+                        "    ove_texcoord = a_texcoord;\n"
                         "}\n");
 }
 
 QString OpenGLShader::CodeAlphaDisassociate(const QString &function_name)
 {
   return QStringLiteral("vec4 %1(vec4 col) {\n"
-                        "  if (col.a > 0.0) {\n"
-                        "    return vec4(col.rgb / col.a, col.a);"
-                        "  }\n"
-                        "  return col;\n"
+                        "    if (col.a > 0.0) {\n"
+                        "        return vec4(col.rgb / col.a, col.a);"
+                        "    }\n"
+                        "    return col;\n"
                         "}\n").arg(function_name);
 }
 
 QString OpenGLShader::CodeAlphaReassociate(const QString &function_name)
 {
   return QStringLiteral("vec4 %1(vec4 col) {\n"
-                        "  if (col.a > 0.0) {\n"
-                        "    return vec4(col.rgb * col.a, col.a);"
-                        "  }\n"
-                        "  return col;\n"
+                        "    if (col.a > 0.0) {\n"
+                        "        return vec4(col.rgb * col.a, col.a);"
+                        "    }\n"
+                        "    return col;\n"
                         "}\n").arg(function_name);
 }
 
 QString OpenGLShader::CodeAlphaAssociate(const QString &function_name)
 {
   return QStringLiteral("vec4 %1(vec4 col) {\n"
-                        "  return vec4(col.rgb * col.a, col.a);\n"
+                        "    return vec4(col.rgb * col.a, col.a);\n"
                         "}\n").arg(function_name);
 }
 

--- a/app/shaders/alphaover.frag
+++ b/app/shaders/alphaover.frag
@@ -1,33 +1,35 @@
-#version 110
-
-varying vec2 ove_texcoord;
+#version 150
 
 uniform sampler2D base_in;
 uniform sampler2D blend_in;
 uniform bool base_in_enabled;
 uniform bool blend_in_enabled;
 
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
+
 void main(void) {
-  vec4 base_col = texture2D(base_in, ove_texcoord);
-  vec4 blend_col = texture2D(blend_in, ove_texcoord);
+    vec4 base_col = texture(base_in, ove_texcoord);
+    vec4 blend_col = texture(blend_in, ove_texcoord);
 
-  if (!base_in_enabled && !blend_in_enabled) {
-    gl_FragColor = vec4(0.0);
-    return;
-  }
+    if (!base_in_enabled && !blend_in_enabled) {
+        fragColor = vec4(0.0);
+        return;
+    }
 
-  if (!base_in_enabled) {
-    gl_FragColor = blend_col;
-    return;
-  }
+    if (!base_in_enabled) {
+        fragColor = blend_col;
+        return;
+    }
 
-  if (!blend_in_enabled) {
-    gl_FragColor = base_col;
-    return; 
-  }
-  
-  base_col *= 1.0 - blend_col.a;
-  base_col += blend_col;
-  
-  gl_FragColor = base_col;
+    if (!blend_in_enabled) {
+        fragColor = base_col;
+        return; 
+    }
+
+    base_col *= 1.0 - blend_col.a;
+    base_col += blend_col;
+
+    fragColor = base_col;
 }

--- a/app/shaders/colorgradient.frag
+++ b/app/shaders/colorgradient.frag
@@ -1,13 +1,16 @@
-#version 110
-
-// Standard inputs
-uniform vec2 ove_resolution;
-varying vec2 ove_texcoord;
+#version 150
 
 // Inputs
 uniform int orientation;
 uniform vec3 color_a;
 uniform vec3 color_b;
+
+// Standard inputs
+uniform vec2 ove_resolution;
+
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
 
 void main(void) {
     float t;
@@ -21,5 +24,5 @@ void main(void) {
         t = 1.0 - ove_texcoord.y;
     }
 
-    gl_FragColor = vec4(mix(color_a, color_b, t), 1.0);
+    fragColor = vec4(mix(color_a, color_b, t), 1.0);
 }

--- a/app/shaders/colorwheel.frag
+++ b/app/shaders/colorwheel.frag
@@ -1,11 +1,14 @@
-#version 110
-
-// Standard inputs
-uniform vec2 ove_resolution;
-varying vec2 ove_texcoord;
+#version 150
 
 // Custom inputs
 uniform float hsv_value;
+
+// Standard inputs
+uniform vec2 ove_resolution;
+
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
 
 // Color wheel uses PI
 #define M_PI 3.1415926535897932384626433832795
@@ -46,7 +49,7 @@ vec3 hsv_to_rgb(float H, float S, float V) {
         Gs = 0.0;
         Bs = X; 
     }
-    
+
     return vec3(Rs + m, Gs + m, Bs + m);
 }
 
@@ -84,8 +87,8 @@ void main(void) {
         float pixel_dist = (pixel_radius / radius) * dist;
         float alpha = min((pixel_radius - pixel_dist), 1.0);
 
-        gl_FragColor = vec4(hsv_to_rgb(hue, sat, hsv_value), alpha);
+        fragColor = vec4(hsv_to_rgb(hue, sat, hsv_value), alpha);
     } else {
-        gl_FragColor = vec4(0.0);
+        fragColor = vec4(0.0);
     }
 }

--- a/app/shaders/crossdissolve.frag
+++ b/app/shaders/crossdissolve.frag
@@ -1,6 +1,4 @@
-#version 110
-
-varying vec2 ove_texcoord;
+#version 150
 
 uniform sampler2D out_block_in;
 uniform sampler2D in_block_in;
@@ -9,17 +7,21 @@ uniform bool in_block_in_enabled;
 
 uniform float ove_tprog_all;
 
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
+
 void main(void) {
-  vec4 composite = vec4(0.0);
+    vec4 composite = vec4(0.0);
 
-  if (out_block_in_enabled) {
-    composite += texture2D(out_block_in, ove_texcoord) * (1.0 - ove_tprog_all);
-  }
+    if (out_block_in_enabled) {
+        composite += texture(out_block_in, ove_texcoord) * (1.0 - ove_tprog_all);
+    }
 
-  if (in_block_in_enabled) {
-    vec4 in_block_col = texture2D(in_block_in, ove_texcoord) * ove_tprog_all;
-    composite += in_block_col;
-  }
-  
-  gl_FragColor = composite;
+    if (in_block_in_enabled) {
+        vec4 in_block_col = texture(in_block_in, ove_texcoord) * ove_tprog_all;
+        composite += in_block_col;
+    }
+
+    fragColor = composite;
 }

--- a/app/shaders/diptoblack.frag
+++ b/app/shaders/diptoblack.frag
@@ -1,6 +1,4 @@
-#version 110
-
-varying vec2 ove_texcoord;
+#version 150
 
 uniform sampler2D out_block_in;
 uniform sampler2D in_block_in;
@@ -10,21 +8,25 @@ uniform bool in_block_in_enabled;
 uniform float ove_tprog_out;
 uniform float ove_tprog_in;
 
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
+
 void main(void) {
-  vec4 out_block_col;
-  vec4 in_block_col;
+    vec4 out_block_col;
+    vec4 in_block_col;
 
-  if (out_block_in_enabled) {
-    out_block_col = texture2D(out_block_in, ove_texcoord) * pow(ove_tprog_out, 2.0);
-  } else {
-    out_block_col = vec4(0.0);
-  }
+    if (out_block_in_enabled) {
+        out_block_col = texture(out_block_in, ove_texcoord) * pow(ove_tprog_out, 2.0);
+    } else {
+        out_block_col = vec4(0.0);
+    }
 
-  if (in_block_in_enabled) {
-    in_block_col = texture2D(in_block_in, ove_texcoord) * pow(ove_tprog_in, 2.0);
-  } else {
-    in_block_col = vec4(0.0);
-  }
-  
-  gl_FragColor = out_block_col + in_block_col;
+    if (in_block_in_enabled) {
+        in_block_col = texture(in_block_in, ove_texcoord) * pow(ove_tprog_in, 2.0);
+    } else {
+        in_block_col = vec4(0.0);
+    }
+
+    fragColor = out_block_col + in_block_col;
 }

--- a/app/shaders/dropshadow.frag
+++ b/app/shaders/dropshadow.frag
@@ -1,9 +1,6 @@
-#version 110
+#version 150
 
 #define M_PI 3.1415926535897932384626433832795
-
-uniform vec2 ove_resolution;
-varying vec2 ove_texcoord;
 
 uniform sampler2D tex_in;
 uniform vec3 color_in;
@@ -12,9 +9,15 @@ uniform float opacity_in;
 uniform float distance_in;
 uniform float direction_in;
 
+uniform vec2 ove_resolution;
+
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
+
 void main(void) {
     // Use pythagoras with the distance (hypotenuse) to find the shadow offset
-    float direction_radians = direction_in * (M_PI/180.0);
+    float direction_radians = direction_in * (M_PI / 180.0);
 
     float opposite = sin(direction_radians) * distance_in;
     float adjacent = cos(direction_radians) * distance_in;
@@ -32,28 +35,28 @@ void main(void) {
         float divider = 1.0 / pow(softness_in, 2.0);
         shadow_alpha = 0.0;
 
-        for (float x=-radius+0.5;x<=radius;x+=2.0) {
-            for (float y=-radius+0.5;y<=radius;y+=2.0) {
+        for (float x = -radius + 0.5; x <= radius; x += 2.0) {
+            for (float y = -radius + 0.5; y <= radius; y += 2.0) {
                 vec2 pixel_coord = ove_texcoord - angle;
-                pixel_coord.x += x/ove_resolution.x;
-                pixel_coord.y += y/ove_resolution.y;
-                vec4 pixel_color = texture2D(tex_in, pixel_coord);
+                pixel_coord.x += x / ove_resolution.x;
+                pixel_coord.y += y / ove_resolution.y;
+                vec4 pixel_color = texture(tex_in, pixel_coord);
 
                 shadow_alpha += pixel_color.a * divider;
             }
         }
     } else {
         // Perfectly hard shadow
-        vec4 src_color = texture2D(tex_in, ove_texcoord - angle);
+        vec4 src_color = texture(tex_in, ove_texcoord - angle);
         shadow_alpha = src_color.a;
     }
-    
+
     vec4 shadow_px = vec4(color_in, shadow_alpha * opacity_in * 0.01);
 
     // Get current pixel and perform an alpha over for it over the shadow we've made
-    vec4 dst_color = texture2D(tex_in, ove_texcoord);
+    vec4 dst_color = texture(tex_in, ove_texcoord);
     shadow_px *= (1.0 - dst_color.a);
     shadow_px += dst_color;
 
-    gl_FragColor = shadow_px;
+    fragColor = shadow_px;
 }

--- a/app/shaders/rgbwaveform.frag
+++ b/app/shaders/rgbwaveform.frag
@@ -1,29 +1,32 @@
 // Adapted from "RGB Waveform" by lebek
 // https://www.shadertoy.com/view/4dK3Wc
 
-#version 110
+#version 150
 
 uniform sampler2D ove_maintex;
 uniform vec2 ove_resolution;
-varying vec2 ove_texcoord;
 
 uniform float threshold;
 
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
+
 void main(void) {
     vec3 col = vec3(0.0);
-    float s = ove_texcoord.y*1.8 - 0.15;
-    float maxb = s+threshold;
-    float minb = s-threshold;
-    
+    float s = ove_texcoord.y * 1.8 - 0.15;
+    float maxb = s + threshold;
+    float minb = s - threshold;
+
     int y_lim = int(ove_resolution.y);
 
     for (int i = 0; i < y_lim; i++) {
-        vec3 x = texture2D(ove_maintex, vec2(ove_texcoord.x, float(i)/float(ove_resolution.y))).rgb;
-        col += step(x, vec3(maxb))*step(vec3(minb), x) / (ove_resolution.y * 0.125);
+        vec3 x = texture(ove_maintex, vec2(ove_texcoord.x, float(i) / float(ove_resolution.y))).rgb;
+        col += step(x, vec3(maxb)) * step(vec3(minb), x) / (ove_resolution.y * 0.125);
 
         float l = dot(x, x);
-        col += step(l, maxb*maxb)*step(minb*minb, l) / (ove_resolution.y * 0.125);
+        col += step(l, maxb * maxb) * step(minb * minb, l) / (ove_resolution.y * 0.125);
     }
 
-    gl_FragColor = vec4(col, 1.0);
+    fragColor = vec4(col, 1.0);
 }

--- a/app/shaders/solid.frag
+++ b/app/shaders/solid.frag
@@ -1,7 +1,9 @@
-#version 110
+#version 150
 
 uniform vec4 color_in;
 
+out vec4 fragColor;
+
 void main(void) {
-  gl_FragColor = color_in;
+    fragColor = color_in;
 }

--- a/app/shaders/stroke.frag
+++ b/app/shaders/stroke.frag
@@ -1,9 +1,4 @@
-#version 110
-
-// Standard inputs
-uniform vec2 ove_resolution;
-varying vec2 ove_texcoord;
-uniform int ove_iteration;
+#version 150
 
 // Node parameter inputs
 uniform sampler2D tex_in;
@@ -12,8 +7,16 @@ uniform float radius_in;
 uniform float opacity_in;
 uniform bool inner_in;
 
+// Standard inputs
+uniform vec2 ove_resolution;
+uniform int ove_iteration;
+
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
+
 void main(void) {
-    vec4 pixel_here = texture2D(tex_in, ove_texcoord);
+    vec4 pixel_here = texture(tex_in, ove_texcoord);
 
     // Detect no-op situations
     if (radius_in == 0.0
@@ -21,7 +24,7 @@ void main(void) {
         || (inner_in && pixel_here.a == 0.0)
         || (!inner_in && pixel_here.a == 1.0)) {
         // No-op, do nothing
-        gl_FragColor = pixel_here;
+        fragColor = pixel_here;
         return;
     }
 
@@ -38,7 +41,7 @@ void main(void) {
 
             if (abs(length(vec2(i, j))) < radius) {
                 // Get pixel here
-                float alpha = texture2D(tex_in, ove_texcoord + vec2(x_coord, y_coord)).a;
+                float alpha = texture(tex_in, ove_texcoord + vec2(x_coord, y_coord)).a;
 
                 if (inner_in) {
                     alpha = 1.0 - alpha;
@@ -76,5 +79,5 @@ void main(void) {
         stroke_col = stroke_col * (1.0 - pixel_here.a) + pixel_here;
     }
 
-    gl_FragColor = stroke_col;
+    fragColor = stroke_col;
 }

--- a/app/shaders/videoinput.frag
+++ b/app/shaders/videoinput.frag
@@ -1,8 +1,11 @@
-#version 110
+#version 150
 
-varying vec2 ove_texcoord;
 uniform sampler2D footage_in;
 
+in vec2 ove_texcoord;
+
+out vec4 fragColor;
+
 void main(void) {
-  gl_FragColor = texture2D(footage_in, ove_texcoord);
+    fragColor = texture(footage_in, ove_texcoord);
 }

--- a/app/shaders/videoinput.vert
+++ b/app/shaders/videoinput.vert
@@ -1,37 +1,37 @@
-#version 110
+#version 150
 
 uniform mat4 matrix_in;
-
-attribute vec4 a_position;
-attribute vec2 a_texcoord;
-
-varying vec2 ove_texcoord;
 
 uniform vec2 footage_in_resolution;
 uniform vec2 ove_resolution;
 
+in vec4 a_position;
+in vec2 a_texcoord;
+
+out vec2 ove_texcoord;
+
 mat4 scale_mat4(vec3 scale) {
-  return mat4(
-    scale.x, 0.0, 0.0, 0.0,
-    0.0, scale.y, 0.0, 0.0,
-    0.0, 0.0, scale.z, 0.0,
-    0.0, 0.0, 0.0, 1.0
-  );
+    return mat4(
+        scale.x, 0.0, 0.0, 0.0,
+        0.0, scale.y, 0.0, 0.0,
+        0.0, 0.0, scale.z, 0.0,
+        0.0, 0.0, 0.0, 1.0
+    );
 }
 
 void main() {
-  // Create identity matrix
-  mat4 transform = mat4(1.0);
+    // Create identity matrix
+    mat4 transform = mat4(1.0);
 
-  // Scale to square
-  transform *= scale_mat4(vec3(1.0/ove_resolution, 1.0));
+    // Scale to square
+    transform *= scale_mat4(vec3(1.0 / ove_resolution, 1.0));
 
-  // Multiply by received matrix
-  transform *= matrix_in;
+    // Multiply by received matrix
+    transform *= matrix_in;
 
-  // Scale back out to footage size
-  transform *= scale_mat4(vec3(footage_in_resolution, 1.0));
+    // Scale back out to footage size
+    transform *= scale_mat4(vec3(footage_in_resolution, 1.0));
 
-  gl_Position = transform * a_position;
-  ove_texcoord = a_texcoord;
+    gl_Position = transform * a_position;
+    ove_texcoord = a_texcoord;
 }


### PR DESCRIPTION
Useful information:
- https://github.com/mattdesl/lwjgl-basics/wiki/GLSL-Versions
- http://www.shaderific.com/blog/2014/3/13/tutorial-how-to-update-a-shader-for-opengl-es-30
- http://retokoradi.com/2014/03/30/opengl-transition-to-core-profile/

Summary:
- `#version 110` -> `#version 150`
- `attribute` -> `in` in vertex shaders
- `varying` -> `out` in vertex shaders
- `varying` -> `in` in fragment shaders
- `gl_FragColor` -> `fragColor` in fragment shaders, and a declaration at the top `out vec4 fragColor;`
- `texture2D()` -> `texture()`
- Formatting

Compiled successfully on my local machine. Footage and sequence viewer were working as before in a brief test run, so I think I didn't break anything.