### PR TITLE
fix: fix the crash caused by assertion

### DIFF
--- a/app/undo/undostack.cpp
+++ b/app/undo/undostack.cpp
@@ -68,14 +68,14 @@ void UndoStack::push(UndoCommand *command, const QString &name)
   }
 
   // Clear any redoable commands
-  this->beginRemoveRows(QModelIndex(), commands_.size(), commands_.size() + undone_commands_.size());
   if (CanRedo()) {
+    this->beginRemoveRows(QModelIndex(), commands_.size(), commands_.size() + undone_commands_.size() - 1);
     for (auto it=undone_commands_.cbegin(); it!=undone_commands_.cend(); it++) {
       delete (*it).command;
     }
     undone_commands_.clear();
+    this->endRemoveRows();
   }
-  this->endRemoveRows();
 
   // Do command and push
   this->beginInsertRows(QModelIndex(), commands_.size(), commands_.size());


### PR DESCRIPTION
1. The internal implementation of the qt function beginRemoveRows, including the assertion judgment: Q_ASSERT(last < rowCount(parent));