### PR TITLE
Set up and implement UI controls for scopes

### DIFF
--- a/app/panel/scope/scope.cpp
+++ b/app/panel/scope/scope.cpp
@@ -47,6 +47,11 @@ ScopePanel::ScopePanel(QWidget* parent) :
   toolbar_layout->addWidget(scope_type_combobox_);
   toolbar_layout->addStretch();
 
+  QStackedWidget* stack_ui = new QStackedWidget();
+  stack_ui->setContentsMargins(0, 0, 0, 0);
+  stack_ui->setFixedHeight(20);
+  toolbar_layout->addWidget(stack_ui);
+
   layout->addLayout(toolbar_layout);
 
   stack_ = new QStackedWidget();
@@ -55,12 +60,16 @@ ScopePanel::ScopePanel(QWidget* parent) :
   // Create waveform view
   waveform_view_ = new WaveformScope();
   stack_->addWidget(waveform_view_);
+  stack_ui->addWidget(waveform_view_->ControlUI());
 
   // Create histogram
   histogram_ = new HistogramScope();
   stack_->addWidget(histogram_);
+  stack_ui->addWidget(histogram_->ControlUI());
 
   connect(scope_type_combobox_, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), stack_, &QStackedWidget::setCurrentIndex);
+  connect(scope_type_combobox_, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), stack_ui,
+          &QStackedWidget::setCurrentIndex);
 
   Retranslate();
 }

--- a/app/panel/scope/scope.cpp
+++ b/app/panel/scope/scope.cpp
@@ -47,10 +47,11 @@ ScopePanel::ScopePanel(QWidget* parent) :
   toolbar_layout->addWidget(scope_type_combobox_);
   toolbar_layout->addStretch();
 
-  QStackedWidget* stack_ui = new QStackedWidget();
-  stack_ui->setContentsMargins(0, 0, 0, 0);
-  stack_ui->setFixedHeight(20);
-  toolbar_layout->addWidget(stack_ui);
+  stack_ui_ = new QStackedWidget();
+  stack_ui_->setContentsMargins(0, 0, 0, 0);
+  // Height has to be forced otherwise it uses far too much space
+  stack_ui_->setFixedHeight(20);
+  toolbar_layout->addWidget(stack_ui_);
 
   layout->addLayout(toolbar_layout);
 
@@ -60,15 +61,15 @@ ScopePanel::ScopePanel(QWidget* parent) :
   // Create waveform view
   waveform_view_ = new WaveformScope();
   stack_->addWidget(waveform_view_);
-  stack_ui->addWidget(waveform_view_->ControlUI());
+  stack_ui_->addWidget(waveform_view_->ControlUI());
 
   // Create histogram
   histogram_ = new HistogramScope();
   stack_->addWidget(histogram_);
-  stack_ui->addWidget(histogram_->ControlUI());
+  stack_ui_->addWidget(histogram_->ControlUI());
 
   connect(scope_type_combobox_, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), stack_, &QStackedWidget::setCurrentIndex);
-  connect(scope_type_combobox_, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), stack_ui,
+  connect(scope_type_combobox_, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), stack_ui_,
           &QStackedWidget::setCurrentIndex);
 
   Retranslate();

--- a/app/panel/scope/scope.h
+++ b/app/panel/scope/scope.h
@@ -62,6 +62,8 @@ private:
 
   QStackedWidget* stack_;
 
+  QStackedWidget* stack_ui_;
+
   QComboBox* scope_type_combobox_;
 
   WaveformScope* waveform_view_;

--- a/app/shaders/rgbwaveform.frag
+++ b/app/shaders/rgbwaveform.frag
@@ -4,6 +4,7 @@ uniform sampler2D ove_maintex;
 uniform vec2 ove_resolution;
 uniform vec2 ove_viewport;
 uniform vec3 luma_coeffs;
+uniform vec4 channel_swizzle;
 
 uniform float waveform_scale;
 
@@ -36,6 +37,11 @@ void main(void) {
             step(vec4(1.0 - quantisation), cur_col) * intensity);
     }
 
