### PR TITLE
Fix issue#1241

### DIFF
--- a/app/widget/nodeview/nodeviewundo.h
+++ b/app/widget/nodeview/nodeviewundo.h
@@ -27,6 +27,7 @@
 #include "node/node.h"
 #include "nodeviewitem.h"
 #include "undo/undocommand.h"
+#include "widget/timelinewidget/undo/undo.h"
 
 OLIVE_NAMESPACE_ENTER
 
@@ -112,7 +113,7 @@ private:
   NodeGraph* graph_;
   QList<Node*> nodes_;
   QList<NodeEdgePtr> edges_;
-  QMap<Block*, QList<Block*>> linked_blocks_;
+  QList<BlockUnlinkAllCommand*> block_unlink_commands_;
 };
 
 class NodeRemoveWithExclusiveDeps : public UndoCommand {

--- a/app/widget/nodeview/nodeviewundo.h
+++ b/app/widget/nodeview/nodeviewundo.h
@@ -112,6 +112,7 @@ private:
   NodeGraph* graph_;
   QList<Node*> nodes_;
   QList<NodeEdgePtr> edges_;
+  QMap<Block*, QList<Block*>> linked_blocks_;
 };
 
 class NodeRemoveWithExclusiveDeps : public UndoCommand {

--- a/app/widget/timelinewidget/timelinewidget.cpp
+++ b/app/widget/timelinewidget/timelinewidget.cpp
@@ -494,8 +494,6 @@ void TimelineWidget::ReplaceBlocksWithGaps(const QList<Block *> &blocks,
     new TrackReplaceBlockWithGapCommand(original_track, b, command);
 
     if (remove_from_graph) {
-      new BlockUnlinkAllCommand(b, command);
-
       new NodeRemoveWithExclusiveDeps(static_cast<NodeGraph*>(b->parent()), b, command);
     }
   }

--- a/app/widget/timelinewidget/undo/undo.cpp
+++ b/app/widget/timelinewidget/undo/undo.cpp
@@ -243,10 +243,6 @@ void TrackRippleRemoveAreaCommand::redo_internal()
     foreach (Block* remove_block, removed_blocks_) {
       track_->RippleRemoveBlock(remove_block);
 
-      BlockUnlinkAllCommand* unlink_command = new BlockUnlinkAllCommand(remove_block);
-      unlink_command->redo();
-      remove_block_commands_.append(unlink_command);
-
       NodeRemoveWithExclusiveDeps* remove_command = new NodeRemoveWithExclusiveDeps(static_cast<NodeGraph*>(remove_block->parent()), remove_block);
       remove_command->redo();
       remove_block_commands_.append(remove_command);


### PR DESCRIPTION
Fixes #1241 

When a Block node was deleted its linked blocks were not unlinked
which caused a crash when the user tried to select a linked block.
This fixes the issue by ensuring all links are removed when a Block
node is delete.

Undo/redo is also supported.

This does fix the problem but I'm not 100% sure this code is in the correct place.