### PR TITLE
[UI] Fix keyframe icons not redrawing correctly

### DIFF
--- a/app/widget/keyframeview/keyframeviewbase.cpp
+++ b/app/widget/keyframeview/keyframeviewbase.cpp
@@ -39,6 +39,7 @@ KeyframeViewBase::KeyframeViewBase(QWidget *parent) :
 {
   SetDefaultDragMode(RubberBandDrag);
   setContextMenuPolicy(Qt::CustomContextMenu);
+  setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
 
   connect(this, &KeyframeViewBase::customContextMenuRequested, this, &KeyframeViewBase::ShowContextMenu);
   connect(scene(), &QGraphicsScene::selectionChanged, this, &KeyframeViewBase::AutoSelectKeyTimeNeighbors);


### PR DESCRIPTION
When changing between nodes the keyframes in the keyframe editor did
not always update correctly. This is the same fix as in 9c488d9 / https://github.com/olive-editor/olive/issues/1190#issuecomment-694252893