### PR TITLE
ffmpegdecoder: Catch bad stream duration estimates

### DIFF
--- a/app/codec/ffmpeg/ffmpegdecoder.cpp
+++ b/app/codec/ffmpeg/ffmpegdecoder.cpp
@@ -350,6 +350,13 @@ FootageDescription FFmpegDecoder::Probe(const QString &filename, CancelAtom *can
 
     int64_t footage_duration = fmt_ctx->duration;
 
+    bool bad_duration = false;
+
+    if (fmt_ctx->duration_estimation_method == AVFMT_DURATION_FROM_BITRATE) {
+      bad_duration = true;
+      qWarning() << "Potentially bad duration estimation, using fallback. This could be slow.";
+    }
+
     // Dump it into the Footage object
     for (unsigned int i=0;i<fmt_ctx->nb_streams;i++) {
 
@@ -409,8 +416,8 @@ FootageDescription FFmpegDecoder::Probe(const QString &filename, CancelAtom *can
 
               if (ret >= 0) {
                 // Check if we need a manual duration
-                if (avstream->duration == AV_NOPTS_VALUE) {
-                  if (footage_duration == AV_NOPTS_VALUE) {
+                if (avstream->duration == AV_NOPTS_VALUE || bad_duration) {
+                  if (footage_duration == AV_NOPTS_VALUE || bad_duration) {
 
                     // Manually read through file for duration
                     int64_t new_dur;
@@ -468,9 +475,9 @@ FootageDescription FFmpegDecoder::Probe(const QString &filename, CancelAtom *can
             channel_layout = static_cast<uint64_t>(av_get_default_channel_layout(avstream->codecpar->channels));
           }
 
-          if (avstream->duration == AV_NOPTS_VALUE) {
+          if (avstream->duration == AV_NOPTS_VALUE || bad_duration) {
             // Loop through stream until we get the whole duration
-            if (footage_duration == AV_NOPTS_VALUE) {
+            if (footage_duration == AV_NOPTS_VALUE || bad_duration) {
               Instance instance;
               instance.Open(filename_c, avstream->index);
 


### PR DESCRIPTION
For some formats, particularly mxf, FFmpeg calculates the duration of the stream incorrectly. Here we try to catch that and force Olive to use it's much slower, but correct fallback method.

It would be nice if it were possible to inform the user that a (potentially much) slower method was being used.

Fixes #2076