### PR TITLE
CI: Get OpenTimelineIO libs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,12 @@ jobs:
           $DOWNLOAD_TOOL https://olivevideoeditor.org/deps/crashpad-win.7z
           $EXTRACT_TOOL crashpad-win.7z
 
+      - name: Acquire OpenTimelineIO
+        shell: bash
+        run: |
+          $DOWNLOAD_TOOL https://olivevideoeditor.org/deps/otio-win.7z
+          $EXTRACT_TOOL otio-win.7z
+
       - name: Configure CMake
         shell: bash
         working-directory: ${{ runner.workspace }}/build


### PR DESCRIPTION
Fetch OpenTimelineIO and OpenTime libraries
- [x] Linux - #1278 
- [x] Windows - [otio-win.zip](https://github.com/olive-editor/olive/files/5442609/otio-win.zip) (unpack for 7z archive)
- [ ] macOS - TBD
