### PR TITLE
Refactor tasks to work on multiple data [DRAFT]

### DIFF
--- a/app/render/framehashcache.h
+++ b/app/render/framehashcache.h
@@ -57,10 +57,10 @@ public:
   static QString CachePathName(const QString& cache_path, const QByteArray &hash);
 
   static bool SaveCacheFrame(const QString& filename, char *data, const VideoParams &vparam, int linesize_bytes);
-  bool SaveCacheFrame(const QByteArray& hash, char *data, const VideoParams &vparam, int linesize_bytes) const;
-  bool SaveCacheFrame(const QByteArray& hash, FramePtr frame) const;
+  bool SaveCacheFrame(const QByteArray &hash, char *data, const VideoParams &vparam, int linesize_bytes) const;
+  bool SaveCacheFrames(QVector<QByteArray> hashes, QVector<FramePtr> frames) const;
   static bool SaveCacheFrame(const QString& cache_path, const QByteArray& hash, char *data, const VideoParams &vparam, int linesize_bytes);
-  static bool SaveCacheFrame(const QString& cache_path, const QByteArray& hash, FramePtr frame);
+  static bool SaveCacheFrames(const QString& cache_path, QVector<QByteArray> hashes, QVector<FramePtr> frames);
   static FramePtr LoadCacheFrame(const QString& cache_path, const QByteArray& hash);
   FramePtr LoadCacheFrame(const QByteArray& hash) const;
   static FramePtr LoadCacheFrame(const QString& fn);

--- a/app/render/previewautocacher.h
+++ b/app/render/previewautocacher.h
@@ -109,7 +109,7 @@ signals:
 private:
   void TryRender();
 
