### PR TITLE
Cineform support

### DIFF
--- a/app/codec/exportcodec.cpp
+++ b/app/codec/exportcodec.cpp
@@ -44,6 +44,8 @@ QString ExportCodec::GetCodecName(ExportCodec::Codec c)
     return tr("PNG");
   case kCodecProRes:
     return tr("ProRes");
+    case kCodecCineform:
+    return tr("Cineform");
   case kCodecTIFF:
     return tr("TIFF");
   case kCodecMP2:
@@ -79,6 +81,7 @@ bool ExportCodec::IsCodecAStillImage(ExportCodec::Codec c)
   case kCodecH264rgb:
   case kCodecH265:
   case kCodecProRes:
+  case kCodecCineform:
   case kCodecMP2:
   case kCodecMP3:
   case kCodecAAC:

--- a/app/codec/exportcodec.cpp
+++ b/app/codec/exportcodec.cpp
@@ -44,8 +44,6 @@ QString ExportCodec::GetCodecName(ExportCodec::Codec c)
     return tr("PNG");
   case kCodecProRes:
     return tr("ProRes");
-    case kCodecCineform:
-    return tr("Cineform");
   case kCodecTIFF:
     return tr("TIFF");
   case kCodecMP2:
@@ -81,7 +79,6 @@ bool ExportCodec::IsCodecAStillImage(ExportCodec::Codec c)
   case kCodecH264rgb:
   case kCodecH265:
   case kCodecProRes:
-  case kCodecCineform:
   case kCodecMP2:
   case kCodecMP3:
   case kCodecAAC:

--- a/app/codec/exportcodec.h
+++ b/app/codec/exportcodec.h
@@ -42,6 +42,7 @@ public:
     kCodecOpenEXR,
     kCodecPNG,
     kCodecProRes,
+    kCodecCineform,
     kCodecTIFF,
     kCodecVP9,
 

--- a/app/codec/exportcodec.h
+++ b/app/codec/exportcodec.h
@@ -42,7 +42,6 @@ public:
     kCodecOpenEXR,
     kCodecPNG,
     kCodecProRes,
-    kCodecCineform,
     kCodecTIFF,
     kCodecVP9,
 

--- a/app/codec/exportformat.cpp
+++ b/app/codec/exportformat.cpp
@@ -117,7 +117,7 @@ QList<ExportCodec::Codec> ExportFormat::GetVideoCodecs(ExportFormat::Format f)
   case kFormatTIFF:
     return {ExportCodec::kCodecTIFF};
   case kFormatQuickTime:
-    return {ExportCodec::kCodecH264, ExportCodec::kCodecH264rgb, ExportCodec::kCodecH265, ExportCodec::kCodecProRes, ExportCodec::kCodecCineform, ExportCodec::kCodecDNxHD};
+    return {ExportCodec::kCodecH264, ExportCodec::kCodecH264rgb, ExportCodec::kCodecH265, ExportCodec::kCodecProRes, ExportCodec::kCodecCineform};
   case kFormatWebM:
     return {ExportCodec::kCodecVP9};
   case kFormatOgg:

--- a/app/codec/exportformat.cpp
+++ b/app/codec/exportformat.cpp
@@ -117,7 +117,7 @@ QList<ExportCodec::Codec> ExportFormat::GetVideoCodecs(ExportFormat::Format f)
   case kFormatTIFF:
     return {ExportCodec::kCodecTIFF};
   case kFormatQuickTime:
-    return {ExportCodec::kCodecH264, ExportCodec::kCodecH264rgb, ExportCodec::kCodecH265, ExportCodec::kCodecProRes};
+    return {ExportCodec::kCodecH264, ExportCodec::kCodecH264rgb, ExportCodec::kCodecH265, ExportCodec::kCodecProRes, ExportCodec::kCodecCineform, ExportCodec::kCodecDNxHD};
   case kFormatWebM:
     return {ExportCodec::kCodecVP9};
   case kFormatOgg:

