### PR TITLE
ocioutils: Use OCIO_NAMESPACE for our namespace

### DIFF
--- a/app/common/ocioutils.h
+++ b/app/common/ocioutils.h
@@ -22,7 +22,7 @@
 #define OCIOUTILS_H
 
 #include <OpenColorIO/OpenColorIO.h>
-namespace OCIO = OpenColorIO_v2_0dev;
+namespace OCIO = OCIO_NAMESPACE;
 
 #include "render/videoparams.h"
 


### PR DESCRIPTION
Use `OCIO_NAMESPACE`, as defined by OCIO, to keep Olive's OCIO namepsace up to date with whatever version of OCIO Olive is compiled with