### PR TITLE
Use appropriate labels for media nodes

### DIFF
--- a/app/core.cpp
+++ b/app/core.cpp
@@ -1081,7 +1081,7 @@ void Core::LabelNodes(const QVector<Node *> &nodes) const
 
   if (ok) {
     foreach (Node* n, nodes) {
-      n->SetLabel(s);
+      n->SetLabel(s, true);
     }
   }
 }

--- a/app/node/input/media/media.cpp
+++ b/app/node/input/media/media.cpp
@@ -23,6 +23,8 @@
 #include "common/timecodefunctions.h"
 #include "common/tohex.h"
 
+#include "project/item/footage/stream.h"
+
 namespace olive {
 
 MediaInput::MediaInput() :
@@ -77,7 +79,7 @@ NodeValueTable MediaInput::Value(NodeValueDatabase &value) const
 void MediaInput::FootageChanged()
 {
   StreamPtr new_footage = footage_input_->get_standard_value().value<StreamPtr>();
-
+  
   if (new_footage == connected_footage_) {
     return;
   }
@@ -90,6 +92,20 @@ void MediaInput::FootageChanged()
 
   if (connected_footage_) {
     connect(connected_footage_.get(), &Stream::ParametersChanged, this, &MediaInput::FootageParametersChanged);
+    
+    // If no user-defined label is set
+    if (!HasUserLabel()){
+      switch (connected_footage_->type()) {
+        case olive::Stream::Type::kVideo:
+          SetLabel(tr("Video Input"), false);
+          break;
+        case olive::Stream::Type::kAudio:
+          SetLabel(tr("Audio Input"), false);
+          break;
+        default:
+          break;
+      }
+    }
   }
 }
 

--- a/app/node/node.cpp
+++ b/app/node/node.cpp
@@ -115,7 +115,7 @@ void Node::Load(QXmlStreamReader *reader, XMLNodeData& xml_node_data, const QAto
 
       SetPosition(p);
     } else if (reader->name() == QStringLiteral("label")) {
-      SetLabel(reader->readElementText());
+      SetLabel(reader->readElementText(), !reader->readElementText().isEmpty());
     } else if (reader->name() == QStringLiteral("custom")) {
       LoadInternal(reader, xml_node_data);
     } else {
@@ -396,10 +396,17 @@ const QString &Node::GetLabel() const
   return label_;
 }
 
-void Node::SetLabel(const QString &s)
+bool Node::HasUserLabel() const
+{
+  return has_custom_label_;
+}
+
+void Node::SetLabel(const QString &s, const bool user_defined)
 {
   if (label_ != s) {
     label_ = s;
+
+    has_custom_label_ = user_defined && !s.isEmpty();
 
     emit LabelChanged(label_);
   }
@@ -495,7 +502,7 @@ void Node::CopyInputs(Node *source, Node *destination, bool include_connections)
   }
 
   destination->SetPosition(source->GetPosition());
-  destination->SetLabel(source->GetLabel());
+  destination->SetLabel(source->GetLabel(), false);
 }
 
 bool Node::CanBeDeleted() const

--- a/app/node/node.h
+++ b/app/node/node.h
@@ -427,7 +427,8 @@ public:
   virtual void GizmoRelease();
 
   const QString& GetLabel() const;
-  void SetLabel(const QString& s);
+  void SetLabel(const QString& s, const bool user_defined);
+  bool HasUserLabel() const;
 
   virtual void Hash(QCryptographicHash& hash, const rational &time) const;
 
@@ -541,6 +542,11 @@ private:
    * @brief Custom user label for node
    */
   QString label_;
+
+  /**
+    * @brief Whether or not the user has set a custom user label for the node
+    */
+  bool has_custom_label_;
 
 };
 

--- a/app/task/project/loadotio/loadotio.cpp
+++ b/app/task/project/loadotio/loadotio.cpp
@@ -143,7 +143,7 @@ bool LoadOTIOTask::Run()
 
         }
 
