### PR TITLE
saveotio: Make sure all tracks are the same length

### DIFF
--- a/app/task/project/saveotio/saveotio.h
+++ b/app/task/project/saveotio/saveotio.h
@@ -44,7 +44,7 @@ protected:
 private:
   OTIO::Timeline* SerializeTimeline(Sequence* sequence);
 
-  OTIO::Track* SerializeTrack(Track* track, double sequence_rate);
+  OTIO::Track* SerializeTrack(Track* track, double sequence_rate, rational max_track_length);
 
   bool SerializeTrackList(TrackList* list, OTIO::Timeline *otio_timeline, double sequence_rate);
 


### PR DESCRIPTION
OTIO ideally requires all tracks to be the same length. This PR adds OTIO::Gaps of the requisite length to make sure all the tracks are as long as the longest track.