### PR TITLE
Implement alt+click to reset to default value in SliderBase Issue #84

### DIFF
--- a/app/dialog/export/codec/h264section.cpp
+++ b/app/dialog/export/codec/h264section.cpp
@@ -121,6 +121,7 @@ H264CRFSection::H264CRFSection(QWidget *parent) :
   crf_input->SetMinimum(kMinimumCRF);
   crf_input->SetMaximum(kMaximumCRF);
   crf_input->SetValue(kDefaultCRF);
+  crf_input->SetDefaultValue(kDefaultCRF);
   layout->addWidget(crf_input);
 
   connect(crf_slider_, &QSlider::valueChanged, crf_input, &IntegerSlider::SetValue);

--- a/app/dialog/export/export.cpp
+++ b/app/dialog/export/export.cpp
@@ -204,7 +204,9 @@ ExportDialog::ExportDialog(ViewerOutput *viewer_node, QWidget *parent) :
   // Set defaults
   format_combobox_->setCurrentIndex(kFormatMPEG4);
   video_tab_->width_slider()->SetValue(viewer_node_->video_params().width());
+  video_tab_->width_slider()->SetDefaultValue(viewer_node_->video_params().width());
   video_tab_->height_slider()->SetValue(viewer_node_->video_params().height());
+  video_tab_->height_slider()->SetDefaultValue(viewer_node_->video_params().height());
   video_tab_->set_frame_rate(viewer_node_->video_params().time_base().flipped());
   audio_tab_->set_sample_rate(viewer_node_->audio_params().sample_rate());
   audio_tab_->set_channel_layout(viewer_node_->audio_params().channel_layout());

--- a/app/dialog/export/exportadvancedvideodialog.cpp
+++ b/app/dialog/export/exportadvancedvideodialog.cpp
@@ -19,6 +19,7 @@ ExportAdvancedVideoDialog::ExportAdvancedVideoDialog(QWidget *parent) :
 
   thread_slider_ = new IntegerSlider();
   thread_slider_->SetMinimum(0);
+  thread_slider_->SetDefaultValue(0);
   layout->addWidget(thread_slider_, row, 1);
 
   row++;

--- a/app/dialog/footageproperties/streamproperties/videostreamproperties.cpp
+++ b/app/dialog/footageproperties/streamproperties/videostreamproperties.cpp
@@ -80,6 +80,7 @@ VideoStreamProperties::VideoStreamProperties(ImageStreamPtr stream) :
     imgseq_start_time_ = new IntegerSlider();
     imgseq_start_time_->SetMinimum(0);
     imgseq_start_time_->SetValue(video_stream->start_time());
+    imgseq_start_time_->SetDefaultValue(video_stream->start_time());
     imgseq_layout->addWidget(imgseq_start_time_, imgseq_row, 1);
 
     imgseq_row++;
@@ -89,6 +90,7 @@ VideoStreamProperties::VideoStreamProperties(ImageStreamPtr stream) :
     imgseq_end_time_ = new IntegerSlider();
     imgseq_end_time_->SetMinimum(0);
     imgseq_end_time_->SetValue(video_stream->start_time() + video_stream->duration() - 1);
+    imgseq_end_time_->SetDefaultValue(video_stream->start_time() + video_stream->duration() - 1);
     imgseq_layout->addWidget(imgseq_end_time_, imgseq_row, 1);
 
     video_layout->addWidget(imgseq_group, row, 0, 1, 2);