-        block->SetLabel(QString::fromStdString(otio_block->name()));
+        block->SetLabel(QString::fromStdString(otio_block->name()), false);
 
         rational start_time = rational::fromDouble(static_cast<OTIO::Item*>(otio_block)->source_range()->start_time().to_seconds());
         rational duration = rational::fromDouble(static_cast<OTIO::Item*>(otio_block)->source_range()->duration().to_seconds());

--- a/app/widget/timelinewidget/tool/add.cpp
+++ b/app/widget/timelinewidget/tool/add.cpp
@@ -97,7 +97,7 @@ void AddTool::MouseRelease(TimelineViewMouseEvent *event)
 
       ClipBlock* clip = new ClipBlock();
       clip->set_length_and_media_out(ghost_->GetAdjustedLength());
-      clip->SetLabel(olive::Tool::GetAddableObjectName(Core::instance()->GetSelectedAddableObject()));
+      clip->SetLabel(olive::Tool::GetAddableObjectName(Core::instance()->GetSelectedAddableObject()), false);
 
       NodeGraph* graph = static_cast<NodeGraph*>(parent()->GetConnectedNode()->parent());
 

--- a/app/widget/timelinewidget/tool/import.cpp
+++ b/app/widget/timelinewidget/tool/import.cpp
@@ -425,6 +425,7 @@ void ImportTool::DropGhosts(bool insert)
       {
         MediaInput* video_input = new MediaInput();
         video_input->SetStream(footage_stream);
+        video_input->SetLabel(QCoreApplication::translate("ImportTool", "Video Input"));
         new NodeAddCommand(dst_graph, video_input, command);
 
 
@@ -452,6 +453,7 @@ void ImportTool::DropGhosts(bool insert)
       {
         MediaInput* audio_input = new MediaInput();
         audio_input->SetStream(footage_stream);
+        audio_input->SetLabel(QCoreApplication::translate("ImportTool", "Audio Input"));
         new NodeAddCommand(dst_graph, audio_input, command);
 
         VolumeNode* volume_node = new VolumeNode();

--- a/app/widget/timelinewidget/tool/import.cpp
+++ b/app/widget/timelinewidget/tool/import.cpp
@@ -417,7 +417,7 @@ void ImportTool::DropGhosts(bool insert)
       ClipBlock* clip = new ClipBlock();
       clip->set_media_in(ghost->GetMediaIn());
       clip->set_length_and_media_out(ghost->GetLength());
-      clip->SetLabel(footage_stream->footage()->name());
+      clip->SetLabel(footage_stream->footage()->name(), false);
       new NodeAddCommand(dst_graph, clip, command);
 
       switch (footage_stream->type()) {
@@ -425,7 +425,6 @@ void ImportTool::DropGhosts(bool insert)
       {
         MediaInput* video_input = new MediaInput();
         video_input->SetStream(footage_stream);
-        video_input->SetLabel(QCoreApplication::translate("ImportTool", "Video Input"));
         new NodeAddCommand(dst_graph, video_input, command);
 
 
@@ -453,7 +452,6 @@ void ImportTool::DropGhosts(bool insert)
       {
         MediaInput* audio_input = new MediaInput();
         audio_input->SetStream(footage_stream);
-        audio_input->SetLabel(QCoreApplication::translate("ImportTool", "Audio Input"));
         new NodeAddCommand(dst_graph, audio_input, command);
 
         VolumeNode* volume_node = new VolumeNode();

--- a/app/widget/timelinewidget/trackview/trackviewitem.cpp
+++ b/app/widget/timelinewidget/trackview/trackviewitem.cpp
@@ -91,7 +91,7 @@ void TrackViewItem::LineEditConfirmed()
 {
   line_edit_->blockSignals(true);
 
-  track_->SetLabel(line_edit_->text());
+  track_->SetLabel(line_edit_->text(), false);
   UpdateLabel();
 
   stack_->setCurrentWidget(label_);


### PR DESCRIPTION
Set imported Media node label to "Video Input" for video footage, and "Audio Input" for audio footage

This was prompted by troubleshooting a friend's node setup, and having unlabelled Media nodes made things kind of confusing (e.g. they would accidentally link a Volume node to a Media node containing only video)