### PR TITLE
Set $APPDIR

### DIFF
--- a/app/packaging/linux/AppRun
+++ b/app/packaging/linux/AppRun
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+APPDIR=$(readlink -f $(dirname "$0"))
 
 # Custom AppRun that ensures the AppImage doesn't dismount before olive-crashhandler exits
 


### PR DESCRIPTION
You cannot rely on the `$APPDIR` variable to be populated. E.g., when the user extracts the AppImage using `--appimage-extract` and then tries to run `./squashfs-root/AppRun`, it will not be there.

Hence you need to set this variable at the beginning of your `AppRun` script:

```
APPDIR=$(readlink -f $(dirname "$0"))
```

---

Also changed the shebang to a version that works on more systems, e.g., on FreeBSD.