### PR TITLE
fix: Fixed the crash caused by assertion dissatisfaction after starti…

### DIFF
--- a/app/undo/undostack.cpp
+++ b/app/undo/undostack.cpp
@@ -68,14 +68,15 @@ void UndoStack::push(UndoCommand *command, const QString &name)
   }
 
   // Clear any redoable commands
-  this->beginRemoveRows(QModelIndex(), commands_.size(), commands_.size() + undone_commands_.size());
   if (CanRedo()) {
+    this->beginRemoveRows(QModelIndex(), commands_.size(), commands_.size() + undone_commands_.size() - 1);
     for (auto it=undone_commands_.cbegin(); it!=undone_commands_.cend(); it++) {
       delete (*it).command;
     }
+    this->endRemoveRows();
+
     undone_commands_.clear();
   }
-  this->endRemoveRows();
 
   // Do command and push
   this->beginInsertRows(QModelIndex(), commands_.size(), commands_.size());


### PR DESCRIPTION
…ng the program in debug mode

1. The internal implementation of the qt function beginRemoveRows, including the assertion judgment: Q_ASSERT(last < rowCount(parent));