### PR TITLE
Revert Olive to a console application and hide console

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -101,9 +101,6 @@ if (WIN32)
   # Set Windows application icon
   target_sources(olive-editor PRIVATE packaging/windows/resources.rc)
 
-  set_target_properties(olive-editor PROPERTIES
-    WIN32_EXECUTABLE TRUE
-  )
 elseif(APPLE)
   # Set Mac application icon
   set(OLIVE_ICON packaging/macos/olive.icns)

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -52,31 +52,6 @@ extern "C" {
 
 int main(int argc, char *argv[])
 {
-  
-#ifdef _WIN32
-  bool console = false;
-  FILE *stream_stdout;
-  FILE *stream_stderr;
-
-  AttachConsole(ATTACH_PARENT_PROCESS);
-  DWORD procIDs[2];
-  DWORD maxIds = 2;
-  DWORD count = GetConsoleProcessList((LPDWORD)procIDs, maxIds);
-
-  if (count == 2) {
-    /* this is a terminal */
-    FreeConsole();
-
-    // Create own console
-    if (AllocConsole()) {
-      freopen_s(&stream_stdout, "CONOUT$", "w", stdout);
-      freopen_s(&stream_stderr, "CONOUT$", "w", stderr);
-      console = true;
-    }
-    
-  }
-#endif
-
   // Set up debug handler
   qInstallMessageHandler(olive::DebugHandler);
 
@@ -129,9 +104,14 @@ int main(int argc, char *argv[])
                        true,
                        QCoreApplication::translate("main", "qm-file"));
 
+  auto console_option =
+      parser.AddOption({QStringLiteral("c"), QStringLiteral("-console")},
+                       QCoreApplication::translate("main", "Launch console (Windows only)"));
+
   auto project_argument =
       parser.AddPositionalArgument(QStringLiteral("project"),
                                    QCoreApplication::translate("main", "Project to open on startup"));
+
 
   // Qt options re-implemented (add to this as necessary)
   //
@@ -152,6 +132,12 @@ int main(int argc, char *argv[])
   parser.AddOption({QStringLiteral("widgetcount")}, QString(), false, QString(), true);
 
   parser.Process(argc, argv);
+
+  if (!console_option->IsSet()) {
+#ifdef _WIN32
+    FreeConsole();
+#endif  // _WIN32
+  }
 
   if (help_option->IsSet()) {
     // Show help
@@ -236,12 +222,6 @@ int main(int argc, char *argv[])
 
   // Clear core memory
   c.Stop();
-
-  #ifdef _WIN32
-  if (console) {
-    system("pause");
-  }
-  #endif
 
   return ret;
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -104,9 +104,11 @@ int main(int argc, char *argv[])
                        true,
                        QCoreApplication::translate("main", "qm-file"));
 
+#ifdef _WIN32
   auto console_option =
       parser.AddOption({QStringLiteral("c"), QStringLiteral("-console")},
-                       QCoreApplication::translate("main", "Launch console (Windows only)"));
+                       QCoreApplication::translate("main", "Launch with debug console"));
+#endif // _WIN32
 
   auto project_argument =
       parser.AddPositionalArgument(QStringLiteral("project"),
@@ -132,12 +134,6 @@ int main(int argc, char *argv[])
   parser.AddOption({QStringLiteral("widgetcount")}, QString(), false, QString(), true);
 
   parser.Process(argc, argv);
-
-  if (!console_option->IsSet()) {
-#ifdef _WIN32
-    FreeConsole();
-#endif  // _WIN32
-  }
 
   if (help_option->IsSet()) {
     // Show help
@@ -193,6 +189,14 @@ int main(int argc, char *argv[])
   std::unique_ptr<QCoreApplication> a;
 
   if (startup_params.run_mode() == olive::Core::CoreParams::kRunNormal) {
+#ifdef _WIN32
+    // Since Olive is linked with the console subsystem (for better POSIX compatibility), a console
+    // is created by default. If the user didn't request one, we free it here.
+    if (!console_option->IsSet()) {
+      FreeConsole();
+    }
+#endif // _WIN32
+
     a.reset(new QApplication(argc, argv));
   } else {
     a.reset(new QCoreApplication(argc, argv));


### PR DESCRIPTION
Now that Olive is a GUI application on WIndows there is no console output. Whilst this is probably fine for most users it's not ideal for dev work as the output can be very useful. This PR adds a console window if the user starts olive from the terminal but not if they run it from the GUI.