### PR TITLE
Compiling doesn't work because 'core' library is needed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "core"]
+	path = core
+	url = https://github.com/olive-editor/core

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+TAG=2022.3
+
+git submodule update --init
+
+docker run --rm -it -v $(pwd):/opt/olive --entrypoint=/opt/olive/docker/scripts/build_appimage.sh olivevideoeditor/ci-olive:$TAG

--- a/docker/scripts/build_appimage.sh
+++ b/docker/scripts/build_appimage.sh
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cd /opt/olive/core
-mkdir build && \
+( test -e build || mkdir build ) && \
 cd build && \
 cmake .. -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=clang++ && \
 cmake --build . && \
 ninja install && \
 \
 cd /opt/olive && \
-mkdir build && \
+( test -e build || mkdir build ) && \
 cd build && \
 cmake .. -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=clang++ && \
 cmake --build . && \

--- a/docker/scripts/build_appimage.sh
+++ b/docker/scripts/build_appimage.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright (C) 2022 Olive Team
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+cd /opt/olive/core
+mkdir build && \
+cd build && \
+cmake .. -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=clang++ && \
+cmake --build . && \
+ninja install && \
+\
+cd /opt/olive && \
+mkdir build && \
+cd build && \
+cmake .. -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=clang++ && \
+cmake --build . && \
+\
+cmake --install app --prefix appdir/usr && \
+/usr/local/linuxdeployqt-x86_64.AppImage appdir/usr/share/applications/org.olivevideoeditor.Olive.desktop -appimage --appimage-extract-and-run


### PR DESCRIPTION
Currently the only way to build the codebase is to first build and install the [core](https://github.com/olive-editor/core) repo.
While this isn't hard to do, the bigger issue here is that it's unclear which revision of [core](https://github.com/olive-editor/core) would be safely compatible with which revision of [olive](https://github.com/olive-editor/olive). Git submodules could help here.

**This PR is just a reference to how you might produce an AppImage currently**.

Another thing is I found you need to compile with `clang++` otherwise errors emitted due to `-Wpedantic`

Just type:

`./build_appimage.sh`