### PR TITLE
Allow CMake to generate compile_commands.json automatically in the build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
+# Generates a compile_commands.json in the build dir, link that to the repo
+# root to enrich your IDE with clangd language server protocol functionalities
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Sanitizers
 add_library(olive-sanitizers INTERFACE)
 include(cmake/Sanitizers.cmake)


### PR DESCRIPTION
Some editors rely on clangd for autocompletion. In those cases clangd will look for a compile_commands.json file in the root of the repository to obtain the list of flags used for compilation and the INCLUDEPATH for each file. 
This commit allows CMake to automatically generate such file in the designated build folder.
To enable clangd to use that file, simply link it in the root of the project repository.
The link will be ignored by git.