### PR TITLE
TimelineWidget: catch hand tool double click

### DIFF
--- a/app/widget/timelinewidget/timelinewidget.cpp
+++ b/app/widget/timelinewidget/timelinewidget.cpp
@@ -807,8 +807,10 @@ void TimelineWidget::ViewMouseReleased(TimelineViewMouseEvent *event)
 
 void TimelineWidget::ViewMouseDoubleClicked(TimelineViewMouseEvent *event)
 {
-  // kHand tool is handled differently to the other tools
-  if (Core::instance()->tool() == olive::Tool::kHand) {
+  // kHand tool will return nullptr
+  if (!GetActiveTool()) {
+    // Only kHand should return a nullptr
+    Q_ASSERT(Core::instance()->tool() == olive::Tool::kHand);
     return;
   }
   if (GetConnectedNode()) {

--- a/app/widget/timelinewidget/timelinewidget.cpp
+++ b/app/widget/timelinewidget/timelinewidget.cpp
@@ -807,6 +807,10 @@ void TimelineWidget::ViewMouseReleased(TimelineViewMouseEvent *event)
 
 void TimelineWidget::ViewMouseDoubleClicked(TimelineViewMouseEvent *event)
 {
+  // kHand tool is handled differently to the other tools
+  if (Core::instance()->tool() == olive::Tool::kHand) {
+    return;
+  }
   if (GetConnectedNode()) {
     GetActiveTool()->MouseDoubleClick(event);
     UpdateViewports();


### PR DESCRIPTION
The hand tool does not inherit from TimelineTool (it is a special program
wide tool) so tools_[olive::Tool::kHand] is a nullptr. Therefore when
ViewMouseDoubleClicked is called we check if the hand tool is
selected and simply return if it is.

Fixes #1577