### PR TITLE
OTIO Dialog

### DIFF
--- a/app/core.cpp
+++ b/app/core.cpp
@@ -1,4 +1,5 @@
 /***
+/***
 
   Olive - Non-Linear Video Editor
   Copyright (C) 2019 Olive Team
@@ -41,6 +42,7 @@
 #include "dialog/about/about.h"
 #include "dialog/export/export.h"
 #include "dialog/footagerelink/footagerelinkdialog.h"
+#include "dialog/otioproperties/otiopropertiesdialog.h"
 #include "dialog/sequence/sequence.h"
 #include "dialog/task/task.h"
 #include "dialog/preferences/preferences.h"
@@ -370,6 +372,13 @@ void Core::DialogExportShow()
     ExportDialog ed(sequence, main_window_);
     ed.exec();
   }
+}
+
+void Core::DialogImportOTIOShow(QList<SequencePtr> sequences)
+{
+  ProjectPtr active_project = GetActiveProject();
+  OTIOPropertiesDialog opd(sequences, active_project);
+  opd.exec();
 }
 
 void Core::CreateNewFolder()

--- a/app/core.h
+++ b/app/core.h
@@ -27,6 +27,7 @@
 
 #include "common/rational.h"
 #include "common/timecodefunctions.h"
+#include "opentimelineio/timeline.h"
 #include "project/item/footage/footage.h"
 #include "project/item/sequence/sequence.h"
 #include "project/project.h"
@@ -354,6 +355,11 @@ public slots:
    * @brief Show Export dialog
    */
   void DialogExportShow();
+
+  /**
+   * @brief Show OTIO import dialog
+   */
+  void DialogImportOTIOShow(QList<SequencePtr> sequences);
 
   /**
    * @brief Create a new folder in the currently active project

--- a/app/dialog/otioproperties/CMakeLists.txt
+++ b/app/dialog/otioproperties/CMakeLists.txt
@@ -14,26 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-add_subdirectory(about)
-add_subdirectory(actionsearch)
-add_subdirectory(color)
-add_subdirectory(diskcache)
-add_subdirectory(export)
-add_subdirectory(footageproperties)
-add_subdirectory(footagerelink)
-add_subdirectory(keyframeproperties)
-if(OpenTimelineIO_FOUND)
-  add_subdirectory(otioproperties)
-endif()
-add_subdirectory(preferences)
-add_subdirectory(progress)
-add_subdirectory(projectproperties)
-add_subdirectory(rendercancel)
-add_subdirectory(richtext)
-add_subdirectory(sequence)
-add_subdirectory(task)
-
 set(OLIVE_SOURCES
   ${OLIVE_SOURCES}
+  dialog/otioproperties/otiopropertiesdialog.h
+  dialog/otioproperties/otiopropertiesdialog.cpp
   PARENT_SCOPE
 )

--- a/app/dialog/otioproperties/otiopropertiesdialog.cpp
+++ b/app/dialog/otioproperties/otiopropertiesdialog.cpp
@@ -1,0 +1,80 @@
+/***
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2019  Olive Team
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include "otiopropertiesdialog.h"
+
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+#include "dialog/sequence/sequence.h"
+#include "core.h"
+
+OLIVE_NAMESPACE_ENTER
+
+OTIOPropertiesDialog::OTIOPropertiesDialog(QList<SequencePtr> sequences, ProjectPtr active_project, QWidget* parent)
+    :
+	QDialog(parent),
+    sequences_(sequences)
+{
+  QVBoxLayout* layout = new QVBoxLayout(this);
+
+  layout->addWidget(new QLabel("Change settings for each OTIO sequence to be loaded"));
+
+  table_ = new QTreeWidget();
+  table_->setColumnCount(2);
+  table_->setHeaderLabels({tr("Sequence"), tr("Actions")});
+  table_->setRootIsDecorated(false);
+
+  for (int i = 0; i < sequences.size(); i++) {
+    QTreeWidgetItem* item = new QTreeWidgetItem();
+    SequencePtr s = sequences.at(i);
+
+    QWidget* item_actions = new QWidget();
+    QHBoxLayout* item_actions_layout = new QHBoxLayout(item_actions);
+    QPushButton* item_settings_btn = new QPushButton(tr("Settings"));
+    item_settings_btn->setProperty("index", i);
+    connect(item_settings_btn, &QPushButton::clicked, this, &OTIOPropertiesDialog::SetupSequence);
+    item_actions_layout->addWidget(item_settings_btn);
+
+    item->setText(0, s->name());
+
+    table_->addTopLevelItem(item);
+
+    table_->setItemWidget(item, 1, item_actions);
+  }
+
+  layout->addWidget(table_);
+
+  QDialogButtonBox* buttons = new QDialogButtonBox(QDialogButtonBox::Ok);
+  connect(buttons, &QDialogButtonBox::accepted, this, &OTIOPropertiesDialog::accept);
+  layout->addWidget(buttons);
+
+  setWindowTitle(tr("Load OTIO File"));
+}
+
+void OTIOPropertiesDialog::SetupSequence()
+{
+  int index = sender()->property("index").toInt();
+  SequencePtr s = sequences_.at(index);
+  SequenceDialog sd(s.get(), SequenceDialog::kNew);
+  sd.SetUndoable(false);
+  sd.exec();
+}
+
+OLIVE_NAMESPACE_EXIT

--- a/app/dialog/otioproperties/otiopropertiesdialog.h
+++ b/app/dialog/otioproperties/otiopropertiesdialog.h
@@ -1,0 +1,60 @@
+/***
+
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2019  Olive Team
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+***/
+
+#ifndef OTIOPROPERTIESDIALOG_H
+#define OTIOPROPERTIESDIALOG_H
+
+#include <QDialog>
+#include <QTreeWidget>
+
+#include "common/define.h"
+#include "opentimelineio/timeline.h"
+#include "project/item/sequence/sequence.h"
+#include "project/project.h"
+
+OLIVE_NAMESPACE_ENTER
+
+/**
+ * @brief Dialog to load setting for OTIO sequences.
+ *
+ * Takes a list of Sequences and allows the setting of options for each.
+ */
+class OTIOPropertiesDialog : public QDialog 
+{
+  Q_OBJECT
+public:
+  OTIOPropertiesDialog(QList<SequencePtr> sequences, ProjectPtr active_project, QWidget* parent = nullptr);
+
+private:
+  QTreeWidget* table_;
+
+  QList<SequencePtr> sequences_;
+
+private slots:
+  /**
+   * @brief Brings up the Sequence settings dialog.
+   */
+  void SetupSequence();
+};
+
+
+OLIVE_NAMESPACE_EXIT
+
+#endif // OTIOPROPERTIESDIALOG_H


### PR DESCRIPTION
OTIO files don't carry a project settings (frame rate. resolution etc.) so this add a dialog that allows the user to select the sequence settings before loading the file. 

Also adds ability for the OTIO loader to load files that don't exist and need relinking.  For example if a user is given an OTIO file and a harddrive, the file paths wont necissarily be correct.