### PR TITLE
Fix Issue #1258

### DIFF
--- a/app/widget/projectexplorer/projectexplorer.cpp
+++ b/app/widget/projectexplorer/projectexplorer.cpp
@@ -666,9 +666,11 @@ void ProjectExplorer::DeleteSelected()
       }
 
       // Close footage if currently open in footage panel
-      FootageViewerPanel* footage_panel = PanelManager::instance()->GetPanelsOfType<FootageViewerPanel>().first();
-      if (footage_panel->GetSelectedFootage().contains(footage)) {
-        footage_panel->SetFootage(nullptr);
+      QList<FootageViewerPanel*> footage_panels = PanelManager::instance()->GetPanelsOfType<FootageViewerPanel>();
+      foreach (FootageViewerPanel* panel, footage_panels) {
+        if (panel->GetSelectedFootage().contains(footage)) {
+          panel->SetFootage(nullptr);
+        }
       }
       break;
     }

--- a/app/widget/viewer/audiowaveformview.cpp
+++ b/app/widget/viewer/audiowaveformview.cpp
@@ -63,10 +63,13 @@ void AudioWaveformView::paintEvent(QPaintEvent *event)
 {
   QWidget::paintEvent(event);
 
+  if (!playback_) {
+    return;
+  }
+
   const AudioParams& params = playback_->GetParameters();
 
-  if (!playback_
-      || playback_->GetPCMFilename().isEmpty()
+  if (playback_->GetPCMFilename().isEmpty()
       || !params.is_valid()) {
     return;
   }

--- a/app/widget/viewer/footageviewer.cpp
+++ b/app/widget/viewer/footageviewer.cpp
@@ -63,6 +63,15 @@ void FootageViewerWidget::SetFootage(Footage *footage)
 
   footage_ = footage;
 
+  if (!footage) {
+    // Set name to blank
+    sequence_.viewer_output()->set_media_name("");
+
+    // Clean up the audio waveform if it is in use
+    waveform()->SetViewer(nullptr);
+    waveform()->hide();
+  }
+
   if (footage_) {
     // Update sequence media name
     sequence_.viewer_output()->set_media_name(footage_->name());

--- a/app/widget/viewer/viewer.h
+++ b/app/widget/viewer/viewer.h
@@ -87,6 +87,11 @@ public:
     return renderer_;
   }
 
+  AudioWaveformView* waveform()
+  {
+    return waveform_view_;
+  }
+
   ColorManager* color_manager() const
   {
     return display_widget_->color_manager();


### PR DESCRIPTION
I'm not entirely sure all of this is required or in the right place but it does fix #1258

The issue is fixed by checking that playback_ is valid before using
it in AudioWaveformView::paintEvent.

The rest of this commit just makes sure playback is set to nullptr
as it should be and makes the UI match what ahppens when a video is
deleted.