### PR TITLE
Docker: Add ci-otio image

### DIFF
--- a/docker/ci-common/Dockerfile
+++ b/docker/ci-common/Dockerfile
@@ -21,7 +21,6 @@ ARG DTS_VERSION
 ARG CMAKE_VERSION
 
 LABEL maintainer="olivevideoeditor@gmail.com"
-
 LABEL org.opencontainers.image.name="$OLIVE_ORG/ci-common"
 LABEL org.opencontainers.image.description="CentOS CI Shared Image"
 LABEL org.opencontainers.image.url="http://olivevideoeditor.org"

--- a/docker/ci-common/Dockerfile
+++ b/docker/ci-common/Dockerfile
@@ -27,6 +27,7 @@ LABEL org.opencontainers.image.url="http://olivevideoeditor.org"
 LABEL org.opencontainers.image.source="https://github.com/olive-editor/olive"
 LABEL org.opencontainers.image.vendor="Olive Team"
 LABEL org.opencontainers.image.version="1.0"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
 
 USER root
 

--- a/docker/ci-crashpad/Dockerfile
+++ b/docker/ci-crashpad/Dockerfile
@@ -19,6 +19,7 @@ LABEL org.opencontainers.image.url="http://olivevideoeditor.org"
 LABEL org.opencontainers.image.source="https://github.com/olive-editor/olive"
 LABEL org.opencontainers.image.vendor="Olive Team"
 LABEL org.opencontainers.image.version="1.0"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
 
 COPY scripts/build_crashpad.sh \
      /tmp/

--- a/docker/ci-crashpad/Dockerfile
+++ b/docker/ci-crashpad/Dockerfile
@@ -13,7 +13,6 @@ ARG OLIVE_ORG
 ARG CI_COMMON_VERSION
 
 LABEL maintainer="olivevideoeditor@gmail.com"
-
 LABEL org.opencontainers.image.name="$OLIVE_ORG/ci-crashpad"
 LABEL org.opencontainers.image.description="CentOS Crashpad Build Image"
 LABEL org.opencontainers.image.url="http://olivevideoeditor.org"

--- a/docker/ci-ffmpeg/Dockerfile
+++ b/docker/ci-ffmpeg/Dockerfile
@@ -33,6 +33,7 @@ LABEL org.opencontainers.image.url="http://olivevideoeditor.org"
 LABEL org.opencontainers.image.source="https://github.com/olive-editor/olive"
 LABEL org.opencontainers.image.vendor="Olive Team"
 LABEL org.opencontainers.image.version="1.0"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
 
 COPY scripts/build_ffmpeg.sh \
      /tmp/

--- a/docker/ci-ffmpeg/Dockerfile
+++ b/docker/ci-ffmpeg/Dockerfile
@@ -27,7 +27,6 @@ ARG OPUS_VERSION
 ARG NUM_JOBS=2
 
 LABEL maintainer="olivevideoeditor@gmail.com"
-
 LABEL org.opencontainers.image.name="$OLIVE_ORG/ci-ffmpeg"
 LABEL org.opencontainers.image.description="CentOS FFmpeg Build Image"
 LABEL org.opencontainers.image.url="http://olivevideoeditor.org"

--- a/docker/ci-olive/Dockerfile
+++ b/docker/ci-olive/Dockerfile
@@ -18,6 +18,7 @@ FROM ${ASWF_PKG_ORG}/ci-package-oiio:${VFXPLATFORM_VERSION} as ci-package-oiio
 FROM ${ASWF_PKG_ORG}/ci-package-ocio:${VFXPLATFORM_VERSION} as ci-package-ocio
 FROM ${OLIVE_ORG}/ci-package-ffmpeg:${FFMPEG_VERSION} as ci-package-ffmpeg
 FROM ${OLIVE_ORG}/ci-package-crashpad:latest as ci-package-crashpad
+FROM ${OLIVE_ORG}/ci-package-otio:${VFXPLATFORM_VERSION}.${CI_COMMON_VERSION} as ci-package-otio
 
 FROM ${OLIVE_ORG}/ci-common:${CI_COMMON_VERSION} as ci-olive
 
@@ -33,6 +34,7 @@ LABEL org.opencontainers.image.url="http://olivevideoeditor.org"
 LABEL org.opencontainers.image.source="https://github.com/olive-editor/olive"
 LABEL org.opencontainers.image.vendor="Olive Team"
 LABEL org.opencontainers.image.version="1.0"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
 
 ENV PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:${PYTHONPATH} \
     CRASHPAD_LOCATION=/usr/local/crashpad \
@@ -46,6 +48,7 @@ COPY --from=ci-package-oiio /. /usr/local/
 COPY --from=ci-package-ocio /. /usr/local/
 COPY --from=ci-package-ffmpeg /. /usr/local/
 COPY --from=ci-package-crashpad /. /usr/local/
+COPY --from=ci-package-otio /. /usr/local/
 
 RUN curl --location "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" \
       -o "/usr/local/linuxdeployqt-x86_64.AppImage" && \

--- a/docker/ci-olive/Dockerfile
+++ b/docker/ci-olive/Dockerfile
@@ -18,7 +18,7 @@ FROM ${ASWF_PKG_ORG}/ci-package-oiio:${VFXPLATFORM_VERSION} as ci-package-oiio
 FROM ${ASWF_PKG_ORG}/ci-package-ocio:${VFXPLATFORM_VERSION} as ci-package-ocio
 FROM ${OLIVE_ORG}/ci-package-ffmpeg:${FFMPEG_VERSION} as ci-package-ffmpeg
 FROM ${OLIVE_ORG}/ci-package-crashpad:latest as ci-package-crashpad
