### PR TITLE
Fix first useable stream being selected

### DIFF
--- a/app/dialog/footageproperties/footageproperties.cpp
+++ b/app/dialog/footageproperties/footageproperties.cpp
@@ -109,7 +109,7 @@ FootagePropertiesDialog::FootagePropertiesDialog(QWidget *parent, Footage *foota
 
   // Auto-select first item that actually has properties
   if (first_usable_stream >= 0) {
-    track_list->item(first_usable_stream)->setSelected(true);
+    track_list->setCurrentRow(first_usable_stream);
   }
   track_list->setFocus();
 }


### PR DESCRIPTION
Footage Properties should always select the first usable stream. Commit 1fa3f4e didn't quite fix this with all footage. This should. I've tested it with Blackmagic Prores files which were causing the issue for me.  

See https://github.com/sobotka/olive/issues/105