### PR TITLE
gitignore updates for Visual Studio with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 .DS_Store
 
 .vscode
+.vs
+CmakeSettings.json
 
 #
 # Qt ignores taken from https://github.com/github/gitignore


### PR DESCRIPTION
Using Visual Studio and it's built in CMake generates a folder called .vs and a
JSON file of CMamke settings called CMakeSettings.json. These have both been
added to the .gitignore file.

Fixes sobotka/Olive#113