### PR TITLE
Handle Missing Files

### DIFF
--- a/app/codec/decoder.cpp
+++ b/app/codec/decoder.cpp
@@ -101,12 +101,16 @@ bool Decoder::ProbeMedia(Footage *f, const QAtomicInt* cancelled)
   // Check for a valid filename
   if (f->filename().isEmpty()) {
     qWarning() << "Tried to probe media with an empty filename";
+    f->set_status(Footage::kInvalid);
+    f->set_decoder(QString());
     return false;
   }
 
   // Check file exists
   if (!QFileInfo::exists(f->filename())) {
     qWarning() << "Tried to probe file that doesn't exist:" << f->filename();
+    f->set_status(Footage::kInvalid);
+    f->set_decoder(QString());
     return false;
   }
 

--- a/app/dialog/footageproperties/footageproperties.cpp
+++ b/app/dialog/footageproperties/footageproperties.cpp
@@ -37,6 +37,7 @@
 #include "render/colormanager.h"
 #include "streamproperties/audiostreamproperties.h"
 #include "streamproperties/videostreamproperties.h"
+#include "node/input/media/media.h"
 
 OLIVE_NAMESPACE_ENTER
 
@@ -184,8 +185,22 @@ void FootagePropertiesDialog::RelinkFootage()
   if (!file.isEmpty()) {
     footage_->set_filename(file);
     Decoder::ProbeMedia(footage_, 0);
-    footage_invalid_warning_->hide();
-    UpdateTrackList();
+    if (footage_->status() == Footage::kReady) {
+      footage_invalid_warning_->hide();
+      UpdateTrackList();
+
+      QList<ItemPtr> sequences = footage_->project()->get_items_of_type(Item::kSequence);
+
+      foreach (ItemPtr s, sequences) {
+        const QList<Node *> &nodes = static_cast<Sequence *>(s.get())->nodes();
+        foreach (Node *n, nodes) {
+          if (n->IsMedia()) {
+            MediaInput *media_node = static_cast<MediaInput *>(n);
+            media_node->SetFootage(media_node->footage());
+          }
+        }
+      }
+    }
   }
 }
 

--- a/app/dialog/footageproperties/footageproperties.cpp
+++ b/app/dialog/footageproperties/footageproperties.cpp
@@ -189,6 +189,7 @@ void FootagePropertiesDialog::RelinkFootage()
       footage_invalid_warning_->hide();
       UpdateTrackList();
 
+      // Loop through all nodes to see if any need to be re-linked to this footage
       QList<ItemPtr> sequences = footage_->project()->get_items_of_type(Item::kSequence);
 
       foreach (ItemPtr s, sequences) {
@@ -196,7 +197,16 @@ void FootagePropertiesDialog::RelinkFootage()
         foreach (Node *n, nodes) {
           if (n->IsMedia()) {
             MediaInput *media_node = static_cast<MediaInput *>(n);
-            media_node->SetFootage(media_node->footage());
+
+            StreamPtr node_stream = media_node->footage();
+
+            if (node_stream->footage() == footage_) {
+              foreach (StreamPtr str, footage_->streams()) {
+                if (node_stream->index() == str.get()->index()) {
+                  media_node->SetFootage(str);
+                }
+              }
+            }
           }
         }
       }

--- a/app/dialog/footageproperties/footageproperties.h
+++ b/app/dialog/footageproperties/footageproperties.h
@@ -31,6 +31,7 @@
 
 #include "project/item/footage/footage.h"
 #include "undo/undocommand.h"
+#include "widget/clickablelabel/clickablelabel.h"
 
 OLIVE_NAMESPACE_ENTER
 
@@ -95,6 +96,11 @@ private:
   };
 
   /**
+   * @brief Update list of streams available in the footage
+   */
+  void UpdateTrackList();
+
+  /**
    * @brief Stack of widgets that changes based on whether the stream is a video or audio stream
    */
   QStackedWidget* stacked_widget_;
@@ -108,6 +114,16 @@ private:
    * @brief Media name text field
    */
   QLineEdit* footage_name_field_;
+
+  /**
+   * @brief Media path text field
+   */
+  ClickableLabel* footage_path_field_;
+
+  /**
+   * @brief Footage invalid warning
+   */
+  QLabel* footage_invalid_warning_;
 
   /**
    * @brief Internal pointer to Media object (set in constructor)
@@ -129,6 +145,8 @@ private slots:
    * @brief Overridden accept function for saving the properties back to the Media class
    */
   void accept();
