### PR TITLE
Fix QString::arg() with scoped enum

### DIFF
--- a/app/render/videoparams.cpp
+++ b/app/render/videoparams.cpp
@@ -226,7 +226,7 @@ QString VideoParams::GetFormatName(PixelFormat format)
     break;
   }
 
-  return QCoreApplication::translate("VideoParams", "Unknown (0x%1)").arg(format, 0, 16);
+  return QCoreApplication::translate("VideoParams", "Unknown (0x%1)").arg(static_cast<int>(format), 0, 16);
 }
 
 int VideoParams::GetDividerForTargetResolution(int src_width, int src_height, int dst_width, int dst_height)

--- a/app/ui/humanstrings.cpp
+++ b/app/ui/humanstrings.cpp
@@ -60,7 +60,7 @@ QString HumanStrings::FormatToString(const SampleFormat &f)
     break;
   }
 
-  return QCoreApplication::translate("AudioParams", "Unknown (0x%1)").arg(f, 1, 16);
+  return QCoreApplication::translate("AudioParams", "Unknown (0x%1)").arg(static_cast<int>(f), 1, 16);
 }
 
 }


### PR DESCRIPTION
Using `QString::arg()` with scoped enum do not implicitly convert the enums to int starting in Qt 6.10.1. This causes compilation error:

```
app/render/videoparams.cpp: In static member function 'static QString olive::VideoParams::GetFormatName(olive::core::PixelFormat)':
app/render/videoparams.cpp:229:74: error: no matching function for call to 'QString::arg(olive::core::PixelFormat&, int, int)'
  229 |   return QCoreApplication::translate("VideoParams", "Unknown (0x%1)").arg(format, 0, 16);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~

app/ui/humanstrings.cpp: In static member function 'static QString olive::HumanStrings::FormatToString(const olive::core::SampleFormat&)':
app/ui/humanstrings.cpp:63:74: error: no matching function for call to 'QString::arg(const olive::core::SampleFormat&, int, int)'
   63 |   return QCoreApplication::translate("AudioParams", "Unknown (0x%1)").arg(f, 1, 16);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
```

This patch add static casts to int to fix these errors.