--- a/app/dialog/speedduration/speedduration.cpp
+++ b/app/dialog/speedduration/speedduration.cpp
@@ -93,6 +93,7 @@ SpeedDurationDialog::SpeedDurationDialog(const rational& timebase, const QList<C
     speed_slider_ = new FloatSlider();
     speed_slider_->SetMinimum(0);
     speed_slider_->SetDisplayType(FloatSlider::kPercentage);
+    speed_slider_->SetDefaultValue(1);
     speed_layout->addWidget(speed_slider_, row, 1);
 
     if (same_speed) {
@@ -111,6 +112,7 @@ SpeedDurationDialog::SpeedDurationDialog(const rational& timebase, const QList<C
     duration_slider_ = new TimeSlider();
     duration_slider_->SetTimebase(timebase_);
     duration_slider_->SetMinimum(1);
+    duration_slider_->SetDefaultValue(Timecode::time_to_timestamp(clips_.first()->length(), timebase_));
     speed_layout->addWidget(duration_slider_, row, 1);
 
     if (same_duration) {

--- a/app/widget/nodeparamview/nodeparamviewwidgetbridge.cpp
+++ b/app/widget/nodeparamview/nodeparamviewwidgetbridge.cpp
@@ -66,6 +66,7 @@ const QList<QWidget *> &NodeParamViewWidgetBridge::widgets() const
 
 void NodeParamViewWidgetBridge::CreateWidgets()
 {
+
   if (input_->IsArray()) {
 
     NodeParamViewArrayWidget* w = new NodeParamViewArrayWidget(static_cast<NodeInputArray*>(input_));
@@ -91,6 +92,11 @@ void NodeParamViewWidgetBridge::CreateWidgets()
     case NodeParam::kInt:
     {
       IntegerSlider* slider = new IntegerSlider();
+      if (!input_->get_standard_value().isNull()) {
+        slider->SetDefaultValue(input_->get_standard_value());
+      } else {
+        slider->SetDefaultValue(0);
+      }
       widgets_.append(slider);
       connect(slider, &IntegerSlider::ValueChanged, this, &NodeParamViewWidgetBridge::WidgetCallback);
       break;
@@ -363,6 +369,11 @@ void NodeParamViewWidgetBridge::CreateSliders(int count)
 {
   for (int i=0;i<count;i++) {
     FloatSlider* fs = new FloatSlider();
+    if (!input_->get_standard_value().isNull()) {
+      fs->SetDefaultValue(input_->get_split_standard_value().at(i));
+    } else {
+      fs->SetDefaultValue(0.0f);
+    }
     widgets_.append(fs);
     connect(fs, &FloatSlider::ValueChanged, this, &NodeParamViewWidgetBridge::WidgetCallback);
   }

--- a/app/widget/slider/sliderbase.cpp
+++ b/app/widget/slider/sliderbase.cpp
@@ -23,6 +23,7 @@
 #include <QDebug>
 #include <QEvent>
 #include <QMessageBox>
+#include <QGuiApplication>
 
 OLIVE_NAMESPACE_ENTER
 
@@ -49,6 +50,7 @@ SliderBase::SliderBase(Mode mode, QWidget *parent) :
   connect(label_, SIGNAL(dragged(int)), this, SLOT(LabelDragged(int)));
   connect(label_, SIGNAL(drag_stop()), this, SLOT(LabelClicked()));
   connect(label_, SIGNAL(focused()), this, SLOT(LabelClicked()));
+  connect(label_, SIGNAL(ResetResult()), this, SLOT(ValueReset()));
   connect(editor_, SIGNAL(Confirmed()), this, SLOT(LineEditConfirmed()));
   connect(editor_, SIGNAL(Cancelled()), this, SLOT(LineEditCancelled()));
 
@@ -135,6 +137,11 @@ void SliderBase::SetValue(const QVariant &v)
   tristate_ = false;
 
   UpdateLabel(value_);
+}
+
+void SliderBase::SetDefaultValue(const QVariant &v) 
+{ 
+  default_value_ = ClampValue(v);
 }
 
 void SliderBase::SetMinimumInternal(const QVariant &v)
@@ -241,7 +248,6 @@ void SliderBase::LabelClicked()
     emit ValueChanged(value_);
   } else {
     // This was a simple click
-
     // Load label's text into editor
     editor_->setText(ValueToString(value_));
 
@@ -325,6 +331,14 @@ void SliderBase::LineEditCancelled()
 
   editor_->blockSignals(false);
   label_->blockSignals(false);
+}
+
+void SliderBase::ValueReset() 
+{
+  if (!default_value_.isNull()) {
+    SetValue(default_value_);
+    emit ValueChanged(value_);
+  }
 }
 
 OLIVE_NAMESPACE_EXIT

--- a/app/widget/slider/sliderbase.h
+++ b/app/widget/slider/sliderbase.h
@@ -45,6 +45,8 @@ public:
 
   void SetAlignment(Qt::Alignment alignment);
 
+  void SetDefaultValue(const QVariant& v);
+
   bool IsTristate() const;
   void SetTristate();
 
@@ -89,6 +91,7 @@ private:
   FocusableLineEdit* editor_;
 
   QVariant value_;
+  QVariant default_value_;
 
   bool has_min_;
   QVariant min_value_;
@@ -120,6 +123,8 @@ private slots:
   void LineEditConfirmed();
 
   void LineEditCancelled();
+
+  void ValueReset();
 };
 
 OLIVE_NAMESPACE_EXIT

--- a/app/widget/slider/sliderlabel.cpp
+++ b/app/widget/slider/sliderlabel.cpp
@@ -55,49 +55,60 @@ SliderLabel::SliderLabel(QWidget *parent) :
 
 void SliderLabel::mousePressEvent(QMouseEvent *)
 {
-  emit drag_start();
+  if (QGuiApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
+    emit ResetResult();
+  }else {
+    emit drag_start();
 
 #if defined(Q_OS_MAC)
-  CGAssociateMouseAndMouseCursorPosition(false);
-  CGDisplayHideCursor(kCGDirectMainDisplay);
-  CGGetLastMouseDelta(nullptr, nullptr);
+    CGAssociateMouseAndMouseCursorPosition(false);
+    CGDisplayHideCursor(kCGDirectMainDisplay);
+    CGGetLastMouseDelta(nullptr, nullptr);
 #else
-  drag_start_ = QCursor::pos();
+    drag_start_ = QCursor::pos();
 
-  static_cast<QGuiApplication*>(QApplication::instance())->setOverrideCursor(Qt::BlankCursor);
+    static_cast<QGuiApplication*>(QApplication::instance())->setOverrideCursor(Qt::BlankCursor);
 #endif
+  }
 }
 
 void SliderLabel::mouseMoveEvent(QMouseEvent *)
 {
-  int32_t x_mvmt, y_mvmt;
+  if (QGuiApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
+      // do nothing
+  }else {
+    int32_t x_mvmt, y_mvmt;
 
-  // Keep cursor in the same position
+    // Keep cursor in the same position
 #if defined(Q_OS_MAC)
-  CGGetLastMouseDelta(&x_mvmt, &y_mvmt);
+    CGGetLastMouseDelta(&x_mvmt, &y_mvmt);
 #else
-  QPoint current_pos = QCursor::pos();
+    QPoint current_pos = QCursor::pos();
 
-  x_mvmt = current_pos.x() - drag_start_.x();
-  y_mvmt = drag_start_.y() - current_pos.y();
+    x_mvmt = current_pos.x() - drag_start_.x();
+    y_mvmt = drag_start_.y() - current_pos.y();
 
-  QCursor::setPos(drag_start_);
+    QCursor::setPos(drag_start_);
 #endif
 
-  emit dragged(x_mvmt + y_mvmt);
+    emit dragged(x_mvmt + y_mvmt);
+  }
 }
 
 void SliderLabel::mouseReleaseEvent(QMouseEvent *)
 {
+  if (QGuiApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
+    //do nothing 
+  } else {
+    // Emit a clicked signal
+    emit drag_stop();
+  }
 #if defined(Q_OS_MAC)
   CGAssociateMouseAndMouseCursorPosition(true);
   CGDisplayShowCursor(kCGDirectMainDisplay);
 #else
   static_cast<QGuiApplication*>(QApplication::instance())->restoreOverrideCursor();
 #endif
-
-  // Emit a clicked signal
-  emit drag_stop();
 }
 
 void SliderLabel::focusInEvent(QFocusEvent *event)

--- a/app/widget/slider/sliderlabel.h
+++ b/app/widget/slider/sliderlabel.h
@@ -51,6 +51,8 @@ signals:
 
   void focused();
 
+  void ResetResult();
+
 private:
   QPoint drag_start_;
 


### PR DESCRIPTION
I've had ago at implementing this in a fairly simple way. I've added a default value that gets set in the constructor. If you Alt click a slider the value gets set to the default value. It doesn't work on sliders where the default is not the default set in SliderBase so I need to sort that. I just wanted to check I was going in the right direction.

Fixes sobotka/Olive#84