### PR TITLE
Fix #1708 Node edge arrow in wrong place

### DIFF
--- a/app/widget/nodeview/nodeview.cpp
+++ b/app/widget/nodeview/nodeview.cpp
@@ -563,6 +563,7 @@ void NodeView::mouseMoveEvent(QMouseEvent *event)
       create_edge_->SetPoints(create_edge_src_->GetOutputPoint(Node::kDefaultOutput),
                               scene_pt,
                               false);
+      create_edge_->SetDrawArrow(true);
     }
 
     // Set connected to whether we have a valid input destination

--- a/app/widget/nodeview/nodeviewedge.cpp
+++ b/app/widget/nodeview/nodeviewedge.cpp
@@ -42,7 +42,8 @@ NodeViewEdge::NodeViewEdge(const NodeOutput &output, const NodeInput &input,
   output_(output),
   input_(input),
   from_item_(from_item),
-  to_item_(to_item)
+  to_item_(to_item),
+  draw_arrow_(true)
 {
   Init();
   SetConnected(true);
@@ -51,7 +52,8 @@ NodeViewEdge::NodeViewEdge(const NodeOutput &output, const NodeInput &input,
 NodeViewEdge::NodeViewEdge(QGraphicsItem *parent) :
   QGraphicsPathItem(parent),
   from_item_(nullptr),
-  to_item_(nullptr)
+  to_item_(nullptr),
+  draw_arrow_(false)
 {
   Init();
 }
@@ -128,9 +130,11 @@ void NodeViewEdge::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
   painter->drawPath(path());
 
   // Draw arrow
-  painter->setPen(Qt::NoPen);
-  painter->setBrush(edge_color);
-  painter->drawPolygon(arrow_);
+  if (DrawArrow()) {
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(edge_color);
+    painter->drawPolygon(arrow_);
+  }
 }
 
 void NodeViewEdge::Init()

--- a/app/widget/nodeview/nodeviewedge.h
+++ b/app/widget/nodeview/nodeviewedge.h
@@ -75,6 +75,17 @@ public:
     return arrow_bounding_rect_;
   }
 
+  /**
+   * @brief Set whether or not to draw the arrow at the endof the curve
+   */
+  void SetDrawArrow(bool draw_arrow) {
+      draw_arrow_ = draw_arrow;
+  }
+
+  bool DrawArrow() {
+      return draw_arrow_;
+  }
+
   void Adjust();
 
   /**
@@ -153,6 +164,8 @@ private:
   QPointF cached_start_;
   QPointF cached_end_;
   bool cached_input_is_expanded_;
+
+  bool draw_arrow_;
 
 };
 


### PR DESCRIPTION
Fixes #1708 

When a node edge is first created its from_item and to_item are not
initilised. This was leading to the arrow at the end of the edge being
drawn in a random place. The work around here is to explicitly set the
arrow to be drawn only when the mouse has started moving and we know
where to draw it.