### PR TITLE
Fix #1284 Odd Image Height Causes Crash

### DIFF
--- a/app/render/videoparams.cpp
+++ b/app/render/videoparams.cpp
@@ -196,9 +196,12 @@ QString VideoParams::FormatPixelAspectRatioString(const QString &format, const r
 
 int VideoParams::GetScaledDimension(int dim, int divider)
 {
+  Q_ASSERT(divider > 0);
+
   if (divider == 1) {
     return dim;
   }
+
   return qCeil(dim / divider * 0.5) * 2;
 }
 

--- a/app/render/videoparams.cpp
+++ b/app/render/videoparams.cpp
@@ -196,6 +196,9 @@ QString VideoParams::FormatPixelAspectRatioString(const QString &format, const r
 
 int VideoParams::GetScaledDimension(int dim, int divider)
 {
+  if (divider == 1) {
+    return dim;
+  }
   return qCeil(dim / divider * 0.5) * 2;
 }
 


### PR DESCRIPTION
Fixes #1284 

VideoParams was incorrectly rounding uneven image dimensions up to the
nearest even number causing a dimension mismatch between the image
texture size and the data loaded. This is fixed by forcing the
dimension to be returned unchanged if the divider input is 1.