-  RenderTicketWatcher *RenderFrame(const QByteArray& hash, const rational &time, bool prioritize, bool texture_only);
+  RenderTicketWatcher *RenderFrames(const QByteArray& hash, TimeRange timerange, bool prioritize, bool texture_only);
   RenderTicketPtr RenderAudio(const TimeRange &range, bool generate_waveforms, bool prioritize);
 
   /**

--- a/app/render/previewautocacher.h
+++ b/app/render/previewautocacher.h
@@ -109,7 +109,7 @@ signals:
 private:
   void TryRender();
 
-  RenderTicketWatcher *RenderFrames(const QByteArray& hash, TimeRange timerange, bool prioritize, bool texture_only);
+  RenderTicketWatcher *RenderFrames(QVector<QByteArray> hashes, QVector<rational> timestamps, bool prioritize, bool texture_only);
   RenderTicketPtr RenderAudio(const TimeRange &range, bool generate_waveforms, bool prioritize);
 
   /**
@@ -190,8 +190,8 @@ private:
 
   QList<QFutureWatcher< QVector<HashData> >*> hash_tasks_;
   QMap<RenderTicketWatcher*, TimeRange> audio_tasks_;
-  QMap<RenderTicketWatcher*, QByteArray> video_tasks_;
-  QMap<RenderTicketWatcher*, QByteArray> video_download_tasks_;
+  QMap<RenderTicketWatcher*, QVector<QByteArray>> video_tasks_;
+  QMap<RenderTicketWatcher*, QVector<QByteArray>> video_download_tasks_;
   QMap<RenderTicketWatcher*, QVector<RenderTicketPtr> > video_immediate_passthroughs_;
 
   JobTime graph_changed_time_;

--- a/app/render/rendermanager.cpp
+++ b/app/render/rendermanager.cpp
@@ -114,12 +114,12 @@ QByteArray RenderManager::Hash(const Node *n, const Node::ValueHint &output, con
 }
 
 RenderTicketPtr RenderManager::RenderFrames(ViewerOutput *viewer, ColorManager* color_manager,
-                                           TimeRange timerange, RenderMode::Mode mode,
+                                           QVector<rational> timestamps, RenderMode::Mode mode,
                                            FrameHashCache* cache, bool prioritize, bool texture_only)
 {
   return RenderFrames(viewer,
                      color_manager,
-                     timerange,
+                     timestamps,
                      mode,
                      viewer->GetVideoParams(),
                      viewer->GetAudioParams(),
@@ -133,7 +133,7 @@ RenderTicketPtr RenderManager::RenderFrames(ViewerOutput *viewer, ColorManager* 
 }
 
 RenderTicketPtr RenderManager::RenderFrames(ViewerOutput *viewer, ColorManager* color_manager,
-                                           TimeRange timerange, RenderMode::Mode mode,
+                                           QVector<rational> timestamps, RenderMode::Mode mode,
                                            const VideoParams &video_params, const AudioParams &audio_params,
                                            const QSize& force_size,
                                            const QMatrix4x4& force_matrix, VideoParams::Format force_format,
@@ -144,7 +144,7 @@ RenderTicketPtr RenderManager::RenderFrames(ViewerOutput *viewer, ColorManager* 
   RenderTicketPtr ticket = std::make_shared<RenderTicket>();
 
   ticket->setProperty("viewer", Node::PtrToValue(viewer));
-  ticket->setProperty("timerange", QVariant::fromValue(timerange));
+  ticket->setProperty("timestamps", QVariant::fromValue(timestamps));
   ticket->setProperty("size", force_size);
   ticket->setProperty("matrix", force_matrix);
   ticket->setProperty("format", force_format);
@@ -201,14 +201,14 @@ RenderTicketPtr RenderManager::RenderAudio(ViewerOutput* viewer, const TimeRange
   return ticket;
 }
 
-RenderTicketPtr RenderManager::SaveFrameToCache(FrameHashCache *cache, FramePtr frame, const QByteArray &hash, bool prioritize)
+RenderTicketPtr RenderManager::SaveFramesToCache(FrameHashCache *cache, QVector<FramePtr> frames, QVector<QByteArray> hashes, bool prioritize)
 {
   // Create ticket
   RenderTicketPtr ticket = std::make_shared<RenderTicket>();
 
   ticket->setProperty("cache", cache->GetCacheDirectory());
-  ticket->setProperty("frame", QVariant::fromValue(frame));
-  ticket->setProperty("hash", hash);
+  ticket->setProperty("frames", QVariant::fromValue(frames));
+  ticket->setProperty("hashes", QVariant::fromValue(hashes));
   ticket->setProperty("type", kTypeVideoDownload);
 
   if (ticket->thread() != this->thread()) {

--- a/app/render/rendermanager.cpp
+++ b/app/render/rendermanager.cpp
@@ -113,13 +113,13 @@ QByteArray RenderManager::Hash(const Node *n, const Node::ValueHint &output, con
   }
 }
 
-RenderTicketPtr RenderManager::RenderFrame(ViewerOutput *viewer, ColorManager* color_manager,
-                                           const rational& time, RenderMode::Mode mode,
+RenderTicketPtr RenderManager::RenderFrames(ViewerOutput *viewer, ColorManager* color_manager,
+                                           TimeRange timerange, RenderMode::Mode mode,
                                            FrameHashCache* cache, bool prioritize, bool texture_only)
 {
-  return RenderFrame(viewer,
+  return RenderFrames(viewer,
                      color_manager,
-                     time,
+                     timerange,
                      mode,
                      viewer->GetVideoParams(),
                      viewer->GetAudioParams(),
@@ -132,8 +132,8 @@ RenderTicketPtr RenderManager::RenderFrame(ViewerOutput *viewer, ColorManager* c
                      texture_only);
 }
 
-RenderTicketPtr RenderManager::RenderFrame(ViewerOutput *viewer, ColorManager* color_manager,
-                                           const rational& time, RenderMode::Mode mode,
+RenderTicketPtr RenderManager::RenderFrames(ViewerOutput *viewer, ColorManager* color_manager,
+                                           TimeRange timerange, RenderMode::Mode mode,
                                            const VideoParams &video_params, const AudioParams &audio_params,
                                            const QSize& force_size,
                                            const QMatrix4x4& force_matrix, VideoParams::Format force_format,
@@ -144,7 +144,7 @@ RenderTicketPtr RenderManager::RenderFrame(ViewerOutput *viewer, ColorManager* c
   RenderTicketPtr ticket = std::make_shared<RenderTicket>();
 
   ticket->setProperty("viewer", Node::PtrToValue(viewer));
-  ticket->setProperty("time", QVariant::fromValue(time));
+  ticket->setProperty("timerange", QVariant::fromValue(timerange));
   ticket->setProperty("size", force_size);
   ticket->setProperty("matrix", force_matrix);
   ticket->setProperty("format", force_format);

--- a/app/render/rendermanager.h
+++ b/app/render/rendermanager.h
@@ -32,7 +32,6 @@
 #include "render/renderer.h"
 #include "rendercache.h"
 #include "threading/threadpool.h"
-#include "common/timerange.h"
 
 namespace olive {
 
@@ -70,7 +69,7 @@ public:
   static QByteArray Hash(const Node *n, const Node::ValueHint &output, const VideoParams &params, const rational &time);
 
   /**
-   * @brief Asynchronously generate frames at a given timerange
+   * @brief Asynchronously generate frames at a given vector of timestamps
    *
    * The ticket from this function will return a FramePtr array - the rendered frames in reference color
    * space.
@@ -81,10 +80,10 @@ public:
    * This function is thread-safe.
    */
   RenderTicketPtr RenderFrames(ViewerOutput *viewer, ColorManager* color_manager,
-                              TimeRange timerange, RenderMode::Mode mode,
+                              QVector<rational> timestamps, RenderMode::Mode mode,
                               FrameHashCache* cache = nullptr, bool prioritize = false, bool texture_only = false);
   RenderTicketPtr RenderFrames(ViewerOutput* viewer, ColorManager* color_manager,
-                              TimeRange timerange, RenderMode::Mode mode,
+                              QVector<rational> timestamps, RenderMode::Mode mode,
                               const VideoParams& video_params, const AudioParams& audio_params,
                               const QSize& force_size,
                               const QMatrix4x4& force_matrix, VideoParams::Format force_format,
@@ -104,7 +103,7 @@ public:
   RenderTicketPtr RenderAudio(ViewerOutput* viewer, const TimeRange& r, const AudioParams& params, RenderMode::Mode mode, bool generate_waveforms, bool prioritize = false);
   RenderTicketPtr RenderAudio(ViewerOutput *viewer, const TimeRange& r, RenderMode::Mode mode, bool generate_waveforms, bool prioritize = false);
 
-  RenderTicketPtr SaveFrameToCache(FrameHashCache* cache, FramePtr frame, const QByteArray& hash, bool prioritize = false);
+  RenderTicketPtr SaveFramesToCache(FrameHashCache* cache, QVector<FramePtr> frames, QVector<QByteArray> hashes, bool prioritize = false);
 
   virtual void RunTicket(RenderTicketPtr ticket) const override;
 

--- a/app/render/rendermanager.h
+++ b/app/render/rendermanager.h
@@ -32,6 +32,7 @@
 #include "render/renderer.h"
 #include "rendercache.h"
 #include "threading/threadpool.h"
+#include "common/timerange.h"
 
 namespace olive {
 
@@ -69,9 +70,9 @@ public:
   static QByteArray Hash(const Node *n, const Node::ValueHint &output, const VideoParams &params, const rational &time);
 
   /**
-   * @brief Asynchronously generate a frame at a given time
+   * @brief Asynchronously generate frames at a given timerange
    *
-   * The ticket from this function will return a FramePtr - the rendered frame in reference color
+   * The ticket from this function will return a FramePtr array - the rendered frames in reference color
    * space.
    *
    * Setting `prioritize` to TRUE puts this ticket at the top of the queue. Leaving it as FALSE
@@ -79,11 +80,11 @@ public:
    *
    * This function is thread-safe.
    */
-  RenderTicketPtr RenderFrame(ViewerOutput *viewer, ColorManager* color_manager,
-                              const rational& time, RenderMode::Mode mode,
+  RenderTicketPtr RenderFrames(ViewerOutput *viewer, ColorManager* color_manager,
+                              TimeRange timerange, RenderMode::Mode mode,
                               FrameHashCache* cache = nullptr, bool prioritize = false, bool texture_only = false);
-  RenderTicketPtr RenderFrame(ViewerOutput* viewer, ColorManager* color_manager,
-                              const rational& time, RenderMode::Mode mode,
+  RenderTicketPtr RenderFrames(ViewerOutput* viewer, ColorManager* color_manager,
+                              TimeRange timerange, RenderMode::Mode mode,
                               const VideoParams& video_params, const AudioParams& audio_params,
                               const QSize& force_size,
                               const QMatrix4x4& force_matrix, VideoParams::Format force_format,

--- a/app/task/render/render.h
+++ b/app/task/render/render.h
@@ -29,6 +29,7 @@
 #include "task/task.h"
 #include "threading/threadticket.h"
 #include "threading/threadticketwatcher.h"
+#include "common/timerange.h"
 
 namespace olive {
 
@@ -125,7 +126,7 @@ private:
 
   void IncrementRunningTickets();
 
-  void StartTicket(const QByteArray &hash, QThread *watcher_thread, ColorManager *manager, const rational &time, RenderMode::Mode mode, FrameHashCache *cache, const QSize &force_size, const QMatrix4x4 &force_matrix, VideoParams::Format force_format, ColorProcessorPtr force_color_output);
+  void StartTicket(const QByteArray &hash, QThread *watcher_thread, ColorManager *manager, TimeRange timerange, RenderMode::Mode mode, FrameHashCache *cache, const QSize &force_size, const QMatrix4x4 &force_matrix, VideoParams::Format force_format, ColorProcessorPtr force_color_output);
 
   ViewerOutput* viewer_;
 

--- a/app/task/render/render.h
+++ b/app/task/render/render.h
@@ -50,7 +50,7 @@ protected:
               VideoParams::Format force_format = VideoParams::kFormatInvalid,
               ColorProcessorPtr force_color_output = nullptr);
 
-  virtual void DownloadFrame(QThread* thread, FramePtr frame, const QByteArray &hash);
+  virtual void DownloadFrames(QThread* thread, QVector<FramePtr> frames, QVector<QByteArray> hashes);
 
   virtual void FrameDownloaded(FramePtr frame, const QByteArray& hash, const QVector<rational>& times) = 0;
 
@@ -126,7 +126,7 @@ private:
 
   void IncrementRunningTickets();
 
-  void StartTicket(const QByteArray &hash, QThread *watcher_thread, ColorManager *manager, TimeRange timerange, RenderMode::Mode mode, FrameHashCache *cache, const QSize &force_size, const QMatrix4x4 &force_matrix, VideoParams::Format force_format, ColorProcessorPtr force_color_output);
+  void StartTicket(QVector<QByteArray> hashes, QThread *watcher_thread, ColorManager *manager, QVector<rational> timestamps, RenderMode::Mode mode, FrameHashCache *cache, const QSize &force_size, const QMatrix4x4 &force_matrix, VideoParams::Format force_format, ColorProcessorPtr force_color_output);
 
   ViewerOutput* viewer_;
 

--- a/app/widget/viewer/viewer.cpp
+++ b/app/widget/viewer/viewer.cpp
@@ -835,7 +835,8 @@ RenderTicketPtr ViewerWidget::GetFrame(const rational &t, bool prioritize)
   } else {
     // Frame has been cached, grab the frame
     RenderTicketPtr ticket = std::make_shared<RenderTicket>();
-    ticket->setProperty("time", QVariant::fromValue(t));
+    QVector<rational> timestamps = {t};
+    ticket->setProperty("timestamps", QVariant::fromValue(timestamps));
     QtConcurrent::run(ViewerWidget::DecodeCachedImage, ticket, GetConnectedNode()->video_frame_cache()->GetCacheDirectory(), cached_hash, t);
     return ticket;
   }


### PR DESCRIPTION
Currently, Olive creates a ticket (which runs on a thread) for each frame to be processed,
returning the processed frame upon ticket completion. 

This is problematic from a performance standpoint as it generates much overhead 
and does not allow memory access patterns that take advantage of cache.

The ultimate goal of this PR is to enable Olive to work on multiple data (e.g: render multiple frames) 
on a single ticket, allowing for SIMD type parallelism and coalesced memory access. 