### PR TITLE
Dilate/Erode node

### DIFF
--- a/app/node/factory.cpp
+++ b/app/node/factory.cpp
@@ -39,6 +39,7 @@
 #include "generator/text/text.h"
 #include "generator/text/textlegacy.h"
 #include "filter/blur/blur.h"
+#include "filter/dilateerode/dilateerode.h"
 #include "filter/mosaic/mosaicfilternode.h"
 #include "filter/stroke/stroke.h"
 #include "input/time/timeinput.h"
@@ -255,6 +256,9 @@ Node *NodeFactory::CreateFromFactoryIndex(const NodeFactory::InternalID &id)
     return new NodeGroup();
   case kOpacityEffect:
     return new OpacityEffect();
+  case kDilateErodeFilter:
+    return new DilateErodeFilterNode();
+
 
   case kInternalNodeCount:
     break;

--- a/app/node/factory.h
+++ b/app/node/factory.h
@@ -63,6 +63,7 @@ public:
     kShapeGenerator,
     kGroupNode,
     kOpacityEffect,
+    kDilateErodeFilter,
 
     // Count value
     kInternalNodeCount

--- a/app/node/filter/dilateerode/CMakeLists.txt
+++ b/app/node/filter/dilateerode/CMakeLists.txt
@@ -14,12 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-add_subdirectory(blur)
-add_subdirectory(mosaic)
-add_subdirectory(stroke)
-add_subdirectory(dilateerode)
-
 set(OLIVE_SOURCES
   ${OLIVE_SOURCES}
+  node/filter/dilateerode/dilateerode.h
+  node/filter/dilateerode/dilateerode.cpp
   PARENT_SCOPE
 )

