### PR TITLE
Waveform Fixes and Updates

### DIFF
--- a/app/shaders/rgbwaveform.frag
+++ b/app/shaders/rgbwaveform.frag
@@ -8,6 +8,11 @@ uniform vec2 ove_resolution;
 uniform vec2 ove_viewport;
 uniform vec3 luma_coeffs;
 
+uniform float waveform_scale;
+uniform vec2 waveform_dims;
+uniform vec4 waveform_region;
+uniform vec4 waveform_uv;
+
 in vec2 ove_texcoord;
 
 out vec4 fragColor;
@@ -19,8 +24,8 @@ void main(void) {
     // based on how granular the increment is set. For example, it can be
     // challenging to spot 8 bit combing with an increment of 1. / 2.^8 - 1.
     float increment = 1.0 / (pow(2, 10) - 1.0);
-    float maxb = ove_texcoord.y + increment;
-    float minb = ove_texcoord.y - increment;
+    float maxb = waveform_dims.y + increment;
+    float minb = waveform_dims.y - increment;
 
     // Intensity would make sense to also expose via the UI, as a density
     // slider allows you to peek past certain values or reveal very low
@@ -29,29 +34,38 @@ void main(void) {
     // emission output strength.
     float intensity = 0.10;
 
-    int y_lim = int(ove_resolution.y);
+    int y_lim = int(waveform_dims.y);
 
     vec3 cur_col = vec3(0.0);
     vec3 cur_lum = vec3(0.0);
-    for (int i = 0; i < y_lim; i++) {
-        cur_col = texture2D(
-            ove_maintex,
-            vec2(ove_texcoord.x, float(i) / float(ove_resolution.y))
-        ).rgb;
 
-        col += step(vec3(ove_texcoord.y - increment), cur_col) *
-            step(cur_col, vec3(ove_texcoord.y + increment)) * intensity;
+    if (
+        (gl_FragCoord.x >= waveform_region.x) &&
+        (gl_FragCoord.y >= waveform_region.y) &&
+        (gl_FragCoord.x < waveform_region.z) &&
+        (gl_FragCoord.y < waveform_region.w)
+    ) {
+        // col = vec3(0.5, 0.5, 0.0);
+        // int start = int(waveform_region.y);
+        int stop = int(waveform_dims.y);
+        float ratio = 0.0;
+        float waveform_x = (ove_texcoord.x - waveform_uv.x) / waveform_scale;
+        float waveform_y = (ove_texcoord.y - waveform_uv.y) / waveform_scale;
+        for (int i = 0; i < waveform_dims.y; i++) {
+            ratio = float(i) / float(waveform_dims.y);
+            cur_col = texture2D(
+                ove_maintex,
+                vec2(waveform_x, ratio)
+            ).rgb;
 
-        // TODO: Implement proper luma / luminance based values.
-        // This is simply taking the luminance weights derived from the
-        // OCIO configuration or the RGB to XYZ matrix and multiplying
-        // the above step approach by the luminance weights.
-        // EG:
-        cur_lum = vec3(dot(cur_col, luma_coeffs));
+            col += step(vec3(waveform_y - increment), cur_col) *
+                step(cur_col, vec3(waveform_y + increment)) * intensity;
 
-        col += step(vec3(ove_texcoord.y - increment), cur_lum) *
-            step(cur_lum, vec3(ove_texcoord.y + increment)) * intensity;
+            cur_lum = vec3(dot(cur_col, luma_coeffs));
 
+            col += step(vec3(waveform_y - increment), cur_lum) *
+                step(cur_lum, vec3(waveform_y + increment)) * intensity;
+        }
     }
 
     gl_FragColor = vec4(col, 1.0);

--- a/app/shaders/rgbwaveform.frag
+++ b/app/shaders/rgbwaveform.frag
@@ -6,8 +6,6 @@
 uniform sampler2D ove_maintex;
 uniform vec2 ove_resolution;
 uniform vec2 ove_viewport;
-varying vec2 ove_texcoord;
-
 
 uniform float threshold;
 
@@ -17,9 +15,20 @@ out vec4 fragColor;
 
 void main(void) {
     vec3 col = vec3(0.0);
-    float increment = 1.0 / 255.0;
+    // Set an increment default to 10 bit encodings. This would likely be
+    // better served as a UI control, as waveforms will change their combing
+    // based on how granular the increment is set. For example, it can be
+    // challenging to spot 8 bit combing with an increment of 1. / 2.^8 - 1.
+    float increment = 1.0 / (pow(2, 10) - 1.0);
     float maxb = ove_texcoord.y + increment;
     float minb = ove_texcoord.y - increment;
+
+    // Intensity would make sense to also expose via the UI, as a density
+    // slider allows you to peek past certain values or reveal very low
+    // values. Hard coding it for now, as there isn't a clear way to have
+    // the various bit depth / code values always display at a consistent
+    // emission output strength.
+    float intensity = 0.10;
 
     int y_lim = int(ove_resolution.y);
 
@@ -31,10 +40,18 @@ void main(void) {
         ).rgb;
 
         col += step(vec3(ove_texcoord.y - increment), cur_col) *
-            step(cur_col, vec3(ove_texcoord.y + increment));
+            step(cur_col, vec3(ove_texcoord.y + increment)) * intensity;
 
-        //float l = dot(x, x);
-        //col += step(l, maxb*maxb)*step(minb*minb, l) / (ove_resolution.y * 0.125);
+        // TODO: Implement proper luma / luminance based values.
+        // This is simply taking the luminance weights derived from the
+        // OCIO configuration or the RGB to XYZ matrix and multiplying
+        // the above step approach by the luminance weights.
+        // EG:
+        // cur_lum = cur_col * lum_coeffs;
+        //
+        // col += step(vec3(ove_texcoord.y - increment), cur_lum) *
+        //     step(cur_lum, vec3(ove_texcoord.y + increment));
+
     }
 
     gl_FragColor = vec4(col, 1.0);

--- a/app/shaders/rgbwaveform.frag
+++ b/app/shaders/rgbwaveform.frag
@@ -5,6 +5,9 @@
 
 uniform sampler2D ove_maintex;
 uniform vec2 ove_resolution;
+uniform vec2 ove_viewport;
+varying vec2 ove_texcoord;
+
 
 uniform float threshold;
 
@@ -33,9 +36,6 @@ void main(void) {
         //float l = dot(x, x);
         //col += step(l, maxb*maxb)*step(minb*minb, l) / (ove_resolution.y * 0.125);
     }
-    // if (ove_texcoord.y > (240.0 / 255.0))
-    // {
-    //     col = vec3(1.0, 0.0, 1.0);
-    // }
+
     gl_FragColor = vec4(col, 1.0);
 }

--- a/app/shaders/rgbwaveform.frag
+++ b/app/shaders/rgbwaveform.frag
@@ -6,8 +6,7 @@
 uniform sampler2D ove_maintex;
 uniform vec2 ove_resolution;
 uniform vec2 ove_viewport;
-
-uniform float threshold;
+uniform vec3 luma_coeffs;
 
 in vec2 ove_texcoord;
 
@@ -33,6 +32,7 @@ void main(void) {
     int y_lim = int(ove_resolution.y);
 
     vec3 cur_col = vec3(0.0);
+    vec3 cur_lum = vec3(0.0);
     for (int i = 0; i < y_lim; i++) {
         cur_col = texture2D(
             ove_maintex,
@@ -47,10 +47,10 @@ void main(void) {
         // OCIO configuration or the RGB to XYZ matrix and multiplying
         // the above step approach by the luminance weights.
         // EG:
-        // cur_lum = cur_col * lum_coeffs;
-        //
-        // col += step(vec3(ove_texcoord.y - increment), cur_lum) *
-        //     step(cur_lum, vec3(ove_texcoord.y + increment));
+        cur_lum = vec3(dot(cur_col, luma_coeffs));
+
+        col += step(vec3(ove_texcoord.y - increment), cur_lum) *
+            step(cur_lum, vec3(ove_texcoord.y + increment)) * intensity;
 
     }
 

--- a/app/shaders/rgbwaveform.frag
+++ b/app/shaders/rgbwaveform.frag
@@ -14,19 +14,28 @@ out vec4 fragColor;
 
 void main(void) {
     vec3 col = vec3(0.0);
-    float s = ove_texcoord.y * 1.8 - 0.15;
-    float maxb = s + threshold;
-    float minb = s - threshold;
+    float increment = 1.0 / 255.0;
+    float maxb = ove_texcoord.y + increment;
+    float minb = ove_texcoord.y - increment;
 
     int y_lim = int(ove_resolution.y);
 
+    vec3 cur_col = vec3(0.0);
     for (int i = 0; i < y_lim; i++) {
-        vec3 x = texture(ove_maintex, vec2(ove_texcoord.x, float(i) / float(ove_resolution.y))).rgb;
-        col += step(x, vec3(maxb)) * step(vec3(minb), x) / (ove_resolution.y * 0.125);
+        cur_col = texture2D(
+            ove_maintex,
+            vec2(ove_texcoord.x, float(i) / float(ove_resolution.y))
+        ).rgb;
 
-        float l = dot(x, x);
-        col += step(l, maxb * maxb) * step(minb * minb, l) / (ove_resolution.y * 0.125);
+        col += step(vec3(ove_texcoord.y - increment), cur_col) *
+            step(cur_col, vec3(ove_texcoord.y + increment));
+
+        //float l = dot(x, x);
+        //col += step(l, maxb*maxb)*step(minb*minb, l) / (ove_resolution.y * 0.125);
     }
-
-    fragColor = vec4(col, 1.0);
+    // if (ove_texcoord.y > (240.0 / 255.0))
+    // {
+    //     col = vec3(1.0, 0.0, 1.0);
+    // }
+    gl_FragColor = vec4(col, 1.0);
 }

--- a/app/widget/scope/waveform/waveform.cpp
+++ b/app/widget/scope/waveform/waveform.cpp
@@ -150,10 +150,12 @@ void WaveformScope::paintGL()
 
     managed_tex_.Release();
 
-    QVector<QLine> ire_lines(6);
     QPainter p(this);
     QFontMetrics font_metrics = QFontMetrics(QFont());
     QString label;
+    float ire_increment = 0.1;
+    float ire_steps = int(1.0 / ire_increment);
+    QVector<QLine> ire_lines(ire_steps + 1);
     int font_x_offset = 0;
     int font_y_offset = font_metrics.capHeight() / 2.0;
 
@@ -162,18 +164,18 @@ void WaveformScope::paintGL()
     p.setPen(QColor(0.0, 0.6 * 255.0, 0.0));
     p.setFont(QFont());
 
-    for (int i=0; i <= 5; i++) {
+    for (int i=0; i <= ire_steps; i++) {
       ire_lines[i].setLine(
         waveform_start_dim_x,
-        (waveform_dim_y * (i * 0.20)) + waveform_start_dim_y,
+        (waveform_dim_y * (i * ire_increment)) + waveform_start_dim_y,
         waveform_end_dim_x,
-        (waveform_dim_y * (i * 0.20)) + waveform_start_dim_y);
-        label = QString::number(1.0 - (i * 0.2), 'f', 1);
+        (waveform_dim_y * (i * ire_increment)) + waveform_start_dim_y);
+        label = QString::number(1.0 - (i * ire_increment), 'f', 1);
         font_x_offset = font_metrics.width(label) + 4;
 
         p.drawText(
           waveform_start_dim_x - font_x_offset,
-          (waveform_dim_y * (i * 0.20)) + waveform_start_dim_y + font_y_offset,
+          (waveform_dim_y * (i * ire_increment)) + waveform_start_dim_y + font_y_offset,
           label);
     }
     p.drawLines(ire_lines);

--- a/app/widget/scope/waveform/waveform.cpp
+++ b/app/widget/scope/waveform/waveform.cpp
@@ -21,6 +21,10 @@
 
 #include "waveform.h"
 
+#include <QPainter>
+#include <QtMath>
+#include <QDebug>
+
 #include "node/node.h"
 #include "render/backend/opengl/openglrenderfunctions.h"
 
@@ -95,6 +99,22 @@ void WaveformScope::paintGL()
 
     color_service()->ProcessOpenGL();
 
+    QVector<QLine> ire_lines(6);
+
+    for (int i=1; i <= 5; i++) {
+      ire_lines[i].setLine(
+        0.0, height() * (i * 0.20), width(), height() *
+        (i * 0.20));
+    }
+    ire_lines[0].setLine(0.0, 0.0, width(), 0.0);
+    ire_lines[5].setLine(0.0, height() - 1.0, width(), height() - 1.0);
+
+    QPainter p(this);
+    p.setCompositionMode(QPainter::CompositionMode_Plus);
+
+    p.setPen(Qt::red);
+    p.drawLines(ire_lines);
+
     texture_.Release();
 
     framebuffer_.Release();
@@ -107,8 +127,11 @@ void WaveformScope::paintGL()
     pipeline_->setUniformValue("ove_resolution", texture_.width(), texture_.height());
     pipeline_->setUniformValue("ove_viewport", width(), height());
 
-    // The general size of a pixel
-    pipeline_->setUniformValue("threshold", 2.0f / static_cast<float>(height()));
+    GLfloat luma[3] = {0.0, 0.0, 0.0};
+
+    color_manager()->GetDefaultLumaCoefs(luma);
+    // qDebug() << "LUMA" << luma[0] << " " << luma[1] << " " << luma[2];
+    pipeline_->setUniformValue("luma_coeffs", luma[0], luma[1], luma[2]);
 
     pipeline_->release();
 

--- a/app/widget/scope/waveform/waveform.cpp
+++ b/app/widget/scope/waveform/waveform.cpp
@@ -154,7 +154,8 @@ void WaveformScope::paintGL()
     QPainter p(this);
     QFontMetrics font_metrics = QFontMetrics(QFont());
     QString label;
-    int font_width = 0;
+    int font_x_offset = 0;
+    int font_y_offset = font_metrics.capHeight() / 2.0;
 
     p.setCompositionMode(QPainter::CompositionMode_Plus);
 
@@ -167,11 +168,12 @@ void WaveformScope::paintGL()
         (waveform_dim_y * (i * 0.20)) + waveform_start_dim_y,
         waveform_end_dim_x,
         (waveform_dim_y * (i * 0.20)) + waveform_start_dim_y);
-        label = QString::number(i * 20);
-        font_width = font_metrics.width(label);
+        label = QString::number(1.0 - (i * 0.2), 'f', 1);
+        font_x_offset = font_metrics.width(label) + 4;
+
         p.drawText(
-          waveform_start_dim_x - font_width,
-          (waveform_dim_y * (i * 0.20)) + waveform_start_dim_y,
+          waveform_start_dim_x - font_x_offset,
+          (waveform_dim_y * (i * 0.20)) + waveform_start_dim_y + font_y_offset,
           label);
     }
     p.drawLines(ire_lines);


### PR DESCRIPTION
Update the waveform and visualization.

Fixes:
 * Waveform did not display luma / luminance correctly with respect to the reference working space. Now uses the luma coefficients from the OpenColorIO configuration.
 * Scaled to fit the surface, and properly displays 100% of the code value post-transformed range.
 * Adds numbers and lines for evaluation.

Further UI needs:
 * Colour space should likely be selectable from the entire colour space listing. For example, if someone needs to monitor in Arri LogC, the reference space should be transformed to it and display the code value range accordingly.
 * Custom luminance weights. In accordance with the above, it is incorrect to assume that the luminance weights are always the same as the working space. To this end, provide a configuration option that allows the set of three unique values for luminance weights, perhaps including some defaults.
 * Custom intensity. Currently hard coded. Being able to slide scrub an intensity permits drilling into the depth of the waveform, exposing or hiding values that may be occluding the data in question.

![IRE Sample](https://user-images.githubusercontent.com/59577/80545823-18de1380-8969-11ea-8177-22872794ac08.png)

