### PR TITLE
Use multiple build-jobs in CI builds to (hopefully) speed up the runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build
         working-directory: build
         run: |
-          cmake --build .
+          cmake --build . --parallel 4
 
       - name: Test
         working-directory: build
@@ -210,7 +210,7 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
         shell: bash
         run: |
-          cmake --build .
+          cmake --build . --parallel 4
 
       - name: Test
         working-directory: ${{ runner.workspace }}/build
@@ -358,7 +358,7 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
         shell: bash
         run: |
-          cmake --build .
+          cmake --build . --parallel 4
 
       - name: Test
         working-directory: ${{ runner.workspace }}/build


### PR DESCRIPTION
Noticed the CI builds were taking ~10+ minutes each. I understand the CI machines are only ~2 cores, but this should give some improvement.