### PR TITLE
Add .clang-tidy for better style and best practices linting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,12 @@
+---
+# Use all checks except for conflicts with project style.
+Checks: "*,\
+-darwin-*,\
+-fuchsia-*,\
+-llvmlibc-*,\
+-modernize-use-trailing-return-type,\
+fuchsia-trailing-return,\
+-llvm-qualified-auto,\
+-readability-qualified-auto,\
+-readability-implicit-bool-conversion"
+...


### PR DESCRIPTION
> **clang-tidy** is a clang-based C++ “linter” tool. Its purpose is to provide an extensible framework for diagnosing and fixing typical programming errors, like style violations, interface misuse, or bugs that can be deduced via static analysis. **clang-tidy** is modular and provides a convenient interface for writing new checks.

With a `.clang-tidy`, text editors and IDE's that have integration with clang-tidy (or clangd) will be able to complain about anti-patterns, and it can also help with enforcing code style in ways that clang-format can't.  clang-tidy is basically a better clang-check.

The file currently has what I think is probably a good starting point, which is turning all checks on and then turning off some of the checks that conflict with what has been done.  The choice of checks to use is pretty subjective, so project leads may want to refer to https://clang.llvm.org/extra/clang-tidy/checks/list.html and choose which ones they will want to disable/enable.