--- a/app/codec/ffmpeg/ffmpegencoder.cpp
+++ b/app/codec/ffmpeg/ffmpegencoder.cpp
@@ -844,8 +844,6 @@ AVCodec *FFmpegEncoder::GetEncoder(ExportCodec::Codec c)
     return avcodec_find_encoder(AV_CODEC_ID_DNXHD);
   case ExportCodec::kCodecProRes:
     return avcodec_find_encoder(AV_CODEC_ID_PRORES);
-    case ExportCodec::kCodecCineform:
-    return avcodec_find_encoder(AV_CODEC_ID_CFHD);
   case ExportCodec::kCodecH265:
     return avcodec_find_encoder(AV_CODEC_ID_HEVC);
   case ExportCodec::kCodecVP9:

--- a/app/codec/ffmpeg/ffmpegencoder.cpp
+++ b/app/codec/ffmpeg/ffmpegencoder.cpp
@@ -844,6 +844,8 @@ AVCodec *FFmpegEncoder::GetEncoder(ExportCodec::Codec c)
     return avcodec_find_encoder(AV_CODEC_ID_DNXHD);
   case ExportCodec::kCodecProRes:
     return avcodec_find_encoder(AV_CODEC_ID_PRORES);
+    case ExportCodec::kCodecCineform:
+    return avcodec_find_encoder(AV_CODEC_ID_CFHD);
   case ExportCodec::kCodecH265:
     return avcodec_find_encoder(AV_CODEC_ID_HEVC);
   case ExportCodec::kCodecVP9:

--- a/app/dialog/export/codec/CMakeLists.txt
+++ b/app/dialog/export/codec/CMakeLists.txt
@@ -16,11 +16,13 @@
 
 set(OLIVE_SOURCES
   ${OLIVE_SOURCES}
-  dialog/export/codec/codecsection.h
+  dialog/export/codec/cineformsection.cpp
+  dialog/export/codec/cineformsection.h
   dialog/export/codec/codecsection.cpp
-  dialog/export/codec/h264section.h
+  dialog/export/codec/codecsection.h
   dialog/export/codec/h264section.cpp
-  dialog/export/codec/imagesection.h
+  dialog/export/codec/h264section.h
   dialog/export/codec/imagesection.cpp
+  dialog/export/codec/imagesection.h
   PARENT_SCOPE
 )

--- a/app/dialog/export/codec/cineformsection.cpp
+++ b/app/dialog/export/codec/cineformsection.cpp
@@ -1,0 +1,85 @@
+/***
+
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2021 Olive Team
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+***/
+
+#include "cineformsection.h"
+
+#include <QGridLayout>
+#include <QLabel>
+
+namespace olive {
+
+CineformSection::CineformSection(QWidget *parent) :
+  CodecSection(parent)
+{
+  QGridLayout *layout = new QGridLayout(this);
+
+  layout->setMargin(0);
+
+  int row = 0;
+
+  layout->addWidget(new QLabel(tr("Quality:")), row, 0);
+
+  quality_combobox_ = new QComboBox();
+
+  /* Correspond to the following indexes for FFmpeg
+   *
+   *   -quality           <int>        E..V....... set quality (from 0 to 12) (default film3+)
+   *     film3+          0            E..V.......
+   *     film3           1            E..V.......
+   *     film2+          2            E..V.......
+   *     film2           3            E..V.......
+   *     film1.5         4            E..V.......
+   *     film1+          5            E..V.......
+   *     film1           6            E..V.......
+   *     high+           7            E..V.......
+   *     high            8            E..V.......
+   *     medium+         9            E..V.......
+   *     medium          10           E..V.......
+   *     low+            11           E..V.......
+   *     low             12           E..V.......
+   *
+   */
+
+  quality_combobox_->addItem(tr("Film Scan 3+"));
+  quality_combobox_->addItem(tr("Film Scan 3"));
+  quality_combobox_->addItem(tr("Film Scan 2+"));
+  quality_combobox_->addItem(tr("Film Scan 2"));
+  quality_combobox_->addItem(tr("Film Scan 1.5"));
+  quality_combobox_->addItem(tr("Film Scan 1+"));
+  quality_combobox_->addItem(tr("Film Scan 1"));
+  quality_combobox_->addItem(tr("High+"));
+  quality_combobox_->addItem(tr("High"));
+  quality_combobox_->addItem(tr("Medium+"));
+  quality_combobox_->addItem(tr("Medium"));
+  quality_combobox_->addItem(tr("Low+"));
+  quality_combobox_->addItem(tr("Low"));
+
+  // Default to "medium"
+  quality_combobox_->setCurrentIndex(10);
+
+  layout->addWidget(quality_combobox_, row, 1);
+}
+
+void CineformSection::AddOpts(EncodingParams *params)
+{
+  params->set_video_option(QStringLiteral("quality"), QString::number(quality_combobox_->currentIndex()));
+}
+
+}

