### PR TITLE
ffmpegdecoder: fix missing include avcodec.h to avoid build failures

### DIFF
--- a/app/codec/ffmpeg/ffmpegdecoder.h
+++ b/app/codec/ffmpeg/ffmpegdecoder.h
@@ -25,6 +25,7 @@
 #include <inttypes.h>
 
 extern "C" {
+#include <libavcodec/avcodec.h>
 #include <libavfilter/avfilter.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>


### PR DESCRIPTION
Hello,

ffmpegdecoder.h declares a pointer to `AVCodecContext` ; which is a type defined in libavcodec/avcodec.h.
However, ffmpegdecoder.h does not include libavcodec/avcodec.h so we are at risk of build failures if no other header includes avcodec.h before using the type.

In Ubuntu, this issue is affecting our ability to build olive-editor from source as part of the ffmpeg 5 transition.

Thanks for considering the patch!
Olivier