### PR TITLE
Fix Help option in headless mode on Windows

### DIFF
--- a/app/common/commandlineparser.cpp
+++ b/app/common/commandlineparser.cpp
@@ -115,17 +115,21 @@ void CommandLineParser::PrintHelp(const char* filename)
   }
 
   const char* basename;
+  bool path = true;
 #ifdef Q_OS_WINDOWS
   basename = strrchr(filename, '\\');
   if (!basename) {
     basename = strrchr(filename, '/');
   }
+  if (!basename) {
+    basename = filename;
+    path = false;
+  }
 #else
   basename = strrchr(filename, '/');
 #endif
 
-  printf("Usage: %s [options] %s\n\n", basename + 1, positional_args.toUtf8().constData());
-
+  printf("Usage: %s [options] %s\n\n", path ? basename + 1 : basename, positional_args.toUtf8().constData());
   foreach (const KnownOption& o, options_) {
     QString all_args;
 

--- a/app/common/commandlineparser.cpp
+++ b/app/common/commandlineparser.cpp
@@ -121,6 +121,9 @@ void CommandLineParser::PrintHelp(const char* filename)
   if (!basename) {
     basename = strrchr(filename, '/');
   }
+  // If no slashes are found we are probably running Olive from the executables own directory
+  // so we set basename equal to the filename (olive-editor.exe). This ensures basename is
+  // always valid.
   if (!basename) {
     basename = filename;
     path = false;


### PR DESCRIPTION
Help option failed when Olive was run in its own directory as `strrchr`
failed. If all else fails `basename` is equal to `argv[0]` and we don't
increment in the print statement. Tested on Windows 7.