### PR TITLE
polygon: Implement polygon gizmo selection and dragging

### DIFF
--- a/app/node/generator/polygon/polygon.cpp
+++ b/app/node/generator/polygon/polygon.cpp
@@ -145,6 +145,12 @@ NodeGizmo *PolygonGenerator::CreateAppropriateGizmo<PointGizmo>()
   return AddDraggableGizmo<PointGizmo>();
 }
 
+template<>
+NodeGizmo *PolygonGenerator::CreateAppropriateGizmo<SelectableGizmo>()
+{
+  return AddDraggableGizmo<SelectableGizmo>();
+}
+
 template<typename T>
 void PolygonGenerator::ValidateGizmoVectorSize(QVector<T*> &vec, int new_sz)
 {
@@ -214,6 +220,21 @@ void PolygonGenerator::UpdateGizmoPositions(const NodeValueRow &row, const NodeG
   }
 
   poly_gizmo_->SetPath(GeneratePath(points).translated(half_res));
+}
+
+void PolygonGenerator::UpdateGizmosOnSelection(QList<PointGizmo*> &selected)
+{
+  for (int i = 0; i < gizmo_position_handles_.size(); i++) {
+    auto& position_handle = gizmo_position_handles_[i];
+    bool point_selected = selected.contains(position_handle);
+    bool beziers_visible = (selected.size() == 1 && point_selected);
+    position_handle->SetSelected(point_selected);
+
+    gizmo_bezier_handles_[i*2]->SetVisible(beziers_visible);
+    gizmo_bezier_lines_[i*2]->SetVisible(beziers_visible);
+    gizmo_bezier_handles_[i*2+1]->SetVisible(beziers_visible);
+    gizmo_bezier_lines_[i*2+1]->SetVisible(beziers_visible);
+  }
 }
 
 ShaderCode PolygonGenerator::GetShaderCode(const ShaderRequest &request) const

--- a/app/node/generator/polygon/polygon.h
+++ b/app/node/generator/polygon/polygon.h
@@ -27,6 +27,7 @@
 #include "node/generator/shape/generatorwithmerge.h"
 #include "node/gizmo/line.h"
 #include "node/gizmo/path.h"
+#include "node/gizmo/selectable.h"
 #include "node/gizmo/point.h"
 #include "node/node.h"
 #include "node/inputdragger.h"
@@ -53,6 +54,7 @@ public:
   virtual void GenerateFrame(FramePtr frame, const GenerateJob &job) const override;
 
   virtual void UpdateGizmoPositions(const NodeValueRow &row, const NodeGlobals &globals) override;
+  virtual void UpdateGizmosOnSelection(QList<PointGizmo*> &selected) override;
 
   virtual ShaderCode GetShaderCode(const ShaderRequest &request) const override;
 
@@ -77,7 +79,7 @@ private:
   NodeGizmo *CreateAppropriateGizmo();
 
   PathGizmo *poly_gizmo_;
-  QVector<PointGizmo*> gizmo_position_handles_;
+  QVector<SelectableGizmo*> gizmo_position_handles_;
   QVector<PointGizmo*> gizmo_bezier_handles_;
   QVector<LineGizmo*> gizmo_bezier_lines_;
 

--- a/app/node/gizmo/CMakeLists.txt
+++ b/app/node/gizmo/CMakeLists.txt
@@ -32,5 +32,6 @@ set(OLIVE_SOURCES
   node/gizmo/screen.h
   node/gizmo/text.cpp
   node/gizmo/text.h
+  node/gizmo/selectable.cpp
   PARENT_SCOPE
 )

--- a/app/node/gizmo/point.cpp
+++ b/app/node/gizmo/point.cpp
@@ -19,25 +19,27 @@
 ***/
 
 #include "point.h"
