### PR TITLE
[RFC] DNxHD support

### DIFF
--- a/app/codec/exportformat.cpp
+++ b/app/codec/exportformat.cpp
@@ -117,7 +117,7 @@ QList<ExportCodec::Codec> ExportFormat::GetVideoCodecs(ExportFormat::Format f)
   case kFormatTIFF:
     return {ExportCodec::kCodecTIFF};
   case kFormatQuickTime:
-    return {ExportCodec::kCodecH264, ExportCodec::kCodecH264rgb, ExportCodec::kCodecH265, ExportCodec::kCodecProRes, ExportCodec::kCodecCineform};
+    return {ExportCodec::kCodecH264, ExportCodec::kCodecH264rgb, ExportCodec::kCodecH265, ExportCodec::kCodecProRes, ExportCodec::kCodecCineform, ExportCodec::kCodecDNxHD};
   case kFormatWebM:
     return {ExportCodec::kCodecVP9};
   case kFormatOgg:

--- a/app/codec/ffmpeg/ffmpegencoder.cpp
+++ b/app/codec/ffmpeg/ffmpegencoder.cpp
@@ -721,6 +721,7 @@ bool FFmpegEncoder::SetupCodecContext(AVStream* stream, AVCodecContext* codec_ct
 
   if (codec->type == AVMEDIA_TYPE_VIDEO) {
     stream->avg_frame_rate = codec_ctx->framerate;
+    stream->time_base = av_add_q(codec_ctx->time_base, {0, 1});
   }
 
   return true;

--- a/app/dialog/export/codec/CMakeLists.txt
+++ b/app/dialog/export/codec/CMakeLists.txt
@@ -22,6 +22,8 @@ set(OLIVE_SOURCES
   dialog/export/codec/codecsection.h
   dialog/export/codec/codecstack.cpp
   dialog/export/codec/codecstack.h
+  dialog/export/codec/dnxhdsection.cpp
+  dialog/export/codec/dnxhdsection.h
   dialog/export/codec/h264section.cpp
   dialog/export/codec/h264section.h
   dialog/export/codec/imagesection.cpp

--- a/app/dialog/export/codec/dnxhdsection.cpp
+++ b/app/dialog/export/codec/dnxhdsection.cpp
@@ -1,0 +1,66 @@
+/***
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2021 Olive Team
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include "dnxhdsection.h"
+
+#include <QGridLayout>
+#include <QLabel>
+
+namespace olive {
+
+DNxHDSection::DNxHDSection(QWidget *parent) :
+  CodecSection(parent)
+{
+  QGridLayout *layout = new QGridLayout(this);
+
+  layout->setMargin(0);
+
+  int row = 0;
+
+  layout->addWidget(new QLabel(tr("preset:")), row, 0);
+
+  preset_combobox_ = new QComboBox();
+
+  /* Correspond to the following indexes for FFmpeg
+   *
+   *-profile           <int>        E..V....... (from 0 to 5) (default dnxhd)
+   *  dnxhd           0            E..V.......
+   *  dnxhr_444       5            E..V.......
+   *  dnxhr_hqx       4            E..V.......
+   *  dnxhr_hq        3            E..V.......
+   *  dnxhr_sq        2            E..V.......
+   *  dnxhr_lb        1            E..V.......
+   *
+   */
+
+  preset_combobox_->addItem(tr("dnxhd"));
+  preset_combobox_->addItem(tr("dnxhr_lb"));
+  preset_combobox_->addItem(tr("dnxhr_sq"));
+  preset_combobox_->addItem(tr("dnxhr_hq"));
+  preset_combobox_->addItem(tr("dnxhr_hqx"));
+  preset_combobox_->addItem(tr("dnxhr_444"));
+
+  //Default to "medium"
+  preset_combobox_->setCurrentIndex(3);
+
+  layout->addWidget(preset_combobox_, row, 1);
+}
+
+void DNxHDSection::AddOpts(EncodingParams *params)
+{
+  params->set_video_option(QStringLiteral("profile"), QString::number(preset_combobox_->currentIndex()));
+}
+
+} 

--- a/app/dialog/export/codec/dnxhdsection.cpp
+++ b/app/dialog/export/codec/dnxhdsection.cpp
@@ -45,7 +45,7 @@ DNxHDSection::DNxHDSection(QWidget *parent) :
    *
    */
 
-  preset_combobox_->addItem(tr("dnxhd"));
+  //preset_combobox_->addItem(tr("dnxhd"));
   preset_combobox_->addItem(tr("dnxhr_lb"));
   preset_combobox_->addItem(tr("dnxhr_sq"));
   preset_combobox_->addItem(tr("dnxhr_hq"));
@@ -60,7 +60,7 @@ DNxHDSection::DNxHDSection(QWidget *parent) :
 
 void DNxHDSection::AddOpts(EncodingParams *params)
 {
-  params->set_video_option(QStringLiteral("profile"), QString::number(preset_combobox_->currentIndex()));
+  params->set_video_option(QStringLiteral("profile"), QString::number(preset_combobox_->currentIndex() + 1));
 }
 
 } 

