### PR TITLE
Add support for x264 and x265 presets

### DIFF
--- a/app/dialog/export/codec/h264section.cpp
+++ b/app/dialog/export/codec/h264section.cpp
@@ -42,6 +42,26 @@ H264Section::H264Section(int default_crf, QWidget *parent) :
   layout->setMargin(0);
 
   int row = 0;
+  layout->addWidget(new QLabel(tr("Preset:")), row, 0);
+
+  preset_combobox_ = new QComboBox();
+
+  preset_combobox_->addItem(tr("Ultrafast"));
+  preset_combobox_->addItem(tr("Superfast"));
+  preset_combobox_->addItem(tr("Veryfast"));
+  preset_combobox_->addItem(tr("Faster"));
+  preset_combobox_->addItem(tr("Fast"));
+  preset_combobox_->addItem(tr("Medium"));
+  preset_combobox_->addItem(tr("Slow"));
+  preset_combobox_->addItem(tr("Slower"));
+  preset_combobox_->addItem(tr("Veryslow"));
+  
+  //Default to "medium"
+  preset_combobox_->setCurrentIndex(5);
+
+  layout->addWidget(preset_combobox_, row, 1);
+
+  row++;
 
   layout->addWidget(new QLabel(tr("Compression Method:")), row, 0);
 
@@ -110,6 +130,8 @@ void H264Section::AddOpts(EncodingParams *params)
     params->set_video_buffer_size(2000000);
 
   }
+  
+  params->set_video_option(QStringLiteral("preset"), QString::number(preset_combobox_->currentIndex()));
 }
 
 H264CRFSection::H264CRFSection(int default_crf, QWidget *parent) :

--- a/app/dialog/export/codec/h264section.cpp
+++ b/app/dialog/export/codec/h264section.cpp
@@ -42,19 +42,25 @@ H264Section::H264Section(int default_crf, QWidget *parent) :
   layout->setMargin(0);
 
   int row = 0;
-  layout->addWidget(new QLabel(tr("Preset:")), row, 0);
+  layout->addWidget(new QLabel(tr("Encode Speed:")), row, 0);
 
+
+  char presettooltip[] = "<head/><body>This setting allows you to tweak the ratio of export speed to compression quality. <br /> <br />"\
+    " If using Constant Rate Factor, slower speeds will result in smaller file sizes for the same quaity. <br /> <br />"\
+    " If using Target Bit Rate or Target File Size, slower speeds will result in higher quality for the same bitrate/filesize. <br /> <br />"\
+    " This setting is equivalent to the `preset` setting in libx264.<head/>";
   preset_combobox_ = new QComboBox();
+  preset_combobox_->setToolTip(presettooltip);
 
-  preset_combobox_->addItem(tr("Ultrafast"));
-  preset_combobox_->addItem(tr("Superfast"));
-  preset_combobox_->addItem(tr("Veryfast"));
+  preset_combobox_->addItem(tr("Ultra Fast"));
+  preset_combobox_->addItem(tr("Super Fast"));
+  preset_combobox_->addItem(tr("Very Fast"));
   preset_combobox_->addItem(tr("Faster"));
   preset_combobox_->addItem(tr("Fast"));
   preset_combobox_->addItem(tr("Medium"));
   preset_combobox_->addItem(tr("Slow"));
   preset_combobox_->addItem(tr("Slower"));
-  preset_combobox_->addItem(tr("Veryslow"));
+  preset_combobox_->addItem(tr("Very Slow"));
   
   //Default to "medium"
   preset_combobox_->setCurrentIndex(5);

--- a/app/dialog/export/codec/h264section.cpp
+++ b/app/dialog/export/codec/h264section.cpp
@@ -45,12 +45,11 @@ H264Section::H264Section(int default_crf, QWidget *parent) :
   layout->addWidget(new QLabel(tr("Encode Speed:")), row, 0);
 
 
-  char presettooltip[] = "<head/><body>This setting allows you to tweak the ratio of export speed to compression quality. <br /> <br />"\
-    " If using Constant Rate Factor, slower speeds will result in smaller file sizes for the same quaity. <br /> <br />"\
-    " If using Target Bit Rate or Target File Size, slower speeds will result in higher quality for the same bitrate/filesize. <br /> <br />"\
-    " This setting is equivalent to the `preset` setting in libx264.<head/>";
   preset_combobox_ = new QComboBox();
-  preset_combobox_->setToolTip(presettooltip);
+  preset_combobox_->setToolTip(tr("This setting allows you to tweak the ratio of export speed to compression quality. \n\n"
+    "If using Constant Rate Factor, slower speeds will result in smaller file sizes for the same quality. \n\n"
+    "If using Target Bit Rate or Target File Size, slower speeds will result in higher quality for the same bitrate/filesize. \n\n"
+    "This setting is equivalent to the `preset` setting in libx264."));
 
   preset_combobox_->addItem(tr("Ultra Fast"));
   preset_combobox_->addItem(tr("Super Fast"));

--- a/app/dialog/export/codec/h264section.h
+++ b/app/dialog/export/codec/h264section.h
@@ -23,6 +23,7 @@
 
 #include <QSlider>
 #include <QStackedWidget>
+#include <QComboBox>
 
 #include "codecsection.h"
 #include "widget/slider/floatslider.h"
@@ -111,6 +112,7 @@ private:
 
   H264FileSizeSection* filesize_section_;
 
+  QComboBox *preset_combobox_;
 };
 
 class H265Section : public H264Section


### PR DESCRIPTION
Adding presets for x264 and 265 encoders. the output lines up with the expected values for each preset on both x265 and x264.

[Values for presets for x265](https://x265.readthedocs.io/en/stable/presets.html)
[Values for presets for x264](https://dev.beandog.org/x264_preset_reference.html)