### PR TITLE
Fix Wayland Transparency

### DIFF
--- a/app/render/renderer.h
+++ b/app/render/renderer.h
@@ -84,7 +84,7 @@ public:
 
   virtual void PostInit() = 0;
 
-  virtual void ClearDestination(olive::Texture *texture = nullptr, double r = 0.0, double g = 0.0, double b = 0.0, double a = 0.0) = 0;
+  virtual void ClearDestination(olive::Texture *texture = nullptr, double r = 0.0, double g = 0.0, double b = 0.0, double a = 1.0) = 0;
 
   virtual QVariant CreateNativeShader(olive::ShaderCode code) = 0;
 


### PR DESCRIPTION
Partially addresses #1630

it turns out that the alpha we set is actually passed onto the compositor, so by setting 0.0 alpha, we were inadvertently telling the compositor to make the window transparent.