### PR TITLE
Text typewriter feature

### DIFF
--- a/app/node/generator/text/text.h
+++ b/app/node/generator/text/text.h
@@ -45,11 +45,14 @@ public:
 
   virtual void GenerateFrame(FramePtr frame, const GenerateJob &job) const override;
 
+  virtual void InputValueChangedEvent(const QString &input, int element);
+
   static const QString kTextInput;
   static const QString kHtmlInput;
   static const QString kVAlignInput;
   static const QString kFontInput;
   static const QString kFontSizeInput;
+  static const QString kTextTypewriterInput;
 
 };
 


### PR DESCRIPTION
Hi! I developed this feature out of necessity and figured it might be useful to others too. I enables the "typewriter" effect on text nodes, where the text is "typed in" one character at a time. 

Would you accept this feature? If so, what do I need to improve before it's ready? Some thoughts:

 - [ ] Better name for it? Resolve calls it "Write On", After Effects has a "Typewriter" effect
 - [ ] Support for HTML text (probably possible with `QTextCursor`)
 - Maybe it would make sense to scrap this implementation and add a "Substring" node that could be plugged into a Text node and keyframed? *I think that could be possible, but I'm completely new to the project so I'm not sure how flexible the node system is...*

Demo:   

https://user-images.githubusercontent.com/3891092/149542312-2f7a8d4c-5f16-44f5-8ceb-4d2ad8620f59.mp4