### PR TITLE
Added option for user to disable transparent dialogs

### DIFF
--- a/app/config/config.cpp
+++ b/app/config/config.cpp
@@ -159,6 +159,8 @@ void Config::SetDefaults()
   SetEntryInternal(QStringLiteral("OfflinePixelFormat"), NodeValue::kInt, VideoParams::kFormatFloat16);
 
   SetEntryInternal(QStringLiteral("MarkerColor"), NodeValue::kInt, ColorCoding::kLime);
+  SetEntryInternal(QStringLiteral("AllowTransparentDialogs"), NodeValue::kBoolean, true);
+
 }
 
 void Config::Load()

--- a/app/dialog/preferences/tabs/preferencesappearancetab.cpp
+++ b/app/dialog/preferences/tabs/preferencesappearancetab.cpp
@@ -61,6 +61,7 @@ PreferencesAppearanceTab::PreferencesAppearanceTab()
 
   appearance_layout->addWidget(style_combobox_, row, 1);
 
+  //Default Node colours
   row++;
 
   {
@@ -82,11 +83,14 @@ PreferencesAppearanceTab::PreferencesAppearanceTab()
     appearance_layout->addWidget(color_group, row, 0, 1, 2);
   }
 
+  //Miscellaneous
   row++;
   {
     QGroupBox* marker_group = new QGroupBox();
     marker_group->setTitle(tr("Miscellaneous"));
 
+
+    //Default marker colour
     QGridLayout* marker_layout = new QGridLayout(marker_group);
 
     marker_layout->addWidget(new QLabel("Default Marker Color"), 0, 0);
@@ -94,6 +98,11 @@ PreferencesAppearanceTab::PreferencesAppearanceTab()
     marker_btn_ = new ColorCodingComboBox();
     marker_btn_->SetColor(OLIVE_CONFIG("MarkerColor").toInt());
     marker_layout->addWidget(marker_btn_, 0, 1);
+
+    //Allow Transparent Dialogs
+    allow_transparent_cb_=  new QCheckBox("Allow Transparent Dialogs");
+    allow_transparent_cb_->setChecked(OLIVE_CONFIG("AllowTransparentDialogs").toBool());
+    marker_layout->addWidget(allow_transparent_cb_);
 
     appearance_layout->addWidget(marker_group, row, 0, 1, 2);
   }
@@ -117,6 +126,7 @@ void PreferencesAppearanceTab::Accept(MultiUndoCommand *command)
   }
 
   OLIVE_CONFIG("MarkerColor") = marker_btn_->GetSelectedColor();
+  OLIVE_CONFIG("AllowTransparentDialogs") = allow_transparent_cb_->isChecked();
 }
 
 }

--- a/app/dialog/preferences/tabs/preferencesappearancetab.h
+++ b/app/dialog/preferences/tabs/preferencesappearancetab.h
@@ -24,6 +24,7 @@
 #include <QComboBox>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QCheckBox>
 
 #include "dialog/configbase/configdialogbase.h"
 #include "ui/style/style.h"
@@ -48,6 +49,7 @@ private:
   QVector<ColorCodingComboBox*> color_btns_;
 
   ColorCodingComboBox* marker_btn_;
+  QCheckBox* allow_transparent_cb_;
 
 };
 

--- a/app/dialog/preferences/tabs/preferencesbehaviortab.cpp
+++ b/app/dialog/preferences/tabs/preferencesbehaviortab.cpp
@@ -23,6 +23,7 @@
 #include <QCheckBox>
 #include <QVBoxLayout>
 
