### PR TITLE
viewer: Safely delete full screen widget

### DIFF
--- a/app/widget/viewer/viewer.cpp
+++ b/app/widget/viewer/viewer.cpp
@@ -323,7 +323,6 @@ void ViewerWidget::SetFullScreen(QScreen *screen)
 
   if (windows_.contains(screen)) {
     ViewerWindow* vw = windows_.take(screen);
-    vw->hide();
     vw->deleteLater();
     return;
   }

--- a/app/widget/viewer/viewer.cpp
+++ b/app/widget/viewer/viewer.cpp
@@ -322,7 +322,9 @@ void ViewerWidget::SetFullScreen(QScreen *screen)
   }
 
   if (windows_.contains(screen)) {
-    delete windows_.take(screen);
+    ViewerWindow* vw = windows_.take(screen);
+    vw->hide();
+    vw->deleteLater();
     return;
   }
 


### PR DESCRIPTION
Hide the full screen widget and then use deleteLater() rather than
delete.

Fixes #1571