### PR TITLE
use base filename in File menu

### DIFF
--- a/app/window/mainwindow/mainmenu.cpp
+++ b/app/window/mainwindow/mainmenu.cpp
@@ -319,10 +319,10 @@ void MainMenu::FileMenuAboutToShow()
   file_close_all_except_item_->setEnabled(active_project);
 
   if (active_project) {
-    file_save_item_->setText(tr("&Save '%1'").arg(active_project->pretty_filename()));
-    file_save_as_item_->setText(tr("Save '%1' &As").arg(active_project->pretty_filename()));
-    file_close_project_item_->setText(tr("Close '%1'").arg(active_project->pretty_filename()));
-    file_close_all_except_item_->setText(tr("Close All Except '%1'").arg(active_project->pretty_filename()));
+    file_save_item_->setText(tr("&Save '%1'").arg(active_project->name()));
+    file_save_as_item_->setText(tr("Save '%1' &As").arg(active_project->name()));
+    file_close_project_item_->setText(tr("Close '%1'").arg(active_project->name()));
+    file_close_all_except_item_->setText(tr("Close All Except '%1'").arg(active_project->name()));
   } else {
     file_save_item_->setText(tr("&Save Project"));
     file_save_as_item_->setText(tr("Save Project &As"));


### PR DESCRIPTION
The file menu get very wide when showing the full project file path in the meny

So i changed it to show only the  basename of the project in the menu, make it look much better.

Before
![Screenshot from 2021-10-09 08-13-39](https://user-images.githubusercontent.com/283985/136656476-85e79a78-dd63-428e-b84d-6aed35bd661e.png)
:
After
![Screenshot from 2021-10-09 13-36-34](https://user-images.githubusercontent.com/283985/136656488-30f5a705-8f1a-4dd7-9bd0-7bc81c574f9a.png)
:
