### PR TITLE
If screen parameter in SeekToScreenPoint is negative, return immediately

### DIFF
--- a/app/widget/timeruler/seekablewidget.cpp
+++ b/app/widget/timeruler/seekablewidget.cpp
@@ -139,7 +139,7 @@ rational SeekableWidget::ScreenToTime(int x) const
 
 void SeekableWidget::SeekToScreenPoint(int screen)
 {
-  if (timebase().isNull()) {
+  if (timebase().isNull() || screen < 0) {
     return;
   }
 


### PR DESCRIPTION
Fixes #1895 