### PR TITLE
Issue template: <details> for backtrace

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-olive_unsupported.md
+++ b/.github/ISSUE_TEMPLATE/00-olive_unsupported.md
@@ -5,7 +5,6 @@ title: "[UNSUPPORTED]"
 labels: "Legacy (Unsupported)"
 assignees: ''
 ---
-
 # Olive 0.1 is unsupported
 
 Unfortunately no one is supporting Olive 0.1 at this time. Any reports pertaining to it will be

--- a/.github/ISSUE_TEMPLATE/01-crash_issue.md
+++ b/.github/ISSUE_TEMPLATE/01-crash_issue.md
@@ -4,7 +4,6 @@ about: Report a fatal crash that resulted in Olive unexpectedly closing.
 title: "[CRASH]"
 labels: "Crash, Triage"
 assignees: ''
-
 ---
 **Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
 
@@ -23,9 +22,8 @@ assignees: ''
 
 <details><summary><strong>Backtrace</strong></summary><pre><code>
 
-Paste backtrace here
+<!-- Paste backtrace here -->
 
 </code></pre></details>
 
 **Additional Information**
-

--- a/.github/ISSUE_TEMPLATE/01-crash_issue.md
+++ b/.github/ISSUE_TEMPLATE/01-crash_issue.md
@@ -6,14 +6,26 @@ labels: "Crash, Triage"
 assignees: ''
 
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Steps to Reproduce**
 
-**Backtrace**
+1. 
+2. 
+3. 
+
+<details><summary><strong>Backtrace</strong></summary><pre><code>
+
+Paste backtrace here
+
+</code></pre></details>
 
 **Additional Information**
+

--- a/.github/ISSUE_TEMPLATE/50-build_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-build_issue.md
@@ -4,12 +4,14 @@ about: Report an issue related to compiling or packaging (including continuous i
 title: "[BUILD]"
 labels: "Building/Packaging, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-cache_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-cache_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to the disk cache system, including failure to c
 title: "[CACHE]"
 labels: "Disk Cache, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-codec_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-codec_issue.md
@@ -4,12 +4,14 @@ about: Report an issue related to codec handling, including importing footage or
 title: "[CODEC]"
 labels: "Codec, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-color_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-color_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to the management of pixels and color, including
 title: "[COLOR]"
 labels: "Color Management, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-editing_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-editing_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to the overall editing experience, including usa
 title: "[EDIT]"
 labels: "Timeline/Editing, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-export_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-export_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to exporting videos from Olive, including errors
 title: "[EXPORT]"
 labels: "Export, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-node_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-node_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to the node-based compositing system, including 
 title: "[NODES]"
 labels: "Nodes/Compositing, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-playback_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-playback_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to the playback of video or audio, including lag
 title: "[PLAYBACK]"
 labels: "Playback, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-project_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-project_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to project management, including working with an
 title: "[PROJECT]"
 labels: "Project, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-renderer_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-renderer_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to rendering, including corrupted frames, incorr
 title: "[RENDER]"
 labels: "Renderer, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**

--- a/.github/ISSUE_TEMPLATE/50-ui_issue.md
+++ b/.github/ISSUE_TEMPLATE/50-ui_issue.md
@@ -4,12 +4,14 @@ about:  Report an issue related to general user interface usability, including b
 title: "[UI]"
 labels: "User Interface, Triage"
 assignees: ''
-
 ---
-**Commit Hash (8 character string of letters/numbers in title bar)**
+**Commit Hash** <!-- 8 character string of letters/numbers in title bar (e.g. 3ea173c9) -->
+
 
 **Platform**
 
+
 **Summary**
+
 
 **Additional Information / Output**


### PR DESCRIPTION
Make the Crash template not show the backtrace by default, as suggested by ZoomTen.

Use HTML comment for explanation of what the commit hash is, so that it doesn't end up in the ticket und is still visible to the user when reporting.