### PR TITLE
Implement RGB to B&W node

### DIFF
--- a/app/node/color/rgbtobw/CMakeLists.txt
+++ b/app/node/color/rgbtobw/CMakeLists.txt
@@ -14,13 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-add_subdirectory(colormanager)
-add_subdirectory(displaytransform)
-add_subdirectory(ociobase)
-add_subdirectory(ociogradingtransformlinear)
-add_subdirectory(rgbtobw)
-
 set(OLIVE_SOURCES
   ${OLIVE_SOURCES}
+  node/color/rgbtobw/rgbtobw.cpp
+  node/color/rgbtobw/rgbtobw.h
   PARENT_SCOPE
 )

--- a/app/node/color/rgbtobw/rgbtobw.cpp
+++ b/app/node/color/rgbtobw/rgbtobw.cpp
@@ -1,0 +1,129 @@
+/***
+
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2021 Olive Team
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+***/
+
+#include "rgbtobw.h"
+
+#include "node/project/project.h"
+
+namespace olive {
+
+const QString RGBToBWNode::kTextureInput = QStringLiteral("tex_in");
+const QString RGBToBWNode::kCustomWeightsEnableInput = QStringLiteral("custom_weights_enable_in");
+const QString RGBToBWNode::kCustomWeightsInput = QStringLiteral("custom_weights_in");
+
+#define super Node
+
+RGBToBWNode::RGBToBWNode()
+{
+  AddInput(kTextureInput, NodeValue::kTexture, InputFlags(kInputFlagNotKeyframable));
+
+  AddInput(kCustomWeightsEnableInput, NodeValue::kBoolean, false);
+
+  AddInput(kCustomWeightsInput, NodeValue::kVec3, QVector3D{0.33f, 0.33f, 0.33f}); //TEMP
+  
+  SetInputProperty(kCustomWeightsInput, QStringLiteral("enabled"), GetStandardValue(kCustomWeightsEnableInput).toBool());
+  SetInputProperty(kCustomWeightsInput, QStringLiteral("color0"), QColor(50, 50, 50).name()); // What is disabled colour?
+  SetInputProperty(kCustomWeightsInput, QStringLiteral("color1"), QColor(50, 50, 50).name());
+  SetInputProperty(kCustomWeightsInput, QStringLiteral("color2"), QColor(50, 50, 50).name());
+
+  SetFlags(kVideoEffect);
+  SetEffectInput(kTextureInput);
+}
+
+QString RGBToBWNode::Name() const
+{
+  return tr("RGB to B&&W");
+}
+
+QString RGBToBWNode::id() const
+{
+  return QStringLiteral("org.olivevideoeditor.Olive.rgbtobw");
+}
+
+QVector<Node::CategoryID> RGBToBWNode::Category() const
+{
+  return {kCategoryColor};
+}
+
+QString RGBToBWNode::Description() const
+{
+  return tr("Converts an color image to a black and white image");
+}
+
+void RGBToBWNode::Retranslate()
+{
+  super::Retranslate();
+
+  SetInputName(kTextureInput, tr("Input"));
+  SetInputName(kCustomWeightsEnableInput, tr("Use Custom Weights"));
+  SetInputName(kCustomWeightsInput, tr("Weights"));
+
+  if (project()) {
+    // Set luma coefficients
+    //double luma_coeffs[3] = {0.0f, 0.0f, 0.0f};
+    project()->color_manager()->GetDefaultLumaCoefs(luma_coeffs_);
+    SetStandardValue(kCustomWeightsInput, QVector3D(luma_coeffs_[0], luma_coeffs_[1], luma_coeffs_[2]));
+  }
+}
+
+void RGBToBWNode::InputValueChangedEvent(const QString &input, int element)
+{
+  Q_UNUSED(element);
+  if (input == kCustomWeightsEnableInput) {
+    if (GetStandardValue(kCustomWeightsEnableInput).toBool()){
+      SetInputProperty(kCustomWeightsInput, QStringLiteral("enabled"), true);
+      SetInputProperty(kCustomWeightsInput, QStringLiteral("color0"), QColor(255, 0, 0).name());
+      SetInputProperty(kCustomWeightsInput, QStringLiteral("color1"), QColor(0, 255, 0).name());
+      SetInputProperty(kCustomWeightsInput, QStringLiteral("color2"), QColor(0, 0, 255).name());
+    } else {
+      SetInputProperty(kCustomWeightsInput, QStringLiteral("enabled"), false);
+      SetInputProperty(kCustomWeightsInput, QStringLiteral("color0"), QColor(50, 50, 50).name());
+      SetInputProperty(kCustomWeightsInput, QStringLiteral("color1"), QColor(50, 50, 50).name());
+      SetInputProperty(kCustomWeightsInput, QStringLiteral("color2"), QColor(50, 50, 50).name());
+    }
+  }
+ }
+ShaderCode RGBToBWNode::GetShaderCode(const ShaderRequest &request) const
+{
+  Q_UNUSED(request)
+  return ShaderCode(FileFunctions::ReadFileAsString(":/shaders/rgbtobw.frag"));
+}
+
+void RGBToBWNode::Value(const NodeValueRow &value, const NodeGlobals &globals, NodeValueTable *table) const {
+  ShaderJob job;
+
+  job.InsertValue(value);
+
+  // Set luma coefficients
+  double luma_coeffs[3] = {0.0f, 0.0f, 0.0f}; // Can this use the cached values?
+  project()->color_manager()->GetDefaultLumaCoefs(luma_coeffs);
+  job.InsertValue(QStringLiteral("luma_coeffs"),
+                  NodeValue(NodeValue::kVec3, QVector3D(luma_coeffs[0], luma_coeffs[1], luma_coeffs[2])));
+
+
+  // If there's no texture, no need to run an operation
+  if (!job.GetValue(kTextureInput).data().isNull()) {
+      table->Push(NodeValue::kTexture, QVariant::fromValue(job), this);
+
+  }
+}
+
+}
+

