### PR TITLE
Docker: Add own ci-ocio image for OpenColorIO v2

### DIFF
--- a/docker/ci-ocio/Dockerfile
+++ b/docker/ci-ocio/Dockerfile
@@ -12,7 +12,6 @@ ARG VFXPLATFORM_VERSION=2021
 # Upstream only copies nuke-default, therefore we also use the older configs.
 ARG OCIO_CONFIGS_VERSION=1.0_r2
 
-#FROM ${ASWF_PKG_ORG}/ci-ocio:${VFXPLATFORM_VERSION} as ci-ocio
 FROM ${OLIVE_ORG}/ci-common:${CI_COMMON_VERSION} as ci-ocio
 
 ARG OLIVE_ORG
@@ -37,8 +36,6 @@ ENV OLIVE_ORG=${OLIVE_ORG} \
     OLIVE_INSTALL_PREFIX=/usr/local
 
 COPY scripts/build_ocio.sh \
-#    scripts/common/before_build.sh \
-#    scripts/common/copy_new_files.sh \
      /tmp/
 
 RUN /tmp/before_build.sh && \

--- a/docker/ci-ocio/Dockerfile
+++ b/docker/ci-ocio/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright (C) 2020 Olive Team
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Build image (default):
+#  docker build -t olivevideoeditor/ci-package-ocio:2021-2.0 -f ci-ocio/Dockerfile .
+
+ARG OLIVE_ORG=olivevideoeditor
+ARG ASWF_PKG_ORG=aswftesting
+ARG CI_COMMON_VERSION=2
+ARG VFXPLATFORM_VERSION=2021
+# Latest configs ~3 GB because of ACES 1.0.x.
+# Upstream only copies nuke-default, therefore we also use the older configs.
+ARG OCIO_CONFIGS_VERSION=1.0_r2
+
+#FROM ${ASWF_PKG_ORG}/ci-ocio:${VFXPLATFORM_VERSION} as ci-ocio
+FROM ${OLIVE_ORG}/ci-common:${CI_COMMON_VERSION} as ci-ocio
+
+ARG OLIVE_ORG
+ARG CI_COMMON_VERSION
+ARG VFXPLATFORM_VERSION
+ARG OCIO_CONFIGS_VERSION
+
+LABEL maintainer="olivevideoeditor@gmail.com"
+LABEL com.vfxplatform.version=$VFXPLATFORM_VERSION
+LABEL org.opencontainers.image.name="$OLIVE_ORG/ci-otio"
+LABEL org.opencontainers.image.description="CentOS OpenColorIO Build Image"
+LABEL org.opencontainers.image.url="http://olivevideoeditor.org"
+LABEL org.opencontainers.image.source="https://github.com/olive-editor/olive"
+LABEL org.opencontainers.image.vendor="Olive Team"
+LABEL org.opencontainers.image.version="1.0"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
+
+ENV OLIVE_ORG=${OLIVE_ORG} \
+    CI_COMMON_VERSION=${CI_COMMON_VERSION} \
+    VFXPLATFORM_VERSION=${VFXPLATFORM_VERSION} \
+    OCIO_CONFIGS_VERSION=${OCIO_CONFIGS_VERSION} \
+    OLIVE_INSTALL_PREFIX=/usr/local
+
+COPY scripts/build_ocio.sh \
+#    scripts/common/before_build.sh \
+#    scripts/common/copy_new_files.sh \
+     /tmp/
+
+RUN /tmp/before_build.sh && \
+    /tmp/build_ocio.sh && \
+    /tmp/copy_new_files.sh
+
+FROM scratch as ci-package-ocio
+
+COPY --from=ci-ocio /package/. /

--- a/docker/ci-olive/Dockerfile
+++ b/docker/ci-olive/Dockerfile
@@ -8,6 +8,7 @@ ARG OLIVE_ORG=olivevideoeditor
 ARG ASWF_PKG_ORG=aswftesting
 ARG CI_COMMON_VERSION=2
 ARG VFXPLATFORM_VERSION=2021
+ARG OCIO_VERSION=2.0
 ARG FFMPEG_VERSION=4.2.4
 
 FROM ${ASWF_PKG_ORG}/ci-package-qt:${VFXPLATFORM_VERSION} as ci-package-qt
@@ -15,7 +16,7 @@ FROM ${ASWF_PKG_ORG}/ci-package-python:${VFXPLATFORM_VERSION} as ci-package-pyth
 FROM ${ASWF_PKG_ORG}/ci-package-boost:${VFXPLATFORM_VERSION} as ci-package-boost
 FROM ${ASWF_PKG_ORG}/ci-package-openexr:${VFXPLATFORM_VERSION} as ci-package-openexr
 FROM ${ASWF_PKG_ORG}/ci-package-oiio:${VFXPLATFORM_VERSION} as ci-package-oiio
-FROM ${ASWF_PKG_ORG}/ci-package-ocio:${VFXPLATFORM_VERSION} as ci-package-ocio
+FROM ${OLIVE_ORG}/ci-package-ocio:${VFXPLATFORM_VERSION}-${OCIO_VERSION} as ci-package-ocio
 FROM ${OLIVE_ORG}/ci-package-ffmpeg:${FFMPEG_VERSION} as ci-package-ffmpeg
 FROM ${OLIVE_ORG}/ci-package-crashpad:latest as ci-package-crashpad
 FROM ${OLIVE_ORG}/ci-package-otio:latest as ci-package-otio

--- a/docker/scripts/build_ocio.sh
+++ b/docker/scripts/build_ocio.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright (C) 2020 Olive Team
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -ex
+
+mkdir ocio
+cd ocio
+
+git clone --depth 1 https://github.com/AcademySoftwareFoundation/OpenColorIO.git
+cd OpenColorIO
+
+mkdir build
+cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX="${OLIVE_INSTALL_PREFIX}" \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DOCIO_BUILD_APPS=OFF \
+    -DOCIO_BUILD_NUKE=OFF \
+    -DOCIO_BUILD_DOCS=OFF \
+    -DOCIO_BUILD_TESTS=OFF \
+    -DOCIO_BUILD_GPU_TESTS=OFF \
+    -DOCIO_USE_HEADLESS=OFF \
+    -DOCIO_BUILD_PYTHON=OFF \
+    -DOCIO_BUILD_JAVA=OFF \
+    -DOCIO_WARNING_AS_ERROR=OFF \
+    -DOCIO_INSTALL_EXT_PACKAGES=ALL \
+    ..
+make -j$(nproc)
+make install
+
+cd ../..
+
+curl --location "https://github.com/imageworks/OpenColorIO-Configs/archive/v${OCIO_CONFIGS_VERSION}.tar.gz" -o "ocio-configs.tar.gz"
+tar -zxf ocio-configs.tar.gz
+cd "OpenColorIO-Configs-${OCIO_CONFIGS_VERSION}"
+
+mkdir "${OLIVE_INSTALL_PREFIX}/openColorIO"
+cp nuke-default/config.ocio "${OLIVE_INSTALL_PREFIX}/openColorIO/"
+cp -r nuke-default/luts "${OLIVE_INSTALL_PREFIX}/openColorIO/"
+
+cd ../..
+rm -rf ocio


### PR DESCRIPTION
`aswf*/ci-package-ocio` for VFX reference platform 2021 is still at OCIO v1.1.1.

Our new Docker image https://hub.docker.com/r/olivevideoeditor/ci-package-ocio is built from OCIO master branch (currently at 46c07a5). Updated `olivevideoeditor/ci-olive:2021.2` accordingly.