### PR TITLE
Fix #1271 Duplicate Keyframed Node

### DIFF
--- a/app/node/input.cpp
+++ b/app/node/input.cpp
@@ -1075,7 +1075,9 @@ void NodeInput::CopyValues(NodeInput *source, NodeInput *dest, bool include_conn
   for (int i=0;i<source->keyframe_tracks_.size();i++) {
     dest->keyframe_tracks_[i].clear();
     foreach (NodeKeyframePtr key, source->keyframe_tracks_.at(i)) {
-      dest->keyframe_tracks_[i].append(key->copy());
+      NodeKeyframePtr key_copy = key->copy();
+      key_copy->set_parent(dest);
+      dest->keyframe_tracks_[i].append(key_copy);
     }
   }
 


### PR DESCRIPTION
Fix #1271 

When nodes with keyframes were copied their parent `NodeInput` was not
set properly leading to a segfult when `key->GetParent` was called in
`KeyframeViewItem::UpdatePos()`.

This fix properly sets parent_ when keys are copied.