-FROM ${OLIVE_ORG}/ci-package-otio:${VFXPLATFORM_VERSION}.${CI_COMMON_VERSION} as ci-package-otio
+FROM ${OLIVE_ORG}/ci-package-otio:latest as ci-package-otio
 
 FROM ${OLIVE_ORG}/ci-common:${CI_COMMON_VERSION} as ci-olive
 

--- a/docker/ci-olive/Dockerfile
+++ b/docker/ci-olive/Dockerfile
@@ -26,7 +26,7 @@ ARG VFXPLATFORM_VERSION
 ARG PYTHON_VERSION=3.7
 
 LABEL maintainer="olivevideoeditor@gmail.com"
-
+LABEL com.vfxplatform.version=$VFXPLATFORM_VERSION
 LABEL org.opencontainers.image.name="olivevideoeditor/ci-olive"
 LABEL org.opencontainers.image.description="CentOS CI Olive Build Image"
 LABEL org.opencontainers.image.url="http://olivevideoeditor.org"

--- a/docker/ci-otio/Dockerfile
+++ b/docker/ci-otio/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Build image (default):
-#  docker build -t olivevideoeditor/ci-package-otio:2021.2 -f ci-otio/Dockerfile .
+#  docker build -t olivevideoeditor/ci-package-otio -f ci-otio/Dockerfile .
 
 ARG OLIVE_ORG=olivevideoeditor
 ARG ASWF_PKG_ORG=aswftesting

--- a/docker/ci-otio/Dockerfile
+++ b/docker/ci-otio/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright (C) 2020 Olive Team
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Build image (default):
+#  docker build -t olivevideoeditor/ci-package-otio:2021.2 -f ci-otio/Dockerfile .
+
+ARG OLIVE_ORG=olivevideoeditor
+ARG ASWF_PKG_ORG=aswftesting
+ARG CI_COMMON_VERSION=2
+ARG VFXPLATFORM_VERSION=2021
+
+FROM ${ASWF_PKG_ORG}/ci-package-python:${VFXPLATFORM_VERSION} as ci-package-python
+FROM ${ASWF_PKG_ORG}/ci-package-qt:${VFXPLATFORM_VERSION} as ci-package-qt
+FROM ${ASWF_PKG_ORG}/ci-package-pyside:${VFXPLATFORM_VERSION} as ci-package-pyside
+
+FROM ${OLIVE_ORG}/ci-common:${CI_COMMON_VERSION} as ci-otio
+
+ARG OLIVE_ORG
+ARG VFXPLATFORM_VERSION
+ARG PYTHON_VERSION=3.7
+
+LABEL maintainer="olivevideoeditor@gmail.com"
+LABEL com.vfxplatform.version=$VFXPLATFORM_VERSION
+LABEL org.opencontainers.image.name="$OLIVE_ORG/ci-otio"
+LABEL org.opencontainers.image.description="CentOS OpenTimelineIO Build Image"
+LABEL org.opencontainers.image.url="http://olivevideoeditor.org"
+LABEL org.opencontainers.image.source="https://github.com/olive-editor/olive"
+LABEL org.opencontainers.image.vendor="Olive Team"
+LABEL org.opencontainers.image.version="1.0"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
+
+ENV OLIVE_ORG=${OLIVE_ORG} \
+    CI_COMMON_VERSION=${CI_COMMON_VERSION} \
+    VFXPLATFORM_VERSION=${VFXPLATFORM_VERSION} \
+    PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:/usr/local/lib/python \
+    OLIVE_INSTALL_PREFIX=/usr/local
+
+COPY scripts/base/install_cmake.sh \
+     scripts/build_otio.sh \
+     /tmp/
+
+COPY --from=ci-package-python /. /usr/local/
+COPY --from=ci-package-qt /. /usr/local/
+COPY --from=ci-package-pyside /. /usr/local/
+
+RUN export DOWNLOADS_DIR=/tmp/downloads && \
+    mkdir /tmp/downloads && \
+    /tmp/install_cmake.sh && \
+    pip install flake8 tox urllib3 && \
+    rm -rf /tmp/downloads
+
+RUN /tmp/before_build.sh && \
+    /tmp/build_otio.sh && \
+    /tmp/copy_new_files.sh
+
+FROM scratch as ci-package-otio
+
+COPY --from=ci-otio /package/. /

--- a/docker/scripts/build_otio.sh
+++ b/docker/scripts/build_otio.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright (C) 2020 Olive Team
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -ex
+
+git clone --depth 1 https://github.com/PixarAnimationStudios/OpenTimelineIO.git
+cd OpenTimelineIO
+
+#if [ "$OTIO_VERSION" != "latest" ]; then
+#    git checkout "tags/v${OTIO_VERSION}" -b "v${OTIO_VERSION}"
+#fi
+
+pip install --prefix="${OLIVE_INSTALL_PREFIX}" .
+
+mkdir build
+cd build
+cmake .. -G "Ninja"
+cmake --build .
+cmake --install . --prefix "${OLIVE_INSTALL_PREFIX}"
+
+cd ../..
+rm -rf OpenTimelineIO


### PR DESCRIPTION
[olivevideoeditor/ci-package-otio](https://hub.docker.com/r/olivevideoeditor/ci-package-otio) contains the Python as well C++ version of OpenTimelineIO (the ASWF image only comes with Python at the time of writing).

AppImage builds should pick up libopentime(lime).so with this and thus allow you to open OTIO files as projects.

Related issue: #310