### PR TITLE
Prefer curl on OSX

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -26,7 +26,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     macdeployqt $BUNDLE_NAME
 
     # Fix other deps that macdeployqt missed
-    wget -c -nv https://github.com/arl/macdeployqtfix/raw/master/macdeployqtfix.py
+    curl -sLOC - https://github.com/arl/macdeployqtfix/raw/master/macdeployqtfix.py
     python2 macdeployqtfix.py $BUNDLE_NAME/Contents/MacOS/Olive /usr/local/Cellar/qt5/5.*/
 
     # Fix deps on crash handler

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -26,7 +26,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     macdeployqt $BUNDLE_NAME
 
     # Fix other deps that macdeployqt missed
-    curl -sLOC - https://github.com/arl/macdeployqtfix/raw/master/macdeployqtfix.py
+    curl -fLOSs --retry 3 https://github.com/arl/macdeployqtfix/raw/master/macdeployqtfix.py
     python2 macdeployqtfix.py $BUNDLE_NAME/Contents/MacOS/Olive /usr/local/Cellar/qt5/5.*/
 
     # Fix deps on crash handler


### PR DESCRIPTION
I'm using the Travis CI scripts to build locally (the build instructions on the website seem to refer to 0.1.0). Maybe at some point the CI scripts could be used for both purposes, in which case it would be a tiny bit easier to prefer curl on OSX as wget is not available by default.