### PR TITLE
traverser: catch color only jobs

### DIFF
--- a/app/node/traverser.cpp
+++ b/app/node/traverser.cpp
@@ -157,6 +157,9 @@ int NodeTraverser::GetChannelCountFromJob(const GenerateJob &job)
       }
     }
   }
+  if (max_channel_count == 0) {
+    max_channel_count = VideoParams::kRGBChannelCount;
+  }
 
   switch (job.GetAlphaChannelRequired()) {
   case GenerateJob::kAlphaForceOn:


### PR DESCRIPTION
If a job has a color but no texture (e.g. a Solid), force the channel count to at least `VideoParams::kRGBChannelCount`.


After recent changes to `NodeTraverser::GetChannelCountFromJob()` Solid nodes caused a crash as their channel count was set to 0, causing a divide by 0 error in `Frame::set_video_params()`