--- a/app/dialog/export/codec/cineformsection.h
+++ b/app/dialog/export/codec/cineformsection.h
@@ -1,0 +1,45 @@
+/***
+
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2021 Olive Team
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+***/
+
+#ifndef CINEFORMSECTION_H
+#define CINEFORMSECTION_H
+
+#include <QComboBox>
+
+#include "codecsection.h"
+
+namespace olive {
+
+class CineformSection : public CodecSection
+{
+  Q_OBJECT
+public:
+  CineformSection(QWidget *parent = nullptr);
+
+  virtual void AddOpts(EncodingParams* params) override;
+
+private:
+  QComboBox *quality_combobox_;
+
+};
+
+}
+
+#endif // CINEFORMSECTION_H

--- a/app/dialog/export/exportvideotab.cpp
+++ b/app/dialog/export/exportvideotab.cpp
@@ -185,6 +185,9 @@ QWidget *ExportVideoTab::SetupCodecSection()
   h265_section_ = new H265Section();
   codec_stack_->addWidget(h265_section_);
 
+  cineform_section_ = new CineformSection();
+  codec_stack_->addWidget(cineform_section_);
+
   row++;
 
   QPushButton* advanced_btn = new QPushButton(tr("Advanced"));
@@ -239,6 +242,9 @@ void ExportVideoTab::VideoCodecChanged()
       break;
     case ExportCodec::kCodecH265:
       SetCodecSection(h265_section_);
+      break;
+    case ExportCodec::kCodecCineform:
+      SetCodecSection(cineform_section_);
       break;
     default:
       SetCodecSection(ExportCodec::IsCodecAStillImage(codec) ? image_section_ : nullptr);

--- a/app/dialog/export/exportvideotab.h
+++ b/app/dialog/export/exportvideotab.h
@@ -26,6 +26,7 @@
 #include <QWidget>
 
 #include "common/rational.h"
+#include "dialog/export/codec/cineformsection.h"
 #include "dialog/export/codec/h264section.h"
 #include "dialog/export/codec/imagesection.h"
 #include "node/color/colormanager/colormanager.h"
@@ -159,6 +160,7 @@ private:
   ImageSection* image_section_;
   H264Section* h264_section_;
   H264Section* h265_section_;
+  CineformSection *cineform_section_;
 
   ColorSpaceChooser* color_space_chooser_;
 


### PR DESCRIPTION
Adds in initial cineform support, only adding for quicktime right now, but I think it would work in matroska too?

It defaults to filmscan 3, which is probably not what most people want (even in the SDK it's listed as overkill [see here](https://github.com/gopro/cineform-sdk/blob/9785875ba0555f92889cac0ded94304ec49ced4c/Common/CFHDTypes.h#L208)) but it's what ffmpeg defaults to anyways, however in terms of testing, it works perfectly fine, and we can always configure it when codec configuration settings eventually get added, which is needed for dnxhd support anyways. 