+#include <qnamespace.h>
 
 #include <QApplication>
 
 namespace olive {
 
-PointGizmo::PointGizmo(const Shape &shape, bool smaller, QObject *parent) :
+PointGizmo::PointGizmo(const Shape &shape, bool smaller, QObject *parent, bool selectable) :
   DraggableGizmo{parent},
   shape_(shape),
-  smaller_(smaller)
+  smaller_(smaller),
+  selectable_(selectable)
 {
 }
 
-PointGizmo::PointGizmo(const Shape &shape, QObject *parent) :
-  PointGizmo(shape, false, parent)
+PointGizmo::PointGizmo(const Shape &shape, QObject *parent,bool selectable) :
+  PointGizmo(shape, false, parent, selectable)
 {
 }
 
-PointGizmo::PointGizmo(QObject *parent) :
-  PointGizmo(kSquare, parent)
+PointGizmo::PointGizmo(QObject *parent, bool selectable) :
+  PointGizmo(kSquare, parent, selectable)
 {
 }
 
@@ -47,7 +49,7 @@ void PointGizmo::Draw(QPainter *p) const
 
   if (shape_ != kAnchorPoint) {
     p->setPen(Qt::NoPen);
-    p->setBrush(Qt::white);
+    p->setBrush(selected_ ? Qt::red : Qt::white);
   }
 
   switch (shape_) {

--- a/app/node/gizmo/point.h
+++ b/app/node/gizmo/point.h
@@ -37,9 +37,9 @@ public:
     kAnchorPoint
   };
 
-  explicit PointGizmo(const Shape &shape, bool smaller, QObject *parent = nullptr);
-  explicit PointGizmo(const Shape &shape, QObject *parent = nullptr);
-  explicit PointGizmo(QObject *parent = nullptr);
+  explicit PointGizmo(const Shape &shape, bool smaller, QObject *parent = nullptr, bool selectable = false);
+  explicit PointGizmo(const Shape &shape, QObject *parent = nullptr, bool selectable = false);
+  explicit PointGizmo(QObject *parent = nullptr, bool selectable = false);
 
   const Shape &GetShape() const { return shape_; }
   void SetShape(const Shape &s) { shape_ = s; }
@@ -49,6 +49,11 @@ public:
 
   bool GetSmaller() const { return smaller_; }
   void SetSmaller(bool e) { smaller_ = e; }
+
+  bool IsSelectable() const { return selectable_; }
+
+  void SetSelected(bool e) { selected_ = e; }
+  bool IsSelected() const { return selected_; }
 
   virtual void Draw(QPainter *p) const override;
 
@@ -64,6 +69,8 @@ private:
   QPointF point_;
 
   bool smaller_;
+  bool selected_ = false;
+  bool selectable_ = false;
 
 };
 

--- a/app/node/gizmo/selectable.cpp
+++ b/app/node/gizmo/selectable.cpp
@@ -1,0 +1,7 @@
+#include "selectable.h"
+
+namespace olive {
+SelectableGizmo::SelectableGizmo(QObject *parent)
+  :PointGizmo(parent, true)
+{}
+}

--- a/app/node/gizmo/selectable.h
+++ b/app/node/gizmo/selectable.h
@@ -1,0 +1,13 @@
+#ifndef SELECTABLE_H
+#define SELECTABLE_H
+#include "node/gizmo/point.h"
+
+namespace olive {
+class SelectableGizmo: public PointGizmo {
+Q_OBJECT    
+public:
+  explicit SelectableGizmo(QObject *parent = nullptr);
+};
+}
+
+#endif

--- a/app/node/node.h
+++ b/app/node/node.h
@@ -62,6 +62,7 @@ namespace olive {
 
 class NodeGraph;
 class Folder;
+class PointGizmo;
 
 /**
  * @brief A single processing unit that can be connected with others to create intricate processing systems
@@ -905,6 +906,7 @@ public:
   virtual QTransform GizmoTransformation(const NodeValueRow &row, const NodeGlobals &globals) const { return QTransform(); }
 
   virtual void UpdateGizmoPositions(const NodeValueRow &row, const NodeGlobals &globals){}
+  virtual void UpdateGizmosOnSelection(QList<PointGizmo*> &selected) {}
 
   const QString& GetLabel() const;
   void SetLabel(const QString& s);

--- a/app/widget/viewer/viewerdisplay.h
+++ b/app/widget/viewer/viewerdisplay.h
@@ -55,6 +55,7 @@ namespace olive {
  * the same texture object, use SetTexture() since it will nearly always be faster to just set it than to check *and*
  * set it.
  */
+class PointGizmo;
 class ViewerDisplayWidget : public ManagedDisplayWidget, public TimeTargetObject
 {
   Q_OBJECT
@@ -290,6 +291,8 @@ private:
 
   void CloseTextEditor();
 
+  bool DragGizmo(DraggableGizmo* gizmo, QMouseEvent *event);
+
   /**
    * @brief Internal reference to the OpenGL texture to draw. Set in SetTexture() and used in paintGL().
    */
@@ -408,6 +411,7 @@ private:
   ViewerTextEditorToolBar *text_toolbar_;
   QTransform text_transform_;
   QTransform text_transform_inverted_;
+  QList<PointGizmo*> selected_gizmos_;
 
 private slots:
   void UpdateFromQueue();


### PR DESCRIPTION
Changes are:
- Ability to select multiple points of polygon by holding down CTRL and then dragging all the points at once
- Bezier lines only show for selected gizmo when only one gizmo is selected
- Double clicking deselects all points

https://user-images.githubusercontent.com/29703546/190712378-4bfae786-f9f6-4e3c-91ca-86b3ef8c00a9.mov


This also fixes the bug where dragging point gizmos does not update the GUI immediately.