### PR TITLE
REGEX MATCHALL doesn't recognise ${TMP} as an argument.

### DIFF
--- a/cmake/FindOpenEXR.cmake
+++ b/cmake/FindOpenEXR.cmake
@@ -40,19 +40,19 @@ if(OPENEXR_INCLUDE_DIR)
            ${openexr_config_file}
            TMP
            REGEX "#define OPENEXR_VERSION_STRING.*$")
-      string(REGEX MATCHALL "[0-9.]+" OPENEXR_VERSION ${TMP})
+      string(REGEX MATCHALL "[0-9.]+" OPENEXR_VERSION "${TMP}")
 
       file(STRINGS
            ${openexr_config_file}
            TMP
            REGEX "#define OPENEXR_VERSION_MAJOR.*$")
-      string(REGEX MATCHALL "[0-9]" OPENEXR_MAJOR_VERSION ${TMP})
+      string(REGEX MATCHALL "[0-9]" OPENEXR_MAJOR_VERSION "${TMP}")
 
       file(STRINGS
            ${openexr_config_file}
            TMP
            REGEX "#define OPENEXR_VERSION_MINOR.*$")
-      string(REGEX MATCHALL "[0-9]" OPENEXR_MINOR_VERSION ${TMP})
+      string(REGEX MATCHALL "[0-9]" OPENEXR_MINOR_VERSION "${TMP}")
   endif()
 endif()
 


### PR DESCRIPTION
Configuring fails with FindOpenEXR.cmake, due to REGEX MATCHALL not recognising ${TMP} as an argument.

```
CMake Error at cmake/FindOpenEXR.cmake:43 (string):
  string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:46 (find_package)


CMake Error at cmake/FindOpenEXR.cmake:49 (string):
  string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:46 (find_package)


CMake Error at cmake/FindOpenEXR.cmake:55 (string):
  string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:46 (find_package)
```

Cmake version 3.16.5

Works if quotations are added to the variables.