--- a/app/node/filter/dilateerode/dilateerode.cpp
+++ b/app/node/filter/dilateerode/dilateerode.cpp
@@ -23,11 +23,14 @@
 namespace olive {
 
 const QString DilateErodeFilterNode::kTextureInput = QStringLiteral("tex_in");
+const QString DilateErodeFilterNode::kMethodInput = QStringLiteral("method_in");
 const QString DilateErodeFilterNode::kPixelsInput = QStringLiteral("pixels_in");
 
 DilateErodeFilterNode::DilateErodeFilterNode()
 {
   AddInput(kTextureInput, NodeValue::kTexture, InputFlags(kInputFlagNotKeyframable));
+
+  AddInput(kMethodInput, NodeValue::kCombo, 0);
 
   AddInput(kPixelsInput, NodeValue::kInt, 0);
 }
@@ -60,6 +63,8 @@ QString DilateErodeFilterNode::Description() const
 void DilateErodeFilterNode::Retranslate()
 {
   SetInputName(kTextureInput, tr("Input"));
+  SetInputName(kMethodInput, tr("Method"));
+  SetComboBoxStrings(kMethodInput, {tr("Box"), tr("Distance"), tr("Gaussian")});
   SetInputName(kPixelsInput, tr("Pixels"));
 }
 
@@ -78,7 +83,7 @@ void DilateErodeFilterNode::Value(const NodeValueRow& value, const NodeGlobals& 
 
   // If there's no texture and no dilation/erosion, no need to run an operation
   if (!job.GetValue(kTextureInput).data().isNull() && job.GetValue(kPixelsInput).data().toInt() != 0) {
-    job.SetIterations(2, kTextureInput);
+    //job.SetIterations(2, kTextureInput);
 
     table->Push(NodeValue::kShaderJob, QVariant::fromValue(job), this);
   } else {

--- a/app/node/filter/dilateerode/dilateerode.cpp
+++ b/app/node/filter/dilateerode/dilateerode.cpp
@@ -1,0 +1,90 @@
+/***
+
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2021 Olive Team
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+***/
+
+#include "dilateerode.h"
+
+namespace olive {
+
+const QString DilateErodeFilterNode::kTextureInput = QStringLiteral("tex_in");
+const QString DilateErodeFilterNode::kPixelsInput = QStringLiteral("pixels_in");
+
+DilateErodeFilterNode::DilateErodeFilterNode()
+{
+  AddInput(kTextureInput, NodeValue::kTexture, InputFlags(kInputFlagNotKeyframable));
+
+  AddInput(kPixelsInput, NodeValue::kInt, 0);
+}
+
+Node* DilateErodeFilterNode::copy() const
+{
+  return new DilateErodeFilterNode();
+}
+
+QString DilateErodeFilterNode::Name() const
+{
+  return tr("Dilate/Erode");
+}
+
+QString DilateErodeFilterNode::id() const
+{
+  return QStringLiteral("org.olivevideoeditor.Olive.dilateerode");
+}
+
+QVector<Node::CategoryID> DilateErodeFilterNode::Category() const
+{
+  return {kCategoryFilter};
+}
+
+QString DilateErodeFilterNode::Description() const
+{
+  return tr("Grows or shrinks bright areas by the set number of pixels");
+}
+
+void DilateErodeFilterNode::Retranslate()
+{
+  SetInputName(kTextureInput, tr("Input"));
+  SetInputName(kPixelsInput, tr("Pixels"));
+}
+
+ShaderCode DilateErodeFilterNode::GetShaderCode(const QString &shader_id) const
+{
+  Q_UNUSED(shader_id)
+  return ShaderCode(FileFunctions::ReadFileAsString(":/shaders/dilateerode.frag"));
+}
+
+void DilateErodeFilterNode::Value(const NodeValueRow& value, const NodeGlobals& globals, NodeValueTable* table) const
+{
+  ShaderJob job;
+
+  job.InsertValue(value);
+  job.InsertValue(QStringLiteral("resolution_in"), NodeValue(NodeValue::kVec2, globals.resolution(), this));
+
+  // If there's no texture and no dilation/erosion, no need to run an operation
+  if (!job.GetValue(kTextureInput).data().isNull() && job.GetValue(kPixelsInput).data().toInt() != 0) {
+    job.SetIterations(2, kTextureInput);
+
+    table->Push(NodeValue::kShaderJob, QVariant::fromValue(job), this);
+  } else {
+    // If we're not doing anything just push the texture
+    table->Push(job.GetValue(kTextureInput));
+  }
+}
+
+}

--- a/app/node/filter/dilateerode/dilateerode.h
+++ b/app/node/filter/dilateerode/dilateerode.h
@@ -1,0 +1,55 @@
+/***
+
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2021 Olive Team
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+***/
+
+#ifndef DILATEERODEFILTERNODE_H
+#define DILATEERODEFILTERNODE_H
+
+#include "node/node.h"
+
+namespace olive {
+
+class DilateErodeFilterNode : public Node
+{
+  Q_OBJECT
+public:
+  DilateErodeFilterNode();
+
+  NODE_DEFAULT_DESTRUCTOR(DilateErodeFilterNode)
+
+  virtual Node* copy() const override;
+
+  virtual QString Name() const override;
+  virtual QString id() const override;
+  virtual QVector<CategoryID> Category() const override;
+  virtual QString Description() const override;
+
+  virtual void Retranslate() override;
+
+  virtual ShaderCode GetShaderCode(const QString& shader_id) const override;
+  virtual void Value(const NodeValueRow& value, const NodeGlobals& globals, NodeValueTable* table) const override;
+
+  static const QString kTextureInput;
+  static const QString kPixelsInput;
+
+};
+
+}
+
+#endif //DILATEERODEFILTERNODE_H

--- a/app/node/filter/dilateerode/dilateerode.h
+++ b/app/node/filter/dilateerode/dilateerode.h
@@ -46,6 +46,7 @@ public:
   virtual void Value(const NodeValueRow& value, const NodeGlobals& globals, NodeValueTable* table) const override;
 
   static const QString kTextureInput;
+  static const QString kMethodInput;
   static const QString kPixelsInput;
 
 };

--- a/app/shaders/dilateerode.frag
+++ b/app/shaders/dilateerode.frag
@@ -1,4 +1,5 @@
 uniform sampler2D tex_in;
+uniform int method_in;
 uniform int pixels_in;
 uniform vec2 resolution_in;
 
@@ -6,41 +7,67 @@ uniform int ove_iteration;
 
 varying vec2 ove_texcoord;
 
+// Gaussian function uses PI
+#define M_PI 3.1415926535897932384626433832795
+
+float gaussian2(float x, float y, float sigma) {
+    return (1.0/((sigma*sigma)*2.0*M_PI))*exp(-0.5*(((x*x) + (y*y))/(sigma*sigma)));
+}
+
 void main(void) {
     vec2 pixel_coord;
+    vec2 offset;
     vec4 sample;
-    vec3 composite;
+    vec4 composite;
+
+    int size = int(abs(float(pixels_in)));
 
     if (pixels_in == 0) {
         gl_FragColor = texture2D(tex_in, ove_texcoord);
         return;
     }
     
-    if (pixels_in > 0) {
-        composite = vec3(-9999.0); // GLSL has no FLOAT_MIN
-        for (int i = -pixels_in; i < pixels_in; i++) {
-            pixel_coord = ove_texcoord;
-            if (ove_iteration == 0) {
-                pixel_coord.x += float(i) / resolution_in.x;
-            } else if (ove_iteration == 1) {
-                pixel_coord.y += float(i) / resolution_in.y;
+
+    pixel_coord = ove_texcoord;
+    float max_weight = gaussian2(0.0, 0.0, float(size)/2.0);
+    size*=3;
+
+    // GLSL has no FLOAT_MIN or FLOAT_MAX
+    composite = pixels_in > 0? vec4(-9999.0) : vec4(9999.0);
+    for (int j = -size; j <= size; j++) {
+        for(int i = -size; i <= size; i++) {
+            offset.x = float(i) / resolution_in.x;
+            offset.y = float(j) / resolution_in.y;
+            if (method_in == 0) {
+                sample = texture2D(tex_in, pixel_coord+offset);
+                if (pixels_in > 0) {
+                    composite = max(sample, composite);
+                } else if (pixels_in < 0) {
+                    composite = min(sample, composite);
+                }
+            } else if (method_in == 1) {
+                float len = length(offset);
+                float scaled_size = float(size) / length(resolution_in);
+                if (len <= scaled_size){
+                    sample = texture2D(tex_in, pixel_coord+offset);
+                    if (pixels_in > 0) {
+                        composite = max(sample, composite);
+                    } else if (pixels_in < 0) {
+                        composite = min(sample, composite);
+                    } 
+                }
+            } else if (method_in == 2) {
+                float weight = gaussian2(float(i), float(j), float(size)/6.0) / max_weight;
+
+                sample = texture2D(tex_in, pixel_coord+offset);
+                if (pixels_in > 0) {
+                    composite = max(sample*weight*weight, composite);
+                } else if (pixels_in < 0) {
+                    composite = min(sample, composite);
+                }
             }
-            sample = texture2D(tex_in, pixel_coord);
-            composite = max(sample.rgb, composite);
-        }
-    } else if (pixels_in < 0) {
-        composite = vec3(9999.0); // GLSL has no FLOAT_MAX
-        for (int i = pixels_in; i < -pixels_in; i++) {
-            pixel_coord = ove_texcoord;
-            if (ove_iteration == 0) {
-                pixel_coord.x += float(i) / resolution_in.x;
-            } else if (ove_iteration == 1) {
-                pixel_coord.y += float(i) / resolution_in.y;
-            }
-            sample = texture2D(tex_in, pixel_coord);
-            composite = min(sample.rgb, composite);
         }
     }
 
-    gl_FragColor = vec4(composite, 1.0);
+    gl_FragColor = vec4(composite);
 }

--- a/app/shaders/dilateerode.frag
+++ b/app/shaders/dilateerode.frag
@@ -33,7 +33,7 @@ void main(void) {
     size*=3;
 
     // GLSL has no FLOAT_MIN or FLOAT_MAX
-    composite = pixels_in > 0? vec4(-9999.0) : vec4(9999.0);
+    composite = pixels_in > 0 || method_in == 2 ? vec4(-9999.0) : vec4(9999.0);
     for (int j = -size; j <= size; j++) {
         for(int i = -size; i <= size; i++) {
             offset.x = float(i) / resolution_in.x;
@@ -63,11 +63,14 @@ void main(void) {
                 if (pixels_in > 0) {
                     composite = max(sample*weight*weight, composite);
                 } else if (pixels_in < 0) {
-                    composite = min(sample, composite);
+                    composite = max((1.0-sample)*weight*weight, composite);
                 }
             }
         }
     }
-
-    gl_FragColor = vec4(composite);
+    if (method_in == 2 && pixels_in < 0) {
+        gl_FragColor = vec4(1.0-composite);
+    } else{
+        gl_FragColor = vec4(composite);
+    }
 }

--- a/app/shaders/dilateerode.frag
+++ b/app/shaders/dilateerode.frag
@@ -1,0 +1,46 @@
+uniform sampler2D tex_in;
+uniform int pixels_in;
+uniform vec2 resolution_in;
+
+uniform int ove_iteration;
+
+varying vec2 ove_texcoord;
+
+void main(void) {
+    vec2 pixel_coord;
+    vec4 sample;
+    vec3 composite;
+
+    if (pixels_in == 0) {
+        gl_FragColor = texture2D(tex_in, ove_texcoord);
+        return;
+    }
+    
+    if (pixels_in > 0) {
+        composite = vec3(-9999.0); // GLSL has no FLOAT_MIN
+        for (int i = -pixels_in; i < pixels_in; i++) {
+            pixel_coord = ove_texcoord;
+            if (ove_iteration == 0) {
+                pixel_coord.x += float(i) / resolution_in.x;
+            } else if (ove_iteration == 1) {
+                pixel_coord.y += float(i) / resolution_in.y;
+            }
+            sample = texture2D(tex_in, pixel_coord);
+            composite = max(sample.rgb, composite);
+        }
+    } else if (pixels_in < 0) {
+        composite = vec3(9999.0); // GLSL has no FLOAT_MAX
+        for (int i = pixels_in; i < -pixels_in; i++) {
+            pixel_coord = ove_texcoord;
+            if (ove_iteration == 0) {
+                pixel_coord.x += float(i) / resolution_in.x;
+            } else if (ove_iteration == 1) {
+                pixel_coord.y += float(i) / resolution_in.y;
+            }
+            sample = texture2D(tex_in, pixel_coord);
+            composite = min(sample.rgb, composite);
+        }
+    }
+
+    gl_FragColor = vec4(composite, 1.0);
+}


### PR DESCRIPTION
Adds a dilate erode node to the filter category. Mainly useful for masks and other grey scale images. 

Only controversial issue is that the Gaussian erode does an inversion via `1.0 - col.rgb` which isn't really okay colour management wise. Is there a better way to do this? It may be okay in this case as this node will only really be used for masks or it may be better to wait until we have implemented an OCIO node so this operation can be done in screen space if required.