### PR TITLE
readme: fix broken compile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Please consider supporting Olive:
 
 ## Compiling from Source:
 
-Compiling instructions for Windows, macOS, and Linux can be found [on the main site](https://olivevideoeditor.org/compile.php).
+Compiling instructions for Windows, macOS, and Linux can be found [on the main site](https://olivevideoeditor.org/compile).


### PR DESCRIPTION
.php link doesn't resolve to the correct page anymore.