-    col.rgb += vec3(col.w);
+    col = col*channel_swizzle;
+
+    if(channel_swizzle.w == 1){
+        col.rgb += vec3(col.w);
+    }
+    
     fragColor = vec4(col.rgb, 1.0);
 }

--- a/app/widget/scope/histogram/histogram.cpp
+++ b/app/widget/scope/histogram/histogram.cpp
@@ -22,6 +22,7 @@
 
 #include <QPainter>
 #include <QtMath>
+#include <QVBoxLayout>
 
 #include "common/qtutils.h"
 #include "node/node.h"
@@ -30,8 +31,29 @@
 OLIVE_NAMESPACE_ENTER
 
 HistogramScope::HistogramScope(QWidget* parent) :
-  ScopeBase(parent)
+  ScopeBase(parent),
+  performance_mode_(false)
 {
+  SetupControlUI();
+}
+
+void HistogramScope::SetupControlUI()
+{
+  control_ui_->setContentsMargins(0, 0, 0, 0);
+
+  QHBoxLayout* toolbar_layout = new QHBoxLayout(control_ui_);
+  toolbar_layout->setMargin(0);
+
+  performance_select_ = new QCheckBox(tr("Performance Mode"), this);
+  performance_select_->setToolTip(tr("Improve playback back speed by disabling the graticule."));
+  toolbar_layout->addWidget(performance_select_);
+
+  connect(performance_select_, &QCheckBox::clicked, this, &HistogramScope::SetPerformanceMode);
+}
+
+void HistogramScope::SetPerformanceMode() {
+  performance_mode_ = !performance_mode_;
+  this->repaint();
 }
 
 HistogramScope::~HistogramScope()
@@ -146,58 +168,59 @@ void HistogramScope::DrawScope()
   OpenGLRenderFunctions::Blit(pipeline_secondary_);
 
   texture_row_sums_.Release();