--- a/app/dialog/export/codec/dnxhdsection.cpp
+++ b/app/dialog/export/codec/dnxhdsection.cpp
@@ -29,9 +29,13 @@ DNxHDSection::DNxHDSection(QWidget *parent) :
 
   int row = 0;
 
-  layout->addWidget(new QLabel(tr("preset:")), row, 0);
+  layout->addWidget(new QLabel(tr("Profile:")), row, 0);
 
   preset_combobox_ = new QComboBox();
+
+  preset_combobox_->setToolTip(tr("While using DNxHD you may need to manually change pixel format. \n\n"
+            "dnxhr_hqx profile will need you to manually specify pixel format `422p10le` in the advanced menu. \n\n"
+            "dnxhr_444 profile will need you to manually specify pixel format `444p10le` or `gbrp10le` in the advanced menu."));
 
   /* Correspond to the following indexes for FFmpeg
    *
@@ -52,8 +56,8 @@ DNxHDSection::DNxHDSection(QWidget *parent) :
   preset_combobox_->addItem(tr("dnxhr_hqx"));
   preset_combobox_->addItem(tr("dnxhr_444"));
 
-  //Default to "medium"
-  preset_combobox_->setCurrentIndex(3);
+  
+  preset_combobox_->setCurrentIndex(1);
 
   layout->addWidget(preset_combobox_, row, 1);
 }

--- a/app/dialog/export/codec/dnxhdsection.h
+++ b/app/dialog/export/codec/dnxhdsection.h
@@ -1,0 +1,40 @@
+/***
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2021 Olive Team
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#ifndef DNXHDSECTION_H
+#define DNXHDSECTION_H
+
+#include <QComboBox>
+
+#include "codecsection.h"
+
+namespace olive {
+
+class DNxHDSection : public CodecSection
+{
+  Q_OBJECT
+public:
+  DNxHDSection(QWidget *parent = nullptr);
+
+  virtual void AddOpts(EncodingParams* params) override;
+
+private:
+  QComboBox *preset_combobox_;
+
+};
+
+}
+
+#endif // DNXHDSECTION_H 

--- a/app/dialog/export/exportvideotab.cpp
+++ b/app/dialog/export/exportvideotab.cpp
@@ -188,6 +188,9 @@ QWidget *ExportVideoTab::SetupCodecSection()
   cineform_section_ = new CineformSection();
   codec_stack_->addWidget(cineform_section_);
 
+  dnxhd_section_ = new DNxHDSection();
+  codec_stack_->addWidget(dnxhd_section_);
+  
   row++;
 
   QPushButton* advanced_btn = new QPushButton(tr("Advanced"));
@@ -245,6 +248,9 @@ void ExportVideoTab::VideoCodecChanged()
       break;
     case ExportCodec::kCodecCineform:
       SetCodecSection(cineform_section_);
+      break;
+    case ExportCodec::kCodecDNxHD:
+      SetCodecSection(dnxhd_section_);
       break;
     default:
       SetCodecSection(ExportCodec::IsCodecAStillImage(codec) ? image_section_ : nullptr);

--- a/app/dialog/export/exportvideotab.h
+++ b/app/dialog/export/exportvideotab.h
@@ -29,6 +29,7 @@
 #include "dialog/export/codec/cineformsection.h"
 #include "dialog/export/codec/codecstack.h"
 #include "dialog/export/codec/h264section.h"
+#include "dialog/export/codec/dnxhdsection.h"
 #include "dialog/export/codec/imagesection.h"
 #include "node/color/colormanager/colormanager.h"
 #include "widget/colorwheel/colorspacechooser.h"
@@ -162,6 +163,7 @@ private:
   H264Section* h264_section_;
   H264Section* h265_section_;
   CineformSection *cineform_section_;
+  DNxHDSection *dnxhd_section_;
 
   ColorSpaceChooser* color_space_chooser_;
 


### PR DESCRIPTION
Sorry for closing yet another PR, but I borked something while trying to clean up commit history. But here is proper full DNxHD support. GUI and .mxf included.

There are a few known issues that I am unsure of how to get around. 

1. the `dnxhd` profile (usually used for 1080p and 720p) needs some special considerations. this is why I have hidden it away for now, we can use dnxhr for most cases that dnxhd would be used anyways. ideally this would be temporary. it would be best to implement it, I am just unsure how to at this moment, let alone the best way to do so. (I believe the issue is setting bitrate, but I have not tested it)

2. the profiles are restricted to pixel format. trying to encode dnxhr_hqx with the default pixel format will not work as it requires 10bit support. I have set the default to standard quality, as it will work with the default pixel format. I have added a tooltip to explain this behavior, but ideally I would like to do this automatically, or at the very least pop up a window notifying the user of why they are getting the error.

3. I thought about "humanizing" it like we did with h264. however I think it would be detrimental. only really two kinds of people will use dnxhd, those who somewhat know what they are doing, or those who were told to do so. in which case they would also likely be told which profile to use.