### PR TITLE
MSVC: Build with Multiple Processes (CMAKE_CXX_FLAGS /MP)

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -92,6 +92,7 @@ if(MSVC)
     /external:anglebrackets
     /external:W0
     "$<$<CONFIG:RELEASE>:/O2>"
+    "$<$<COMPILE_LANGUAGE:CXX>:/MP>"
   )
 else()
   target_compile_options(


### PR DESCRIPTION
Enables parallel compilation under Windows for MSVC compiler. `/MP` will spawn one process per effective processor (virtual CPU core count), so `%NUMBER_OF_PROCESSORS%`. `/MP4` would use 4 processes etc.

https://docs.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=vs-2017

Note to self: Docker for Windows with Hyper-V isolation uses 2 virtual cores by default. Can be increased like `docker run -it --cpu-count %NUMBER_OF_PROCESSORS% olive`.