+  if (!performance_mode_) {
+    // Draw line overlays
+    QPainter p(this);
+    QFont font = p.font();
+    font.setPixelSize(10);
+    QFontMetrics font_metrics = QFontMetrics(font);
+    QString label;
+    std::vector<float> histogram_increments = {
+      0.00,
+      0.25,
+      0.50,
+      1.0
+    };
 
-  // Draw line overlays
-  QPainter p(this);
-  QFont font = p.font();
-  font.setPixelSize(10);
-  QFontMetrics font_metrics = QFontMetrics(font);
-  QString label;
-  std::vector<float> histogram_increments = {
-    0.00,
-    0.25,
-    0.50,
-    1.0
-  };
+    int histogram_steps = histogram_increments.size();
+    QVector<QLine> histogram_lines(histogram_steps + 1);
+    int font_x_offset = 0;
+    int font_y_offset = font_metrics.capHeight() / 2.0f;
 
-  int histogram_steps = histogram_increments.size();
-  QVector<QLine> histogram_lines(histogram_steps + 1);
-  int font_x_offset = 0;
-  int font_y_offset = font_metrics.capHeight() / 2.0f;
+    p.setCompositionMode(QPainter::CompositionMode_Plus);
 
-  p.setCompositionMode(QPainter::CompositionMode_Plus);
+    p.setPen(QColor(0.0, 0.6 * 255.0, 0.0));
+    p.setFont(font);
 
-  p.setPen(QColor(0.0, 0.6 * 255.0, 0.0));
-  p.setFont(font);
+    float histogram_dim_x = ceil((width() - 1.0) * histogram_scale);
+    float histogram_dim_y = ceil((height() - 1.0) * histogram_scale);
+    float histogram_start_dim_x =
+      ((width() - 1.0) - histogram_dim_x) / 2.0f;
+    float histogram_start_dim_y =
+      ((height() - 1.0) - histogram_dim_y) / 2.0f;
+    float histogram_end_dim_x = (width() - 1.0) - histogram_start_dim_x;
 
-  float histogram_dim_x = ceil((width() - 1.0) * histogram_scale);
-  float histogram_dim_y = ceil((height() - 1.0) * histogram_scale);
-  float histogram_start_dim_x =
-    ((width() - 1.0) - histogram_dim_x) / 2.0f;
-  float histogram_start_dim_y =
-    ((height() - 1.0) - histogram_dim_y) / 2.0f;
-  float histogram_end_dim_x = (width() - 1.0) - histogram_start_dim_x;
-
-  // for (int i=0; i <= histogram_steps; i++) {
-  for(std::vector<float>::iterator it = histogram_increments.begin();
-    it != histogram_increments.end(); it++) {
-    histogram_lines[it - histogram_increments.begin()].setLine(
-      histogram_start_dim_x,
-      (histogram_dim_y * pow(1.0 - *it, histogram_base)) +
-        histogram_start_dim_y,
-      histogram_end_dim_x,
-      (histogram_dim_y * pow(1.0 - *it, histogram_base)) +
-        histogram_start_dim_y);
-      label = QString::number(
-        *it * 100, 'f', 1) + "%";
-      font_x_offset = QFontMetricsWidth(font_metrics, label) + 4;
-
-      p.drawText(
-        histogram_start_dim_x - font_x_offset,
+    // for (int i=0; i <= histogram_steps; i++) {
+    for(std::vector<float>::iterator it = histogram_increments.begin();
+      it != histogram_increments.end(); it++) {
+      histogram_lines[it - histogram_increments.begin()].setLine(
+        histogram_start_dim_x,
         (histogram_dim_y * pow(1.0 - *it, histogram_base)) +
-          histogram_start_dim_y + font_y_offset, label);
+          histogram_start_dim_y,
+        histogram_end_dim_x,
+        (histogram_dim_y * pow(1.0 - *it, histogram_base)) +
+          histogram_start_dim_y);
+        label = QString::number(
+          *it * 100, 'f', 1) + "%";
+        font_x_offset = QFontMetricsWidth(font_metrics, label) + 4;
+
+        p.drawText(
+          histogram_start_dim_x - font_x_offset,
+          (histogram_dim_y * pow(1.0 - *it, histogram_base)) +
+            histogram_start_dim_y + font_y_offset, label);
+    }
+    p.drawLines(histogram_lines);
   }
-  p.drawLines(histogram_lines);
 }
 
 OLIVE_NAMESPACE_EXIT

--- a/app/widget/scope/histogram/histogram.h
+++ b/app/widget/scope/histogram/histogram.h
@@ -21,6 +21,8 @@
 #ifndef HISTOGRAMSCOPE_H
 #define HISTOGRAMSCOPE_H
 
+#include <QCheckBox>
+
 #include "widget/scope/scopebase/scopebase.h"
 
 OLIVE_NAMESPACE_ENTER
@@ -44,8 +46,13 @@ protected:
   virtual void DrawScope() override;
 
 private:
+  virtual void SetupControlUI() override;
+  void SetPerformanceMode();
+
   OpenGLShaderPtr pipeline_secondary_;
   OpenGLTexture texture_row_sums_;
+  QCheckBox* performance_select_;
+  bool performance_mode_;
 
 private slots:
   void CleanUp();

--- a/app/widget/scope/scopebase/scopebase.cpp
+++ b/app/widget/scope/scopebase/scopebase.cpp
@@ -156,9 +156,4 @@ void ScopeBase::paintGL()
   }
 }
 
-void ScopeBase::SetupControlUI()
-{
-  control_ui_ = new QWidget();
-}
-
 OLIVE_NAMESPACE_EXIT

--- a/app/widget/scope/scopebase/scopebase.cpp
+++ b/app/widget/scope/scopebase/scopebase.cpp
@@ -29,6 +29,7 @@ ScopeBase::ScopeBase(QWidget* parent) :
   buffer_(nullptr)
 {
   EnableDefaultContextMenu();
+  control_ui_ = new QWidget();
 }
 
 ScopeBase::~ScopeBase()
@@ -38,6 +39,11 @@ ScopeBase::~ScopeBase()
   if (context()) {
     disconnect(context(), &QOpenGLContext::aboutToBeDestroyed, this, &ScopeBase::CleanUp);
   }