+
+  void RelinkFootage();
 
 };
 

--- a/app/node/input/media/media.cpp
+++ b/app/node/input/media/media.cpp
@@ -40,14 +40,15 @@ QList<Node::CategoryID> MediaInput::Category() const
   return {kCategoryInput};
 }
 
-StreamPtr MediaInput::footage()
-{
+StreamPtr MediaInput::footage() {
+  //printf("footage: %s\n", QString::number(reinterpret_cast<quintptr>(footage_input_->get_standard_value().value<StreamPtr>().get())).toStdString().c_str());
   return footage_input_->get_standard_value().value<StreamPtr>();
 }
 
 void MediaInput::SetFootage(StreamPtr f)
 {
   footage_input_->set_standard_value(QVariant::fromValue(f));
+  FootageChanged();
 }
 
 bool MediaInput::IsMedia() const

--- a/app/project/item/footage/footage.cpp
+++ b/app/project/item/footage/footage.cpp
@@ -99,7 +99,19 @@ void Footage::Load(QXmlStreamReader *reader, XMLNodeData &xml_node_data, const Q
       }
 
       if (stream_index > -1 && stream_ptr > 0) {
-        xml_node_data.footage_ptrs.insert(stream_ptr, stream(stream_index));
+        StreamPtr str;
+
+        // If footage hasn't been read properly assume streams ahven't been created and create
+        // our own that have enough info to link back to the originals if required
+        if (status() != kReady) {
+          str = std::make_shared<Stream>();
+          str->set_footage(this);
+          str->set_index(stream_index);
+          add_stream(str);
+        } else {
+          str = stream(stream_index);
+        }
+        xml_node_data.footage_ptrs.insert(stream_ptr, str);
 
         if (status() == kReady) {
           stream(stream_index)->Load(reader);
@@ -186,10 +198,7 @@ void Footage::add_stream(StreamPtr s)
 
 StreamPtr Footage::stream(int index) const
 {
-  if (streams_.count() > 0) {
-    return streams_.at(index);
-  }
-  return nullptr;
+  return streams_.at(index);
 }
 
 const QList<StreamPtr> &Footage::streams() const

--- a/app/project/item/footage/footage.cpp
+++ b/app/project/item/footage/footage.cpp
@@ -75,12 +75,7 @@ void Footage::Load(QXmlStreamReader *reader, XMLNodeData &xml_node_data, const Q
     }
   }
 
-  bool valid = false;
-  if (Decoder::ProbeMedia(this, cancelled)) {
-    valid = true;
-  } else {
-    set_status(kInvalid);
-  }
+  Decoder::ProbeMedia(this, cancelled);
 
   while (XMLReadNextStartElement(reader)) {
     if (cancelled && *cancelled) {

--- a/app/render/backend/renderworker.cpp
+++ b/app/render/backend/renderworker.cpp
@@ -348,7 +348,7 @@ DecoderPtr RenderWorker::ResolveDecoderFromInput(StreamPtr stream)
 
   DecoderPtr decoder = decoder_cache_.value(stream.get());
 
-  if (!decoder && stream) {
+  if (!decoder && stream && stream->footage()->status() == Footage::kReady) {
     // Create a new Decoder here
     decoder = Decoder::CreateFromID(stream->footage()->decoder());
     decoder->set_stream(stream);
@@ -357,9 +357,12 @@ DecoderPtr RenderWorker::ResolveDecoderFromInput(StreamPtr stream)
       decoder_cache_.insert(stream.get(), decoder);
     } else {
       decoder = nullptr;
+      stream->footage()->set_status(Footage::kInvalid);
       qWarning() << "Failed to open decoder for" << stream->footage()->filename()
                  << "::" << stream->index();
     }
+  } else {
+    decoder = nullptr;
   }
 
   decoder_age_.insert(stream.get(), QDateTime::currentMSecsSinceEpoch());


### PR DESCRIPTION
Fix #1260 and fix sobotka/Olive#101

This is a basic fix for handling missing files on load. If a footage probe returns false the clip/nodes are created but with null pointers for there streams and the clip is marked as `kInvalid` in the project explorer. It would be good to also add a warning message and maybe some kind of visual indicator in the timeline and/or the viewer.

Also need to add a way to relink the footage.