### PR TITLE
NSIS: Use 64-bit version of ShellExecAsUser.dll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,8 @@ jobs:
           cp $(cygpath $GITHUB_WORKSPACE)/app/packaging/windows/nsis/* .
           cp $(cygpath $GITHUB_WORKSPACE)/LICENSE .
           $DOWNLOAD_TOOL https://nsis.sourceforge.io/mediawiki/images/6/68/ShellExecAsUser_amd64-Unicode.7z
-          7z e ShellExecAsUser_amd64-Unicode.7z Plugins/x86-unicode/ShellExecAsUser.dll
-          makensis -V4 -DX64 "-XOutFile $PKGNAME.exe" "-X!AddPluginDir /x86-unicode $(pwd -W)" olive.nsi
+          7z e ShellExecAsUser_amd64-Unicode.7z Plugins/amd64-unicode/ShellExecAsUser.dll
+          makensis -V4 -DX64 "-XOutFile $PKGNAME.exe" "-X!AddPluginDir /amd64-unicode $(pwd -W)" olive.nsi
 
           # Create Portable ZIP
           echo -n > olive-editor/portable


### PR DESCRIPTION
The `Amd64 Unicode` plugin download from https://nsis.sourceforge.io/ShellExecAsUser_plug-in contains an ANSI version, a 32-bit Unicode version, and a 64-bit Unicode version. The CI currently uses the 32-bit version.

My hope is that using the 64-bit version resolves #2075, but the problem could also be deep inside its source code or how it was built (the readme mentions VS 2010...)