### PR TITLE
Reset Timecode in Footage Viewer

### DIFF
--- a/app/widget/playbackcontrols/playbackcontrols.cpp
+++ b/app/widget/playbackcontrols/playbackcontrols.cpp
@@ -186,6 +186,10 @@ void PlaybackControls::SetEndTime(const int64_t &r)
   end_tc_lbl_->setText(Timecode::timestamp_to_timecode(end_time_,
                                                        time_base_,
                                                        Core::instance()->GetTimecodeDisplay()));
+
+  if (end_time_ == 0) {
+    end_tc_lbl_->setVisible(false);
+  }
 }
 
 void PlaybackControls::ShowPauseButton()

--- a/app/widget/viewer/footageviewer.cpp
+++ b/app/widget/viewer/footageviewer.cpp
@@ -54,6 +54,7 @@ void FootageViewerWidget::SetFootage(Footage *footage)
 {
   if (footage_) {
     cached_timestamps_.insert(footage_, GetTimestamp());
+    controls()->SetEndTime(0);
 
     ConnectViewerNode(nullptr);
 
@@ -110,6 +111,9 @@ void FootageViewerWidget::SetFootage(Footage *footage)
     ConnectViewerNode(sequence_.viewer_output(), footage_->project()->color_manager());
 
     SetTimestamp(cached_timestamps_.value(footage_, 0));
+  }
+  else {
+    SetTimestamp(0);
   }
 }
 

--- a/app/widget/viewer/viewer.cpp
+++ b/app/widget/viewer/viewer.cpp
@@ -712,7 +712,6 @@ void ViewerWidget::UpdateStack()
       new_tb = GetConnectedNode()->video_params().time_base();
     }*/
   }
-
   /*if (new_tb != timebase()) {
     SetTimebase(new_tb);
   }*/

--- a/app/widget/viewer/viewer.h
+++ b/app/widget/viewer/viewer.h
@@ -92,6 +92,11 @@ public:
     return display_widget_->color_manager();
   }
 
+  PlaybackControls* controls() const
+  {
+    return controls_;
+  }
+
   void SetGizmos(Node* node);
 
 public slots:


### PR DESCRIPTION
Resets the current timecode to 0 when the footage in the viewer is
closed.

Hides the end timecode of a viewer whenever the end timecode is equal
to 0.