+
 #include "config/config.h"
 
 namespace olive {
@@ -35,73 +36,86 @@ PreferencesBehaviorTab::PreferencesBehaviorTab()
   layout->addWidget(behavior_tree_);
 
   behavior_tree_->setHeaderLabel(tr("Behavior"));
+   
+  {
+    QTreeWidgetItem* general_group = AddParent(tr("General"));
+    AddItem(tr("Enable hover focus"),
+            QStringLiteral("HoverFocus"),
+            tr("Panels will be considered focused when the mouse cursor is over them without having to click them."),
+            general_group);
+    AddItem(tr("Enable slider ladder"),
+            QStringLiteral("UseSliderLadders"),
+            general_group);
+  }
+  {
+    QTreeWidgetItem* visual_group = AddParent(tr("Visual"));
+    AddItem(tr("Enable transparent widgets/dialogs"),
+            QStringLiteral("AllowTransparentDialogs"),
+            tr("Some systems may have issues displaying transparent dialogs, in which case this option should be unchecked."),
+            visual_group);
+  }
+  {
+    QTreeWidgetItem* audio_group = AddParent(tr("Audio"));
+    AddItem(tr("Enable audio scrubbing"),
+            QStringLiteral("AudioScrubbing"),
+            audio_group);
+  }
+  {
+    QTreeWidgetItem* timeline_group = AddParent(tr("Timeline"));
+    AddItem(tr("Auto-Seek to Imported Clips"),
+            QStringLiteral("EnableSeekToImport"),
+            timeline_group);
+    AddItem(tr("Edit Tool Also Seeks"),
+            QStringLiteral("EditToolAlsoSeeks"),
+            timeline_group);
+    AddItem(tr("Edit Tool Selects Links"),
+            QStringLiteral("EditToolSelectsLinks"),
+            timeline_group);
+    AddItem(tr("Enable Drag Files to Timeline"),
+            QStringLiteral("EnableDragFilesToTimeline"),
+            timeline_group);
+    AddItem(tr("Invert Timeline Scroll Axes"),
+            QStringLiteral("InvertTimelineScrollAxes"),
+            tr("Hold ALT on any UI element to switch scrolling axes"),
+            timeline_group);
+    AddItem(tr("Seek Also Selects"),
+            QStringLiteral("SelectAlsoSeeks"),
+            timeline_group);
+    AddItem(tr("Seek to the End of Pastes"),
+            QStringLiteral("PasteSeeks"),
+            timeline_group);
+    AddItem(tr("Selecting Also Seeks"),
+            QStringLiteral("SelectAlsoSeeks"),
+            timeline_group);
+  }
+  {
+    QTreeWidgetItem* playback_group = AddParent(tr("Playback"));
+    AddItem(tr("Ask For Name When Setting Marker"),
+            QStringLiteral("SetNameWithMarker"),
+            playback_group);
+    AddItem(tr("Automatically rewind at the end of a sequence"),
+            QStringLiteral("AutoSeekToBeginning"),
+            playback_group);
 
-  QTreeWidgetItem* general_group = AddParent(tr("General"));
-  AddItem(tr("Enable hover focus"),
-          QStringLiteral("HoverFocus"),
-          tr("Panels will be considered focused when the mouse cursor is over them without having to click them."),
-          general_group);
-  AddItem(tr("Enable slider ladder"),
-          QStringLiteral("UseSliderLadders"),
-          general_group);
-
-  QTreeWidgetItem* audio_group = AddParent(tr("Audio"));
-  AddItem(tr("Enable audio scrubbing"),
-          QStringLiteral("AudioScrubbing"),
-          audio_group);
-
-  QTreeWidgetItem* timeline_group = AddParent(tr("Timeline"));
-  AddItem(tr("Auto-Seek to Imported Clips"),
-          QStringLiteral("EnableSeekToImport"),
-          timeline_group);
-  AddItem(tr("Edit Tool Also Seeks"),
-          QStringLiteral("EditToolAlsoSeeks"),
-          timeline_group);
-  AddItem(tr("Edit Tool Selects Links"),
-          QStringLiteral("EditToolSelectsLinks"),
-          timeline_group);
-  AddItem(tr("Enable Drag Files to Timeline"),
-          QStringLiteral("EnableDragFilesToTimeline"),
-          timeline_group);
-  AddItem(tr("Invert Timeline Scroll Axes"),
-          QStringLiteral("InvertTimelineScrollAxes"),
-          tr("Hold ALT on any UI element to switch scrolling axes"),
-          timeline_group);
-  AddItem(tr("Seek Also Selects"),
-          QStringLiteral("SelectAlsoSeeks"),
-          timeline_group);
-  AddItem(tr("Seek to the End of Pastes"),
-          QStringLiteral("PasteSeeks"),
-          timeline_group);
-  AddItem(tr("Selecting Also Seeks"),
-          QStringLiteral("SelectAlsoSeeks"),
-          timeline_group);
-
-  QTreeWidgetItem* playback_group = AddParent(tr("Playback"));
-  AddItem(tr("Ask For Name When Setting Marker"),
-          QStringLiteral("SetNameWithMarker"),
-          playback_group);
-  AddItem(tr("Automatically rewind at the end of a sequence"),
-          QStringLiteral("AutoSeekToBeginning"),
-          playback_group);
-
-  QTreeWidgetItem* project_group = AddParent(tr("Project"));
-  AddItem(tr("Drop Files on Media to Replace"),
-          QStringLiteral("DropFileOnMediaToReplace"),
-          project_group);
-
-  QTreeWidgetItem* node_group = AddParent(tr("Nodes"));
-  AddItem(tr("Add Default Effects to New Clips"),
-          QStringLiteral("AddDefaultEffectsToClips"),
-          node_group);
-  AddItem(tr("Auto-Scale By Default"),
-          QStringLiteral("AutoscaleByDefault"),
-          node_group);
-  AddItem(tr("Splitting Clips Copies Dependencies"),
-          QStringLiteral("SplitClipsCopyNodes"),
-          tr("Multiple clips can share the same nodes. Disable this to automatically share node "
-             "dependencies among clips when copying or splitting them."),
-          node_group);
+    QTreeWidgetItem* project_group = AddParent(tr("Project"));
+    AddItem(tr("Drop Files on Media to Replace"),
+            QStringLiteral("DropFileOnMediaToReplace"),
+            project_group);
+  }
+  {
+    QTreeWidgetItem* node_group = AddParent(tr("Nodes"));
+    AddItem(tr("Add Default Effects to New Clips"),
+            QStringLiteral("AddDefaultEffectsToClips"),
+            node_group);
+    AddItem(tr("Auto-Scale By Default"),
+            QStringLiteral("AutoscaleByDefault"),
+            node_group);
+    AddItem(tr("Splitting Clips Copies Dependencies"),
+            QStringLiteral("SplitClipsCopyNodes"),
+            tr("Multiple clips can share the same nodes. Disable this to automatically share node "
+               "dependencies among clips when copying or splitting them."),
+            node_group);
+  }
 }
 
 void PreferencesBehaviorTab::Accept(MultiUndoCommand *command)

