### PR TITLE
Update standard test name to improve usability in Visual Studio.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ function(olive_add_test GROUP NAME SOURCE)
     PRIVATE
     ${OLIVE_COMPILE_OPTIONS}
   )
-  add_test(${NAME} ${NAME})
+  add_test("OliveLib.Tests.${NAME}" ${NAME})
 endfunction()
 
 add_subdirectory(compositing)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,11 @@ function(olive_add_test GROUP NAME SOURCE)
     PRIVATE
     ${OLIVE_COMPILE_OPTIONS}
   )
-  add_test("OliveLib.Tests.${NAME}" ${NAME})
+  if (MSVC)
+    add_test("Olive.${GROUP}.${NAME}" ${NAME})
+  else()
+    add_test(${NAME} ${NAME})
+endif()
 endfunction()
 
 add_subdirectory(compositing)


### PR DESCRIPTION
This change just improves the GUI experience of running CTests in Visual Studio. I think it interprets the name as `[namespace].[class].[name]`. There's a known bug in VS (https://developercommunity.visualstudio.com/t/cmake-weird-test-name-prefix/793209) where it appends a random generated string to the start of all tests which makes searching through them a pain and this should make it easier to filter tests. It's not a big issue with the current three tests but could be going forwards.