### PR TITLE
Gaussian Blur: Use straight multiply

### DIFF
--- a/app/shaders/blur.frag
+++ b/app/shaders/blur.frag
@@ -29,7 +29,7 @@ out vec4 fragColor;
 // Double gaussian formula, actually used in the code below
 // Should be faster than the single gaussian above since it doesn't need sqrt()
 float gaussian2(float x, float y, float sigma) {
-    return (1.0/(pow(sigma, 2.0)*2.0*M_PI))*exp(-0.5*((pow(x, 2.0) + pow(y, 2.0))/pow(sigma, 2.0)));
+    return (1.0/((sigma*sigma)*2.0*M_PI))*exp(-0.5*(((x*x) + (y*y))/(sigma*sigma)));
 }
 
 void main(void) {


### PR DESCRIPTION
Minor change. Results are identical (tested with Olive 0.1.x).

Using a straight multiply is faster if the compiler doesn't optimize pow(). Straight multiply also safer because with pow(), [the result is undefined if x<0 or if x=0 and y≤0](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/pow.xhtml).