### PR TITLE
Fix building without OTIO support

### DIFF
--- a/app/codec/CMakeLists.txt
+++ b/app/codec/CMakeLists.txt
@@ -16,7 +16,9 @@
 
 add_subdirectory(ffmpeg)
 add_subdirectory(oiio)
-add_subdirectory(otio)
+if(OpenTimelineIO_FOUND)
+  add_subdirectory(otio)
+endif()
 
 set(OLIVE_SOURCES
   ${OLIVE_SOURCES}

--- a/app/codec/decoder.cpp
+++ b/app/codec/decoder.cpp
@@ -27,7 +27,9 @@
 #include "codec/ffmpeg/ffmpegcommon.h"
 #include "codec/ffmpeg/ffmpegdecoder.h"
 #include "codec/oiio/oiiodecoder.h"
+#ifdef USE_OTIO
 #include "codec/otio/otiodecoder.h"
+#endif
 #include "codec/waveinput.h"
 #include "codec/waveoutput.h"
 #include "common/filefunctions.h"
@@ -90,8 +92,9 @@ QVector<DecoderPtr> ReceiveListOfAllDecoders() {
 
   // The order in which these decoders are added is their priority when probing. Hence FFmpeg should usually be last,
   // since it supports so many formats and we presumably want to override those formats with a more specific decoder.
-
+#ifdef USE_OTIO
   decoders.append(std::make_shared<OTIODecoder>());
+#endif
   decoders.append(std::make_shared<OIIODecoder>());
   decoders.append(std::make_shared<FFmpegDecoder>());
 

--- a/app/core.cpp
+++ b/app/core.cpp
@@ -53,7 +53,9 @@
 #include "render/diskmanager.h"
 #include "render/pixelformat.h"
 #include "render/shaderinfo.h"
+#ifdef USE_OTIO
 #include "task/project/exportotio/exportotiotask.h"
+#endif
 #include "task/project/import/import.h"
 #include "task/project/import/importerrordialog.h"
 #include "task/project/load/load.h"

--- a/app/task/project/CMakeLists.txt
+++ b/app/task/project/CMakeLists.txt
@@ -14,7 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-add_subdirectory(exportotio)
+if(OpenTimelineIO_FOUND)
+  add_subdirectory(exportotio)
+endif()
+
 add_subdirectory(import)
 add_subdirectory(load)
 add_subdirectory(save)


### PR DESCRIPTION
I saw there was already some support for building `otio` _without_ OTIO support so got it working on Windows at least (I've not yet attempted building OTIO myself...). I don't really know CMake very well so I might not have done it properly.