--- a/app/widget/viewer/viewerdisplay.cpp
+++ b/app/widget/viewer/viewerdisplay.cpp
@@ -627,7 +627,8 @@ void ViewerDisplayWidget::OpenTextGizmo(TextGizmo *text, QMouseEvent *event)
   auto popup = new QWidget(this);
   popup->setWindowFlags(Qt::Popup | Qt::FramelessWindowHint);
   popup->setAttribute(Qt::WA_DeleteOnClose);
-  popup->setAttribute(Qt::WA_TranslucentBackground);
+  if (OLIVE_CONFIG("AllowTransparentDialogs").toBool())
+    popup->setAttribute(Qt::WA_TranslucentBackground);
 
   // Create text editor
   ViewerTextEditor *text_edit = new ViewerTextEditor(gizmo_transform.m11(), popup);

--- a/app/widget/viewer/viewertexteditor.cpp
+++ b/app/widget/viewer/viewertexteditor.cpp
@@ -29,6 +29,7 @@
 #include <QTextBlock>
 
 #include "common/qtutils.h"
+#include "config/config.h"
 #include "ui/icons/icons.h"
 
 namespace olive {
@@ -297,7 +298,10 @@ void ViewerTextEditor::DocumentChanged()
   cursor.select(QTextCursor::Document);
 
   QTextCharFormat fmt;
-  fmt.setForeground(QColor(0, 0, 0, 0));
+  if (OLIVE_CONFIG("AllowTransparentDialogs").toBool()) {
+      fmt.setForeground(QColor(0, 0, 0, 0));
+
+  }
   cursor.mergeCharFormat(fmt);
 }
 


### PR DESCRIPTION
Apologies for re-creating this but because I am still learning how to use GitHub, I've had to re-order my branches, forcing the previous pull request #1984 to be deleted and me to duplicate this pull request.
~~~
So I ran Olive in I3WM and had a problem when editing title text in video viewer: the text I typed did not show up at all in the editor, but it did show up on the video after I quit the Viewer Text Editor. This was because I3WM has issues with transparent windows. I did not get this issue when using KDE Plasma.

Therefore, I have added an option into Preferences which allows the user to turn off/on transparent dialogs, which is enabled by default but can be disabled in case of any problems.

Can provide screenshots on request.