--- a/app/node/color/rgbtobw/rgbtobw.h
+++ b/app/node/color/rgbtobw/rgbtobw.h
@@ -1,0 +1,56 @@
+/***
+
+  Olive - Non-Linear Video Editor
+  Copyright (C) 2021 Olive Team
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+***/
+
+#ifndef RGBTOBWNODE_H
+#define RGBTOBWNODE_H
+
+#include "node/node.h"
+
+namespace olive {
+
+class RGBToBWNode : public Node
+{
+  Q_OBJECT
+ public:
+  RGBToBWNode();
+
+  NODE_DEFAULT_FUNCTIONS(RGBToBWNode)
+
+  virtual QString Name() const override;
+  virtual QString id() const override;
+  virtual QVector<CategoryID> Category() const override;
+  virtual QString Description() const override;
+
+  virtual void Retranslate() override;
+  virtual void InputValueChangedEvent(const QString &input, int element) override;
+
+  virtual ShaderCode GetShaderCode(const ShaderRequest &request) const override;
+  virtual void Value(const NodeValueRow &value, const NodeGlobals &globals, NodeValueTable *table) const override;
+
+  static const QString kTextureInput;
+  static const QString kCustomWeightsEnableInput;
+  static const QString kCustomWeightsInput;
+
+  double luma_coeffs_[3];
+};
+
+}  // namespace olive
+
+#endif  // RGBTOBWNODE_H

--- a/app/node/factory.cpp
+++ b/app/node/factory.cpp
@@ -31,6 +31,7 @@
 #include "block/transition/diptocolor/diptocolortransition.h"
 #include "color/displaytransform/displaytransform.h"
 #include "color/ociogradingtransformlinear/ociogradingtransformlinear.h"
+#include "color/rgbtobw/rgbtobw.h"
 #include "distort/cornerpin/cornerpindistortnode.h"
 #include "distort/crop/cropdistortnode.h"
 #include "distort/flip/flipdistortnode.h"
@@ -290,6 +291,8 @@ Node *NodeFactory::CreateFromFactoryIndex(const NodeFactory::InternalID &id)
     return new OCIOGradingTransformLinearNode();
   case kChromaKey:
     return new ChromaKeyNode();
+  case kRGBToBW:
+    return new RGBToBWNode();
 
   case kInternalNodeCount:
     break;

--- a/app/node/factory.h
+++ b/app/node/factory.h
@@ -73,6 +73,7 @@ public:
     kDisplayTransform,
     kOCIOGradingTransformLinear,
     kChromaKey,
+    kRGBToBW,
 
     // Count value
     kInternalNodeCount

--- a/app/shaders/rgbtobw.frag
+++ b/app/shaders/rgbtobw.frag
@@ -1,0 +1,18 @@
+// Input texture
+uniform sampler2D tex_in;
+uniform vec3 custom_weights_in;
+uniform bool custom_weights_enable_in;
+uniform vec3 luma_coeffs;
+
+// Input texture coordinate
+in vec2 ove_texcoord;
+out vec4 frag_color;
+
+void main() {
+  vec4 color = texture(tex_in, ove_texcoord);
+  if (!custom_weights_enable_in){
+    frag_color = vec4(vec3(dot(color.rgb, luma_coeffs)), color.w);
+  } else {
+    frag_color = vec4(vec3(dot(color.rgb, custom_weights_in)), color.w);
+  }
+}


### PR DESCRIPTION
Implements a RGB to B&W node using OCIO luma coefficients. ALso allows for overriding these with custom weights. There's a few questions in the code comments.

Specifically is there a good way to have coloured sliders be disabled and greyed out? I feel my solution is not ideal. Also I've tried to cache the luma coefficients but I can't seem to get it to work properly. 