### PR TITLE
Select node when right clicking

### DIFF
--- a/app/widget/nodeview/nodeviewitem.cpp
+++ b/app/widget/nodeview/nodeviewitem.cpp
@@ -398,6 +398,13 @@ void NodeViewItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 
     return;
 
+  } else if (event->button() & Qt::RightButton) {
+    // If shift is not held deselect all nodes
+    if (!(event->modifiers() & Qt::ShiftModifier)) {
+      this->scene()->clearSelection();
+    }
+    // Select current node
+    this->setSelected(true);
   } else {
 
     // We aren't using any override behaviors, switch back to standard click behavior


### PR DESCRIPTION
Previously right clicking on a node would not select it. This often led to annoying problems of accidentally changing the label or copying the wrong node.

The new behaviour deselects all other nodes and selects the current node if you right click on it. However if the shift key is held whilst right clicking then any other currently selected nodes stay selected.

This is similar to the behaviour in most file browsers etc. so should be familiar to users.

Does this seem resonable?