### PR TITLE
Polygon: Fix misalignment of gizmos

### DIFF
--- a/app/node/distort/transform/transformdistortnode.cpp
+++ b/app/node/distort/transform/transformdistortnode.cpp
@@ -406,7 +406,7 @@ QTransform TransformDistortNode::GizmoTransformation(const NodeValueRow &row, co
 {
   if (TexturePtr texture = row[kTextureInput].toTexture()) {
     //auto m = GenerateMatrix(row, false, false, false, row[kParentInput].toMatrix());
-    auto m = GenerateMatrix(row, false, false, false, QMatrix4x4());
+    auto m = GenerateMatrix(row, false, false, false, QMatrix4x4(), true);
     return GenerateAutoScaledMatrix(m, row, globals, texture->params()).toTransform();
   }
   return super::GizmoTransformation(row, globals);

--- a/app/node/generator/matrix/matrix.cpp
+++ b/app/node/generator/matrix/matrix.cpp
@@ -94,7 +94,7 @@ void MatrixGenerator::Value(const NodeValueRow &value, const NodeGlobals &global
   table->Push(NodeValue::kMatrix, mat, this);
 }
 
-QMatrix4x4 MatrixGenerator::GenerateMatrix(const NodeValueRow &value, bool ignore_anchor, bool ignore_position, bool ignore_scale, const QMatrix4x4 &mat) const
+QMatrix4x4 MatrixGenerator::GenerateMatrix(const NodeValueRow &value, bool ignore_anchor, bool ignore_position, bool ignore_scale, const QMatrix4x4 &mat, bool is_gizmo) const
 {
   QVector2D anchor;
   QVector2D position;
@@ -110,6 +110,8 @@ QMatrix4x4 MatrixGenerator::GenerateMatrix(const NodeValueRow &value, bool ignor
 
   if (!ignore_position) {
     position = value[kPositionInput].toVec2();
+    if (is_gizmo)
+      position /= 2;
   }
 
   return GenerateMatrix(position,

--- a/app/node/generator/matrix/matrix.h
+++ b/app/node/generator/matrix/matrix.h
@@ -53,7 +53,7 @@ public:
   static const QString kAnchorInput;
 
 protected:
-  QMatrix4x4 GenerateMatrix(const NodeValueRow &value, bool ignore_anchor, bool ignore_position, bool ignore_scale, const QMatrix4x4 &mat) const;
+  QMatrix4x4 GenerateMatrix(const NodeValueRow &value, bool ignore_anchor, bool ignore_position, bool ignore_scale, const QMatrix4x4 &mat, bool is_gizmo = false) const;
   static QMatrix4x4 GenerateMatrix(const QVector2D &pos,
                                    const float &rot,
                                    const QVector2D &scale,

--- a/app/node/generator/polygon/polygon.cpp
+++ b/app/node/generator/polygon/polygon.cpp
@@ -175,6 +175,7 @@ void PolygonGenerator::UpdateGizmoPositions(const NodeValueRow &row, const NodeG
 
   QPointF half_res = res.toPointF()/2;
 
+
   auto points = row[kPointsInput].toArray();
 
   int current_pos_sz = gizmo_position_handles_.size();

--- a/app/widget/viewer/viewerdisplay.cpp
+++ b/app/widget/viewer/viewerdisplay.cpp
@@ -448,7 +448,6 @@ void ViewerDisplayWidget::OnPaint()
     QPainter p(paint_device());
 
     GenerateGizmoTransforms();
-
     p.setWorldTransform(gizmo_last_draw_transform_);
 
     gizmos_->UpdateGizmoPositions(gizmo_db_, NodeGlobals(gizmo_params_, gizmo_audio_params_, gizmo_draw_time_, LoopMode::kLoopModeOff));


### PR DESCRIPTION
This PR fixes the bug where the gizmos for a polygon weren't aligned when the output of a polygon node was directly connected to the input of a transform node. This issue happened for all kinds of pixel aspect ratios, including 1.0.

Video of before fix:

https://user-images.githubusercontent.com/29703546/200065847-9991129a-e695-47b9-a44f-86fe23a32bca.mov

Video of after fix:

https://user-images.githubusercontent.com/29703546/200065888-c34d06c1-efcf-4a79-8f86-f880eccb0fe2.mov
