### PR TITLE
Issue 72 Save footage proxy information to project

### DIFF
--- a/app/project/item/footage/imagestream.cpp
+++ b/app/project/item/footage/imagestream.cpp
@@ -54,6 +54,7 @@ void ImageStream::LoadCustomParameters(QXmlStreamReader *reader)
   while (XMLReadNextStartElement(reader)) {
     if (reader->name() == QStringLiteral("colorspace")) {
       set_colorspace(reader->readElementText());
+      break; // hacky if we want more parameters
     } else {
       reader->skipCurrentElement();
     }

--- a/app/project/item/footage/videostream.cpp
+++ b/app/project/item/footage/videostream.cpp
@@ -70,7 +70,6 @@ void VideoStream::SaveCustomParameters(QXmlStreamWriter *writer) const
 {
   ImageStream::SaveCustomParameters(writer);
   writer->writeTextElement("proxylevel", QString::number(using_proxy_));
-  //writer->writeTextElement("colorspace", ImageStream::colorspace());
 }
 
 QString VideoStream::description() const

--- a/app/project/item/footage/videostream.cpp
+++ b/app/project/item/footage/videostream.cpp
@@ -23,6 +23,7 @@
 #include <QFile>
 
 #include "common/timecodefunctions.h"
+#include "common/xmlutils.h"
 
 OLIVE_NAMESPACE_ENTER
 
@@ -33,6 +34,25 @@ VideoStream::VideoStream() :
   using_proxy_(0)
 {
   set_type(kVideo);
+}
+
+void VideoStream::LoadCustomParameters(QXmlStreamReader* reader)
+{
+  ImageStream::LoadCustomParameters(reader);
+  while (XMLReadNextStartElement(reader)) {
+    if (reader->name() == QStringLiteral("proxylevel")) {
+      set_proxy(reader->readElementText().toInt(), QVector<int64_t>());
+    } else {
+      reader->skipCurrentElement();
+    }
+  }
+}
+
+void VideoStream::SaveCustomParameters(QXmlStreamWriter *writer) const
+{
+  ImageStream::SaveCustomParameters(writer);
+  writer->writeTextElement("proxylevel", QString::number(using_proxy_));
+  //writer->writeTextElement("colorspace", ImageStream::colorspace());
 }
 
 QString VideoStream::description() const

--- a/app/project/item/footage/videostream.cpp
+++ b/app/project/item/footage/videostream.cpp
@@ -45,27 +45,20 @@ void VideoStream::LoadCustomParameters(QXmlStreamReader* reader)
   while (XMLReadNextStartElement(reader)) {
     if (reader->name() == QStringLiteral("proxylevel")) {
       int divider = reader->readElementText().toInt();
-      //set_proxy(divider, QVector<int64_t>());
-      QString proxy_filename = FileFunctions::GetMediaIndexFilename(FileFunctions::GetUniqueFileIdentifier(Stream::footage()->filename()))
-          .append(QString::number(footage()->get_first_stream_of_type(kVideo)->index()))
-          .append('d')
-          .append(QString::number(divider));
-      printf("%s\n", proxy_filename.toStdString().c_str());
+      QString proxy_filename = generate_proxy_name(divider);
+
       if (QFileInfo::exists(proxy_filename)) {
-        printf("Exists\n");
         QFile index_file(proxy_filename);
+
         if (index_file.open(QFile::ReadOnly)) {
           QVector<int64_t> index(index_file.size() / sizeof(int64_t));
-
           index_file.read(reinterpret_cast<char *>(index.data()), index_file.size());
-
           index_file.close();
-
           set_proxy(divider, index);
-          printf("Proxy Set\n");
+          qInfo() << "Proxy set for:" << Stream::footage()->filename();
         }
       } else {
-        //
+        qInfo() << "Proxy missing for:" << Stream::footage()->filename();
       }
     } else {
       reader->skipCurrentElement();
@@ -187,6 +180,15 @@ int64_t VideoStream::get_closest_timestamp_in_frame_index(int64_t timestamp)
   }
 
   return -1;
+}
+
+QString VideoStream::generate_proxy_name(int divider)
+{
+  return FileFunctions::GetMediaIndexFilename(
+      FileFunctions::GetUniqueFileIdentifier(Stream::footage()->filename()))
+      .append(QString::number(footage()->get_first_stream_of_type(kVideo)->index()))
+      .append('d')
+      .append(QString::number(divider));
 }
 
 /*

--- a/app/project/item/footage/videostream.h
+++ b/app/project/item/footage/videostream.h
@@ -64,6 +64,11 @@ public:
   int using_proxy();
   void set_proxy(const int& divider, const QVector<int64_t>& index);
 
+protected:
+  virtual void LoadCustomParameters(QXmlStreamReader* reader) override;
+
+  virtual void SaveCustomParameters(QXmlStreamWriter* writer) const override;
+
 private:
   rational frame_rate_;
 

--- a/app/project/item/footage/videostream.h
+++ b/app/project/item/footage/videostream.h
@@ -63,6 +63,7 @@ public:
   bool try_start_proxy();
   int using_proxy();
   void set_proxy(const int& divider, const QVector<int64_t>& index);
+  QString generate_proxy_name(int divider);
 
 protected:
   virtual void LoadCustomParameters(QXmlStreamReader* reader) override;


### PR DESCRIPTION
Fixes sobotka/olive#72

Proxy  level is added to the `.ove` file in the stream section (similar to how `colorspace` is stored) and is retireved/set up. The only issue is how to tell the user if a proxy no loger exists? At the moment I'm using qInfo() but I suppose it would probaly be better to have a pop up. The issue is loading a project is done on a new thread (I think) which makes passing info back and forth a little tricky. Would it be reasonable to add a new function to `TaskDialog` , similar to `TaskFailed` the returns if a task completes but has non critical errors? Could be helpful with sobotka/olive#101. Might be over thinking it though.

Also the extending of `LoadCustomParameters` could probably be done in a nicer way, I feel the `break` statement could cause issues down the line. What are your thoughts? 