+}
+
+QWidget* ScopeBase::ControlUI()
+{
+  return control_ui_;
 }
 
 void ScopeBase::SetBuffer(Frame *frame)
@@ -148,6 +154,11 @@ void ScopeBase::paintGL()
 
     DrawScope();
   }
+}
+
+void ScopeBase::SetupControlUI()
+{
+  control_ui_ = new QWidget();
 }
 
 OLIVE_NAMESPACE_EXIT

--- a/app/widget/scope/scopebase/scopebase.h
+++ b/app/widget/scope/scopebase/scopebase.h
@@ -68,17 +68,16 @@ protected:
     return framebuffer_;
   }
 
-  QWidget* controlUI()
-  {
-    return control_ui_;
-  }
-
   QWidget* control_ui_;
 
 private:
   void UploadTextureFromBuffer();
 
-  virtual void SetupControlUI();
+   /**
+   * @brief Only needs to be implemented if the scope requires UI control. See waveform.cpp for an example
+   * Sets up the UI that control_ui_ points to.
+   */
+  virtual void SetupControlUI(){};
 
   OpenGLShaderPtr pipeline_;
 
@@ -89,8 +88,6 @@ private:
   OpenGLFramebuffer framebuffer_;
 
   Frame* buffer_;
-
-  
 
 private slots:
   void CleanUp();

--- a/app/widget/scope/scopebase/scopebase.h
+++ b/app/widget/scope/scopebase/scopebase.h
@@ -37,6 +37,8 @@ public:
 
   virtual ~ScopeBase() override;
 
+  QWidget* ControlUI();
+
 public slots:
   void SetBuffer(Frame* frame);
 
@@ -66,8 +68,17 @@ protected:
     return framebuffer_;
   }
 
+  QWidget* controlUI()
+  {
+    return control_ui_;
+  }
+
+  QWidget* control_ui_;
+
 private:
   void UploadTextureFromBuffer();
+
+  virtual void SetupControlUI();
 
   OpenGLShaderPtr pipeline_;
 
@@ -78,6 +89,8 @@ private:
   OpenGLFramebuffer framebuffer_;
 
   Frame* buffer_;
+
+  
 
 private slots:
   void CleanUp();

--- a/app/widget/scope/waveform/waveform.cpp
+++ b/app/widget/scope/waveform/waveform.cpp
@@ -42,7 +42,6 @@ WaveformScope::WaveformScope(QWidget* parent) :
 
 void WaveformScope::SetupControlUI()
 {
-  //control_ui_ = new QWidget();
   control_ui_->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout* toolbar_layout = new QHBoxLayout(control_ui_);

--- a/app/widget/scope/waveform/waveform.h
+++ b/app/widget/scope/waveform/waveform.h
@@ -22,6 +22,8 @@
 #define WAVEFORMSCOPE_H
 
 #include "widget/scope/scopebase/scopebase.h"
+#include <QCheckBox>
+#include <QVector>
 
 OLIVE_NAMESPACE_ENTER
 
@@ -35,6 +37,21 @@ protected:
   virtual OpenGLShaderPtr CreateShader() override;
 
   virtual void DrawScope() override;
+
+private:
+  virtual void SetupControlUI() override;
+
+  void SortSwizzleData(int checkbox);
+
+  QCheckBox* luma_select_;
+
+  QCheckBox* red_select_;
+
+  QCheckBox* green_select_;
+
+  QCheckBox* blue_select_;
+
+  QVector<bool> swizzle_;
 
 };
 


### PR DESCRIPTION
I've added another `QStackedWidget` to the scope panel that can hold the UI controls for the selected scope. The controls themselves are created in the scope classes (`WaveformScope` and `HistogramScope`) and then a pointer is passed to the scope panel but I'm not sure if this is the best way to do it. I could put them into a new classes and hook it all up with connections but they don't really seem big enough to be worth separating out. What do you think?

I've also re implemented the same controls as I'd added in PR 1161 and PR1144