### PR TITLE
Fix reversing

### DIFF
--- a/app/node/block/block.cpp
+++ b/app/node/block/block.cpp
@@ -153,11 +153,11 @@ rational Block::SequenceToMediaTime(const rational &sequence_time, bool ignore_r
     local_time = rational::fromDouble(local_time.toDouble() * speed_value);
   }
 
-  rational media_time = local_time + media_in();
-
   if (reverse() && !ignore_reverse) {
-    media_time = length() - media_time;
+    local_time = length() - local_time;
   }
+
+  rational media_time = local_time + media_in();
 
   return media_time;
 }


### PR DESCRIPTION
Hi, using hash 48828d6632a126c0967368eefd7114b9acebb076, I noticed that reversing was broken (no video or audio output), so I made this change that fixes it. Tested to be working with playback and export.

Thank you for your work and I hope this PR is of any use.