### PR TITLE
Fix viewertexteditor toolbar not displaying properly in i3wm

### DIFF
--- a/app/widget/viewer/viewerdisplay.cpp
+++ b/app/widget/viewer/viewerdisplay.cpp
@@ -737,7 +737,7 @@ void ViewerDisplayWidget::OpenTextGizmo(TextGizmo *text, QMouseEvent *event)
 
   // Create toolbar
   text_toolbar_ = new ViewerTextEditorToolBar(text_edit_);
-  text_toolbar_->setWindowFlags(Qt::Window | Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
+  text_toolbar_->setWindowFlags(Qt::Dialog| Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
   connect(text_toolbar_, &ViewerTextEditorToolBar::VerticalAlignmentChanged, text, &TextGizmo::SetVerticalAlignment);
   connect(text, &TextGizmo::VerticalAlignmentChanged, text_toolbar_, &ViewerTextEditorToolBar::SetVerticalAlignment);
   text_toolbar_->SetVerticalAlignment(text->GetVerticalAlignment());


### PR DESCRIPTION
When using the I3 window manager, when clicking to edit text in the video, the toolbar was being created as an entirely separate window, causing it to not show up on the screen. Changing the flag to Qt::Dialog fixes the issue.