### PR TITLE
openglrenderer: fix destroying surface assert error

### DIFF
--- a/app/render/opengl/openglrenderer.cpp
+++ b/app/render/opengl/openglrenderer.cpp
@@ -145,7 +145,7 @@ void OpenGLRenderer::DestroyInternal()
 
     // Destroy surface if we created it
     if (surface_.isValid()) {
-      surface_.destroy();
+      QMetaObject::invokeMethod(surface_.thread(), "destroy", Qt::AutoConnection);
     }
   }
 }


### PR DESCRIPTION
DestroyInternal() was trying to destroy a surface that was in a
different thread leading to a sendEvent Assert error. This is fixed
by invoking the destroy() method in the correct thread.