### PR TITLE
Small audio caching optimisation

### DIFF
--- a/app/render/audioparams.cpp
+++ b/app/render/audioparams.cpp
@@ -141,7 +141,7 @@ rational AudioParams::bytes_to_time(const qint64 &bytes) const
 
 int AudioParams::channel_count() const
 {
-  return av_get_channel_layout_nb_channels(channel_layout());
+  return channel_count_;
 }
 
 int AudioParams::bytes_per_sample_per_channel() const

--- a/app/render/audioparams.h
+++ b/app/render/audioparams.h
@@ -66,6 +66,9 @@ public:
     format_(kFormatInvalid)
   {
     set_default_footage_parameters();
+
+    // Cache channel count
+    channel_count_ = av_get_channel_layout_nb_channels(channel_layout());
   }
 
   AudioParams(const int& sample_rate, const uint64_t& channel_layout, const Format& format) :
@@ -75,6 +78,9 @@ public:
   {
     set_default_footage_parameters();
     timebase_ = sample_rate_as_time_base();
+
+    // Cache channel count
+    channel_count_ = av_get_channel_layout_nb_channels(this->channel_layout());
   }
 
   int sample_rate() const
@@ -200,6 +206,8 @@ private:
   int sample_rate_;
 
   uint64_t channel_layout_;
+
+  int channel_count_;
 
   Format format_;
 

--- a/app/render/audioparams.h
+++ b/app/render/audioparams.h
@@ -68,7 +68,7 @@ public:
     set_default_footage_parameters();
 
     // Cache channel count
-    channel_count_ = av_get_channel_layout_nb_channels(channel_layout());
+    calculate_channel_count();
   }
 
   AudioParams(const int& sample_rate, const uint64_t& channel_layout, const Format& format) :
@@ -80,7 +80,7 @@ public:
     timebase_ = sample_rate_as_time_base();
 
     // Cache channel count
-    channel_count_ = av_get_channel_layout_nb_channels(this->channel_layout());
+    calculate_channel_count();
   }
 
   int sample_rate() const
@@ -101,6 +101,7 @@ public:
   void set_channel_layout(uint64_t channel_layout)
   {
     channel_layout_ = channel_layout;
+    calculate_channel_count();
   }
 
   rational time_base() const
@@ -201,6 +202,11 @@ private:
     enabled_ = true;
     stream_index_ = 0;
     duration_ = 0;
+  }
+
+  void calculate_channel_count()
+  {
+    channel_count_ = av_get_channel_layout_nb_channels(channel_layout());
   }
 
   int sample_rate_;

--- a/app/render/audioplaybackcache.cpp
+++ b/app/render/audioplaybackcache.cpp
@@ -64,14 +64,10 @@ void AudioPlaybackCache::WritePCM(const TimeRange &range, SampleBufferPtr sample
 
   // Ensure if we have enough segments to write this data, creating more if not
   qint64 length_diff = params_.time_to_bytes(range.out()) - playlist_.GetLength();
-  qint64 whole_segments = length_diff / kDefaultSegmentSize;
-  qint64 remainder = length_diff % kDefaultSegmentSize;
-
-  for (int i = 0; i < whole_segments; i++) {
-    playlist_.push_back(CreateSegment(kDefaultSegmentSize, playlist_.GetLength()));
-  }
-  if (remainder > 0) {
-    playlist_.push_back(CreateSegment(remainder, playlist_.GetLength()));
+  while (length_diff > 0) {
+    qint64 seg_sz = qMin(kDefaultSegmentSize, length_diff);
+    playlist_.push_back(CreateSegment(seg_sz, playlist_.GetLength()));
+    length_diff -= seg_sz;
   }
 
   // Convert to packed data, which is what we store on disk so it can be played back easily

--- a/app/render/audioplaybackcache.cpp
+++ b/app/render/audioplaybackcache.cpp
@@ -64,10 +64,14 @@ void AudioPlaybackCache::WritePCM(const TimeRange &range, SampleBufferPtr sample
 
   // Ensure if we have enough segments to write this data, creating more if not
   qint64 length_diff = params_.time_to_bytes(range.out()) - playlist_.GetLength();
-  while (length_diff > 0) {
-    qint64 seg_sz = qMin(kDefaultSegmentSize, length_diff);
-    playlist_.push_back(CreateSegment(seg_sz, playlist_.GetLength()));
-    length_diff -= seg_sz;
+  qint64 whole_segments = length_diff / kDefaultSegmentSize;
+  qint64 remainder = length_diff % kDefaultSegmentSize;
+
+  for (int i = 0; i < whole_segments; i++) {
+    playlist_.push_back(CreateSegment(kDefaultSegmentSize, playlist_.GetLength()));
+  }
+  if (remainder > 0) {
+    playlist_.push_back(CreateSegment(remainder, playlist_.GetLength()));
   }
 
   // Convert to packed data, which is what we store on disk so it can be played back easily


### PR DESCRIPTION
A couple of changes based of profiling while caching. An example of the improvement form the first commit:
![image](https://user-images.githubusercontent.com/7781683/115972890-13e67c80-a549-11eb-9589-ee22f7974479.png)

The second commit gave a similar improvement.
